### PR TITLE
feat: simplify rover actions — station-only charging and delivery-based success

### DIFF
--- a/.claude/commands/get_started_lv.md
+++ b/.claude/commands/get_started_lv.md
@@ -1,0 +1,1 @@
+Please read the Claude_lv.md and the Changelog.md file to get up to speed with the scope of this repo as well as the recent changes made to the codebase.

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,16 @@
+# Product Overview
+
+Agent One is a multi-agent LLM-powered Mars mission simulation built for the Mistral Hackathon.
+
+Autonomous agents (Rover, Drone, Station) collaborate in a simulated Mars environment, coordinated by a central Coordinator. Each agent runs its own LLM reasoning loop via the Mistral API to observe world state, evaluate goals, propose actions, and execute tool calls.
+
+The simulation features:
+- A deterministic grid-based world with terrain, stones (precious/common), and fog-of-war visibility
+- A Rover that moves, digs, picks up stones, and charges at a Station
+- Probabilistic goals with confidence tracking (satisfied when `confidence >= threshold`)
+- Real-time WebSocket streaming of simulation events to a browser-based mission control UI
+- A structured JSON message protocol: `{id, ts, source, type, name, payload, correlation_id}`
+
+The current implementation uses a `MockSimAgent` that picks random legal actions each tick. The full LLM-driven agent loop (observe → reason → act → update confidence → emit actions) is the target architecture.
+
+Agents never communicate directly — all messages route through the Coordinator.

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,56 @@
+# Project Structure
+
+```
+agent-one/
+├── server/                     # Python FastAPI backend
+│   ├── app/
+│   │   ├── main.py             # FastAPI app, lifespan, CORS, health endpoint, agent loop
+│   │   ├── config.py           # pydantic-settings (Settings class, reads .env)
+│   │   ├── db.py               # SurrealDB connection helpers, get_db() generator
+│   │   ├── views.py            # REST endpoints + /ws WebSocket endpoint
+│   │   ├── broadcast.py        # Broadcaster singleton for WebSocket fan-out
+│   │   ├── agent.py            # RoverAgent (Mistral LLM) + MockRoverAgent (legacy)
+│   │   ├── sim_agent.py        # MockSimAgent wrapping SimulationEngine (current demo agent)
+│   │   ├── world.py            # Legacy world model (dict-based zones)
+│   │   └── sim/                # Deterministic simulation engine
+│   │       ├── models.py       # Domain models: WorldState, RoverState, StationState, GridState, etc.
+│   │       ├── engine.py       # SimulationEngine: validates actions, advances world state
+│   │       ├── world_factory.py# WorldFactory: seeded world creation with guaranteed feasibility
+│   │       └── errors.py       # Error constants (INVALID_OUT_OF_BOUNDS, etc.)
+│   ├── tests/
+│   │   ├── conftest.py         # In-memory SurrealDB setup, CaseWithDB base class
+│   │   ├── test_sim_engine.py  # SimulationEngine unit tests
+│   │   └── ...                 # Other test modules
+│   ├── pyproject.toml          # Python project config (uv, ruff)
+│   ├── uv.lock                 # Locked dependencies
+│   └── run                     # Dev server start script
+├── ui/                         # Vue 3 + Vite frontend
+│   ├── src/
+│   │   ├── App.vue             # Root component, WebSocket connection, layout
+│   │   ├── main.js             # Vue app entry point
+│   │   └── components/
+│   │       ├── MarsGrid.vue    # Grid-based surface map visualization
+│   │       ├── RoverTelemetry.vue # Rover status, battery, mission progress
+│   │       └── EventLog.vue    # Scrolling event log
+│   ├── vite.config.js          # Vite config with proxy to backend
+│   └── package.json
+├── Dockerfile                  # Multi-stage: Node build → Python runtime
+├── railway.toml                # Railway deployment config
+├── SPEC.md                     # Full system specification
+├── IDEA.md                     # High-level vision
+├── ROADMAP.md                  # Milestone plan (M0–M5)
+└── tasks/todo.md               # Task tracking
+```
+
+## Key Architecture Patterns
+
+- The simulation engine (`server/app/sim/`) is fully deterministic and decoupled from LLM/network concerns
+- `SimulationEngine` owns world state, validates actions, and returns `StepResult` with events and state deltas
+- `WorldFactory` creates seeded worlds with guaranteed mission feasibility (enough precious stones)
+- Domain models use Python dataclasses with `slots=True` for performance
+- Action types are TypedDict unions (`MoveAction | DigAction | ...`)
+- The `Broadcaster` singleton fans out events to all WebSocket clients
+- Frontend connects via a single WebSocket at `/ws` and receives all state updates as JSON events
+- Vite proxies `/api/*` and `/ws` to the backend during development
+- Two agent implementations exist: `RoverAgent` (real Mistral LLM calls) and `MockSimAgent` (random actions for demo)
+- `world.py` is a legacy dict-based world model; `sim/` is the current engine

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,68 @@
+# Tech Stack & Build
+
+## Backend (server/)
+- Python 3.12+
+- FastAPI (web framework, WebSocket support)
+- uvicorn (ASGI server)
+- SurrealDB (database, port 4002 dev / 8009 test)
+- pydantic-settings (configuration via `.env`)
+- mistralai SDK (LLM integration)
+- rich (logging)
+- uv (package manager, replaces pip)
+- ruff (linter, line-length 100)
+
+## Frontend (ui/)
+- Vue 3 (Composition API with `<script setup>`)
+- Vite 7 (dev server on port 4089, proxies to backend)
+- Node >= 22.12.0
+- ESLint with eslint-plugin-vue
+
+## Testing
+- unittest (Python standard library, not pytest)
+- `rut` as the test runner (custom runner, not pytest)
+- Tests spawn an in-memory SurrealDB instance automatically
+- `CaseWithDB` base class provides per-test DB isolation
+
+## Deployment
+- Docker multi-stage build (Node build → Python runtime)
+- Railway (railway.toml config)
+- Health check at `/health`
+
+## Common Commands
+
+```bash
+# Server
+cd server
+uv sync                          # install dependencies
+./run                            # start dev server (uvicorn :4009 --reload)
+rut tests/                       # run all tests
+rut tests/test_sim_engine.py     # run single test file
+rut tests/test_sim_engine.py::TestSimEngine::test_move_updates_position_and_battery  # single test
+
+# UI
+cd ui
+npm install                      # install dependencies
+npm run dev                      # start vite dev server (:4089)
+npm run build                    # production build
+npm run lint                     # lint with eslint --fix
+
+# Database
+cd server
+./start_db                       # start SurrealDB for development
+
+# Docker
+docker build -t agent-one .      # full build
+```
+
+## Environment Variables
+- `MISTRAL_API_KEY` — required for LLM agent functionality
+- Server config via `server/.env` (see `server/env.sample`)
+- Settings managed by pydantic-settings in `server/app/config.py`
+
+## Ports
+| Service          | Port |
+|------------------|------|
+| Server (FastAPI) | 4009 |
+| UI (Vite)        | 4089 |
+| SurrealDB (dev)  | 4002 |
+| SurrealDB (test) | 8009 |

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `check_ground` from rover actions — ground is now auto-scanned after every move
+- Removed `charge` from rover actions — charging is now station-only via `charge_rover()`
+- Mission success now requires delivering target stones to the station, not just collecting them
+- Station agent can charge rovers (new `charge_rover` tool) and auto-charges them on arrival
+- Mock rover now digs/picks up stones and navigates back to station when carrying target stone
+- Updated rover system prompt with auto-charge and return-to-base instructions
+
 ### Added
 
 - GitHub Actions CI pipeline (`.github/workflows/ci.yml`) with 5 jobs: change detection, server lint (ruff), server test (rut + SurrealDB), UI lint + build (eslint + vite), and Docker build verification

--- a/Claude_lv.md
+++ b/Claude_lv.md
@@ -1,0 +1,137 @@
+# Claude_lv.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Multi-agent LLM-powered Mars mission simulation for the Mistral Hackathon (Feb 28 – Mar 1). Three autonomous agents (Rover, Drone, Station) collaborate in a simulated Mars environment, coordinated by a central Coordinator. Each agent runs its own LLM reasoning loop (Mistral API) to evaluate goals, propose actions, and execute tool calls.
+
+## Architecture
+
+- **Coordinator**: Spawns agent subprocesses, injects world state into prompts, routes messages/actions between agents, handles timed events (storms, terrain shifts). Agents communicate through the Coordinator — never directly.
+- **Agents**: Rover (move, drill, carry), Drone (scan, map routes, relay), Station (power allocation, alerts). Each runs an observe → reason (LLM) → act → update-confidence loop.
+- **World Model**: Python dict holding zones, rocks, agent positions/battery/mobility, storm level, hazards. Updated by tool call results and external events.
+- **Protocol**: JSON messages with `{id, ts, source, type, name, payload, correlation_id}`. Types: event, action, command, tool, stream.
+- **Goals**: Probabilistic — each goal has a `confidence` (0.0–1.0) updated dynamically, satisfied when `confidence >= threshold`.
+
+Agent classes and protocol types are adapted from the Snowball project (`snowball` repo).
+
+## Project Structure
+
+- `server/` — Python FastAPI backend (port 4009)
+- `ui/` — Vue 3 + Vite frontend (port 4089)
+
+## Server
+
+Uses FastAPI with SurrealDB and pydantic-settings. Managed with `uv`.
+
+```bash
+cd server
+uv sync                        # install deps
+./run                          # uvicorn on :4009 with --reload
+rut tests/                     # run all tests
+rut tests/test_health.py       # run single test file
+rut tests/test_health.py::TestHealth::test_health_returns_ok  # single test
+```
+
+Key modules:
+- `app/main.py` — FastAPI app, lifespan (DB init/close), CORS, health endpoint
+- `app/config.py` — pydantic-settings (`Settings`), reads `.env`
+- `app/db.py` — SurrealDB connection helpers, `get_db()` generator for request-scoped connections
+- `app/broadcast.py` — `Broadcaster` singleton for WebSocket fan-out
+- `app/views.py` — REST endpoints + `/ws` WebSocket endpoint
+
+Tests use `rut` (unittest runner) with in-memory SurrealDB spawned in `conftest.py` (`rut_session_setup`/`rut_session_teardown`). Base class `CaseWithDB` provides per-test DB isolation.
+
+## UI
+
+```bash
+cd ui
+npm install
+npm run dev                    # vite on :4089
+```
+
+Vite proxies `/api/*` to `http://localhost:4009` and `/ws` to `ws://localhost:4009`. Single-page app connects via WebSocket to receive real-time simulation events.
+
+## Best Practices to adhere to
+- Before working on any changes on the codebase, create a new feature branch and do the changes in this dedicated feature branch. Once the implementation is done, ensure complete test coverage, full documentation and then submit a Pull Request (PR) and merge it into main if all tests are passing.
+- After each change to the codebase, update the Changelog.md file and report what was changed as well as what errors have been identified to prevent from duplicate or similar errors happening again.
+- After each change to the codebase, also scan the repo for any bloated code or in-efficient implementations. The repo has a very strong emphasis on accuracy and performance.
+- Ensure that the website is optimized for computers/laptops, tablets and mobile phones using a responsive design.
+- If you need to look up the latest documentation for an external tool, e.g., Vercel, Supabase, etc., please include 'use context7' in your prompt
+- For each new task, please first create a plan in a markdown file in this repo such that we can always trace back at which stage of the implementation for this particular task we currenlty are by comparing the code and then what's in the plan. Also, divide each plan into smaller tasks and sub-tasks that **shall** be marked as completed in this markdown file if done so. -->
+
+## Workflow Orchestration
+
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately — don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes — don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests — then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+---
+
+## Task Management
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items
+2. **Verify Plan**: Check in before starting implementation
+3. **Track Progress**: Mark items complete as you go
+4. **Explain Changes**: High-level summary at each step
+5. **Document Results**: Add review section to `tasks/todo.md`
+6. **Capture Lessons**: Update `tasks/lessons.md` after corrections
+
+---
+
+## Core Principles
+
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+
+## Dependencies
+
+| What | Detail |
+|------|--------|
+| Python | 3.12+ |
+| LLM SDK | `mistralai` |
+| API key | `MISTRAL_API_KEY` env var |
+| SurrealDB | running on port 4002 (dev) |
+| Node | >= 22.12.0 |
+| Base code | Protocol types and BaseAgent adapted from Snowball |
+
+## Key Spec References
+
+- `SPEC.md` — full system spec: world model, agent tools, event/action system, message schema, demo timeline
+- `IDEA.md` — high-level concept and vision
+- `ROADMAP.md` — milestone plan (M0–M5 + stretch goals)
+- `_private/PROTOCOL_REF.md` — protocol reference from Snowball

--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -127,10 +127,12 @@ class RoverAgent:
             "\n"
             "RULES:\n"
             "- Battery is your lifeline. Each move costs 2%/tile, dig costs 6%, pickup costs 2%.\n"
-            "- Station is your base at ({sx},{sy}). You can recharge there.\n"
+            "- Station is your base at ({sx},{sy}). Return there when battery is low — "
+            "the station will recharge you automatically.\n"
             "- ALWAYS keep enough battery to return to station. If distance_to_station * 2% "
             "approaches your battery, head back immediately.\n"
             "- If you find a stone: dig it, then pickup. Both must happen on the same tile.\n"
+            "- Once you have collected all target stones, RETURN TO STATION to complete the mission.\n"
             "- Prefer unvisited tiles when exploring. Don't backtrack aimlessly.\n"
             "- Ground is auto-scanned after every move. No need to check manually.\n"
             "- Follow your current tasks list. It tells you exactly what to do next.".format(
@@ -238,7 +240,7 @@ class RoverAgent:
 
 
 class MockRoverAgent:
-    """Mock rover that picks a random valid direction each turn — no LLM calls."""
+    """Mock rover that explores, collects stones, and returns to station — no LLM calls."""
 
     def __init__(self, agent_id="rover-mock"):
         self.agent_id = agent_id
@@ -246,19 +248,8 @@ class MockRoverAgent:
     def run_turn(self):
         agent = WORLD["agents"][self.agent_id]
         x, y = agent["position"]
-        visited_set = {tuple(p) for p in agent.get("visited", [])}
-
-        valid = []
-        unvisited = []
-        for name, (dx, dy) in DIRECTIONS.items():
-            nx, ny = x + dx, y + dy
-            if 0 <= nx < GRID_W and 0 <= ny < GRID_H:
-                valid.append((name, nx, ny))
-                if (nx, ny) not in visited_set:
-                    unvisited.append((name, nx, ny))
-
-        candidates = unvisited if unvisited else valid
-        direction, tx, ty = random.choice(candidates)
+        mission = WORLD.get("mission", {})
+        target_type = mission.get("target_type", "core")
 
         context = (
             f"Mock rover at ({x},{y}), battery={agent['battery']:.0%}, "
@@ -266,6 +257,49 @@ class MockRoverAgent:
             f"mission=\"{agent['mission']['objective']}\""
         )
         agent["last_context"] = context
+
+        # Check for stone at current tile — dig or pickup
+        ground = check_ground(self.agent_id)
+        if ground["stone"]:
+            if not ground["stone"]["extracted"]:
+                thinking = f"I'm at ({x}, {y}). Found a {ground['stone']['type']} stone — digging."
+                return {"thinking": thinking, "action": {"name": "dig", "params": {}}}
+            else:
+                thinking = f"I'm at ({x}, {y}). Stone extracted — picking up."
+                return {"thinking": thinking, "action": {"name": "pickup", "params": {}}}
+
+        # If carrying target stone, navigate toward station
+        has_target = any(s["type"] == target_type for s in agent.get("inventory", []))
+        if has_target:
+            station = WORLD["agents"].get("station")
+            sp = station["position"] if station else [0, 0]
+            dx, dy = sp[0] - x, sp[1] - y
+            if dx != 0:
+                direction = "east" if dx > 0 else "west"
+                distance = min(abs(dx), MAX_MOVE_DISTANCE)
+            elif dy != 0:
+                direction = "south" if dy > 0 else "north"
+                distance = min(abs(dy), MAX_MOVE_DISTANCE)
+            else:
+                # Already at station
+                direction = "north"
+                distance = 1
+            thinking = f"I'm at ({x}, {y}). Carrying target stone, heading to station at ({sp[0]},{sp[1]})."
+            return {"thinking": thinking, "action": {"name": "move", "params": {"direction": direction, "distance": distance}}}
+
+        # Default: explore unvisited tiles
+        visited_set = {tuple(p) for p in agent.get("visited", [])}
+        valid = []
+        unvisited = []
+        for name, (ddx, ddy) in DIRECTIONS.items():
+            nx, ny = x + ddx, y + ddy
+            if 0 <= nx < GRID_W and 0 <= ny < GRID_H:
+                valid.append((name, nx, ny))
+                if (nx, ny) not in visited_set:
+                    unvisited.append((name, nx, ny))
+
+        candidates = unvisited if unvisited else valid
+        direction, tx, ty = random.choice(candidates)
 
         thinking = f"I'm at ({x}, {y}). I'll move {direction} to ({tx}, {ty})."
         action = {"name": "move", "params": {"direction": direction}}

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -14,7 +14,7 @@ from .config import settings
 from .db import init_db, close_db
 from .station import StationAgent
 from .views import router as views_router
-from .world import execute_action, get_snapshot, WORLD
+from .world import execute_action, get_snapshot, WORLD, charge_rover
 
 logging.basicConfig(
     level=logging.INFO,
@@ -121,6 +121,26 @@ async def agent_loop(agent, interval):
                     "payload": get_snapshot(),
                 }
             )
+
+            # Auto-charge rover when it arrives at station
+            rover = WORLD["agents"].get(agent.agent_id)
+            station_agent = WORLD["agents"].get("station")
+            if (
+                rover
+                and station_agent
+                and rover["position"] == station_agent["position"]
+                and rover["battery"] < 1.0
+            ):
+                charge_result = charge_rover(agent.agent_id)
+                if charge_result["ok"]:
+                    await broadcaster.send(
+                        {
+                            "source": "station",
+                            "type": "action",
+                            "name": "charge_rover",
+                            "payload": charge_result,
+                        }
+                    )
 
             # Trigger station on stone-found events
             for event in events:

--- a/server/app/station.py
+++ b/server/app/station.py
@@ -6,7 +6,7 @@ import logging
 from mistralai import Mistral
 
 from .config import settings
-from .world import WORLD, GRID_W, GRID_H, assign_mission
+from .world import WORLD, GRID_W, GRID_H, assign_mission, charge_rover
 
 logger = logging.getLogger(__name__)
 
@@ -50,14 +50,34 @@ BROADCAST_ALERT_TOOL = {
     },
 }
 
-STATION_TOOLS = [ASSIGN_MISSION_TOOL, BROADCAST_ALERT_TOOL]
+CHARGE_ROVER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "charge_rover",
+        "description": "Recharge a rover's battery. The rover must be co-located with the station. Adds 20% charge per call.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "rover_id": {
+                    "type": "string",
+                    "description": "The rover agent to charge (e.g. 'rover-mock', 'rover-mistral').",
+                },
+            },
+            "required": ["rover_id"],
+        },
+    },
+}
+
+STATION_TOOLS = [ASSIGN_MISSION_TOOL, BROADCAST_ALERT_TOOL, CHARGE_ROVER_TOOL]
 
 SYSTEM_PROMPT = (
     "You are the Mars base station. You coordinate the Mars mission.\n"
-    "Your role is to assign missions to rover agents and respond to field reports.\n"
+    "Your role is to assign missions to rover agents, respond to field reports, "
+    "and recharge rovers when they return to the station.\n"
     "You have two rovers available: 'rover-mock' and 'rover-mistral'.\n"
     "Keep responses short (1-2 sentences of reasoning, then act).\n"
     "Always assign missions to at least one rover when defining the initial mission.\n"
+    "When a rover arrives at the station with low battery, charge it.\n"
 )
 
 
@@ -107,6 +127,16 @@ def _execute_tool_calls(tool_calls):
                     "type": "event",
                     "name": "alert",
                     "payload": {"message": args["message"]},
+                }
+            )
+        elif name == "charge_rover":
+            result = charge_rover(args["rover_id"])
+            events.append(
+                {
+                    "source": "station",
+                    "type": "action",
+                    "name": "charge_rover",
+                    "payload": result,
                 }
             )
     return events

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -104,12 +104,10 @@ WORLD = {
             "tools": [
                 {
                     "name": "move",
-                    "description": "Move 1-3 tiles in a cardinal direction (north/south/east/west). Costs 2% battery per tile.",
+                    "description": "Move 1-3 tiles in a cardinal direction (north/south/east/west). Costs 2% battery per tile. Ground is auto-scanned after each move.",
                 },
-                {"name": "check_ground", "description": "Scan current tile for rocks or minerals."},
                 {"name": "dig", "description": "Dig at current tile to extract a stone (costs 3x move battery)."},
                 {"name": "pickup", "description": "Pick up an extracted stone at current tile into inventory."},
-                {"name": "charge", "description": "Recharge battery at the station (must be co-located)."},
             ],
         },
         "rover-mistral": {
@@ -125,12 +123,10 @@ WORLD = {
             "tools": [
                 {
                     "name": "move",
-                    "description": "Move 1-3 tiles in a cardinal direction (north/south/east/west). Costs 2% battery per tile.",
+                    "description": "Move 1-3 tiles in a cardinal direction (north/south/east/west). Costs 2% battery per tile. Ground is auto-scanned after each move.",
                 },
-                {"name": "check_ground", "description": "Scan current tile for rocks or minerals."},
                 {"name": "dig", "description": "Dig at current tile to extract a stone (costs 3x move battery)."},
                 {"name": "pickup", "description": "Pick up an extracted stone at current tile into inventory."},
-                {"name": "charge", "description": "Recharge battery at the station (must be co-located)."},
             ],
         },
     },
@@ -218,10 +214,6 @@ def execute_action(agent_id, action_name, params):
         result = _execute_pickup(agent_id, agent)
         if result["ok"]:
             record_memory(agent_id, f"Picked up {result['stone']['type']} stone at ({result['position'][0]},{result['position'][1]}), inventory={result['inventory_count']}")
-    elif action_name == "charge":
-        result = _execute_charge(agent_id, agent)
-        if result["ok"]:
-            record_memory(agent_id, f"Charged battery {result['battery_before']:.0%} -> {result['battery_after']:.0%}")
     else:
         return {"ok": False, "error": f"Unknown action: {action_name}"}
 
@@ -305,6 +297,19 @@ def _execute_charge(agent_id, agent):
     return {"ok": True, "battery_before": old_battery, "battery_after": agent["battery"]}
 
 
+def charge_rover(rover_id):
+    """Station-initiated charge: recharge a rover that is co-located with the station."""
+    agent = WORLD["agents"].get(rover_id)
+    if agent is None:
+        return {"ok": False, "error": f"Unknown agent: {rover_id}"}
+    if agent.get("type") != "rover":
+        return {"ok": False, "error": f"{rover_id} is not a rover"}
+    result = _execute_charge(rover_id, agent)
+    if result["ok"]:
+        record_memory(rover_id, f"Station charged battery {result['battery_before']:.0%} -> {result['battery_after']:.0%}")
+    return result
+
+
 def check_mission_status():
     """Update mission collected_count and detect success/failure.
 
@@ -315,23 +320,28 @@ def check_mission_status():
         return None
 
     # Count target stones across all rover inventories
+    station = WORLD["agents"].get("station")
+    station_pos = station["position"] if station else [0, 0]
     collected = 0
+    delivered = 0
     for agent in WORLD["agents"].values():
+        if agent.get("type") != "rover":
+            continue
         for stone in agent.get("inventory", []):
             if stone["type"] == mission["target_type"]:
                 collected += 1
+                if agent["position"] == station_pos:
+                    delivered += 1
     mission["collected_count"] = collected
 
-    # Success: collected enough target stones
-    if collected >= mission["target_count"]:
+    # Success: enough target stones delivered to station
+    if delivered >= mission["target_count"]:
         mission["status"] = "success"
-        logger.info("Mission SUCCESS: collected %d/%d %s stones",
-                     collected, mission["target_count"], mission["target_type"])
-        return {"status": "success", "collected": collected}
+        logger.info("Mission SUCCESS: delivered %d/%d %s stones to station",
+                     delivered, mission["target_count"], mission["target_type"])
+        return {"status": "success", "collected": collected, "delivered": delivered}
 
     # Failure: all rovers have zero battery and none are at the station
-    station = WORLD["agents"].get("station")
-    station_pos = station["position"] if station else None
     all_dead = True
     for agent in WORLD["agents"].values():
         if agent.get("type") != "rover":

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -1,7 +1,7 @@
 import unittest
 
 from app.world import WORLD, move_agent, execute_action, get_snapshot, check_ground
-from app.world import check_mission_status
+from app.world import check_mission_status, charge_rover
 from app.world import BATTERY_COST_MOVE, BATTERY_COST_DIG, BATTERY_COST_PICKUP
 from app.world import CHARGE_RATE, REVEAL_RADIUS, GRID_W, GRID_H, AGENT_STARTS, MAX_MOVE_DISTANCE
 from app.world import assign_mission, _cells_in_radius, record_memory, MEMORY_MAX
@@ -410,47 +410,70 @@ class TestPickup(unittest.TestCase):
 
 
 class TestCharge(unittest.TestCase):
+    """Charging is a station-only action via charge_rover()."""
 
     def setUp(self):
         WORLD["agents"]["rover-mock"]["position"] = [0, 0]
         WORLD["agents"]["rover-mock"]["battery"] = 0.5
         WORLD["agents"]["rover-mock"]["inventory"] = []
         WORLD["agents"]["rover-mock"]["visited"] = [[0, 0]]
+        WORLD["agents"]["rover-mock"]["memory"] = []
         WORLD["agents"]["station"]["position"] = [0, 0]
 
-    def test_charge_success(self):
-        result = execute_action("rover-mock", "charge", {})
+    def test_charge_rover_success(self):
+        result = charge_rover("rover-mock")
         self.assertTrue(result["ok"])
         self.assertAlmostEqual(result["battery_before"], 0.5)
         self.assertAlmostEqual(result["battery_after"], 0.5 + CHARGE_RATE)
 
-    def test_charge_increases_battery(self):
-        execute_action("rover-mock", "charge", {})
+    def test_charge_rover_increases_battery(self):
+        charge_rover("rover-mock")
         self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 0.5 + CHARGE_RATE)
 
-    def test_charge_caps_at_full(self):
+    def test_charge_rover_caps_at_full(self):
         WORLD["agents"]["rover-mock"]["battery"] = 0.95
-        execute_action("rover-mock", "charge", {})
+        charge_rover("rover-mock")
         self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 1.0)
 
-    def test_charge_already_full(self):
+    def test_charge_rover_already_full(self):
         WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        result = execute_action("rover-mock", "charge", {})
+        result = charge_rover("rover-mock")
         self.assertFalse(result["ok"])
         self.assertIn("already full", result["error"])
 
-    def test_charge_not_at_station(self):
+    def test_charge_rover_not_at_station(self):
         WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        result = execute_action("rover-mock", "charge", {})
+        result = charge_rover("rover-mock")
         self.assertFalse(result["ok"])
         self.assertIn("Not at station", result["error"])
 
-    def test_charge_multiple_times(self):
+    def test_charge_rover_multiple_times(self):
         WORLD["agents"]["rover-mock"]["battery"] = 0.1
-        execute_action("rover-mock", "charge", {})
+        charge_rover("rover-mock")
         self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 0.1 + CHARGE_RATE)
-        execute_action("rover-mock", "charge", {})
+        charge_rover("rover-mock")
         self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 0.1 + 2 * CHARGE_RATE)
+
+    def test_charge_rover_unknown_agent(self):
+        result = charge_rover("rover-99")
+        self.assertFalse(result["ok"])
+        self.assertIn("Unknown agent", result["error"])
+
+    def test_charge_rover_rejects_non_rover(self):
+        result = charge_rover("station")
+        self.assertFalse(result["ok"])
+        self.assertIn("not a rover", result["error"])
+
+    def test_charge_rover_records_memory(self):
+        charge_rover("rover-mock")
+        mem = WORLD["agents"]["rover-mock"]["memory"]
+        self.assertEqual(len(mem), 1)
+        self.assertIn("Station charged", mem[0])
+
+    def test_charge_not_available_as_rover_action(self):
+        result = execute_action("rover-mock", "charge", {})
+        self.assertFalse(result["ok"])
+        self.assertIn("Unknown action", result["error"])
 
 
 class TestFogOfWar(unittest.TestCase):
@@ -590,23 +613,48 @@ class TestMissionCompletion(unittest.TestCase):
         execute_action("rover-mock", "pickup", {})
         self.assertEqual(WORLD["mission"]["collected_count"], 0)
 
-    def test_mission_success_on_target_reached(self):
+    def test_pickup_away_from_station_no_success(self):
+        """Picking up a target stone away from station should NOT trigger success."""
         WORLD["mission"]["target_count"] = 1
         WORLD["stones"] = [{"position": [5, 5], "type": "core", "extracted": True}]
+        result = execute_action("rover-mock", "pickup", {})
+        self.assertEqual(WORLD["mission"]["status"], "running")
+        self.assertNotIn("mission", result)
+        self.assertEqual(WORLD["mission"]["collected_count"], 1)
+
+    def test_mission_success_on_delivery_to_station(self):
+        """Success requires the rover to deliver the stone to the station."""
+        WORLD["mission"]["target_count"] = 1
+        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
+        WORLD["agents"]["station"]["position"] = [0, 0]
+        WORLD["stones"] = [{"position": [0, 0], "type": "core", "extracted": True}]
         result = execute_action("rover-mock", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "success")
         self.assertIn("mission", result)
         self.assertEqual(result["mission"]["status"], "success")
 
+    def test_mission_success_on_move_to_station_with_stone(self):
+        """Moving to station while carrying target stone triggers success."""
+        WORLD["mission"]["target_count"] = 1
+        WORLD["agents"]["rover-mock"]["position"] = [1, 0]
+        WORLD["agents"]["rover-mock"]["inventory"] = [{"type": "core"}]
+        WORLD["agents"]["station"]["position"] = [0, 0]
+        WORLD["stones"] = []
+        result = execute_action("rover-mock", "move", {"direction": "west"})
+        self.assertEqual(WORLD["mission"]["status"], "success")
+        self.assertIn("mission", result)
+
     def test_mission_success_with_two_rovers(self):
         WORLD["mission"]["target_count"] = 2
-        # Rover-mock picks up one core
-        WORLD["stones"] = [{"position": [5, 5], "type": "core", "extracted": True}]
+        WORLD["agents"]["station"]["position"] = [0, 0]
+        # Rover-mock picks up one core at station
+        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
+        WORLD["stones"] = [{"position": [0, 0], "type": "core", "extracted": True}]
         execute_action("rover-mock", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "running")
-        # Rover-mistral picks up another core
-        WORLD["agents"]["rover-mistral"]["position"] = [7, 7]
-        WORLD["stones"] = [{"position": [7, 7], "type": "core", "extracted": True}]
+        # Rover-mistral picks up another core at station
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
+        WORLD["stones"] = [{"position": [0, 0], "type": "core", "extracted": True}]
         result = execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "success")
         self.assertEqual(WORLD["mission"]["collected_count"], 2)
@@ -695,10 +743,10 @@ class TestMemory(unittest.TestCase):
     def test_charge_records_memory(self):
         WORLD["agents"]["rover-mock"]["position"] = [0, 0]
         WORLD["agents"]["rover-mock"]["battery"] = 0.5
-        execute_action("rover-mock", "charge", {})
+        charge_rover("rover-mock")
         mem = WORLD["agents"]["rover-mock"]["memory"]
         self.assertEqual(len(mem), 1)
-        self.assertIn("Charged", mem[0])
+        self.assertIn("Station charged", mem[0])
 
     def test_failed_action_records_memory(self):
         WORLD["stones"] = []

--- a/tasks/simplify-rover-actions.md
+++ b/tasks/simplify-rover-actions.md
@@ -1,0 +1,43 @@
+# Simplify Rover Actions
+
+## Tasks
+
+- [x] Remove `check_ground` from rover tool lists (auto-scanned after each move)
+- [x] Remove `charge` from rover tool lists
+- [x] Add `charge_rover()` function to `world.py` (station-initiated only)
+- [x] Add `CHARGE_ROVER_TOOL` to station agent tools
+- [x] Add auto-charge in `agent_loop` when rover arrives at station with low battery
+- [x] Update rover prompt: mention auto-charge and return-to-base rule
+- [x] Change mission success condition: require delivery to station (not just pickup)
+- [x] Enhance mock rover: dig/pickup stones, navigate to station when carrying target stone
+- [x] Update all tests: charge tests use `charge_rover()`, mission tests require station delivery
+- [x] Verify all 107 tests pass
+
+## Summary of Changes
+
+### `world.py`
+- Removed `check_ground` and `charge` from both rover tool definitions
+- Updated move tool description to mention auto-scan
+- Removed `charge` case from `execute_action()`
+- Added `charge_rover()` function for station-initiated charging
+- Changed `check_mission_status()`: success now requires target stones delivered to station (rover at station position), not just collected
+
+### `agent.py`
+- Updated rover system prompt: auto-charge explanation, return-to-base rule
+- Enhanced `MockRoverAgent`: digs/picks up stones at current tile, navigates to station when carrying target stone
+
+### `station.py`
+- Added `CHARGE_ROVER_TOOL` definition
+- Added `charge_rover` to `STATION_TOOLS` list
+- Updated system prompt to mention charging responsibility
+- Added `charge_rover` handling in `_execute_tool_calls()`
+
+### `main.py`
+- Imported `charge_rover` from world
+- Added auto-charge logic in `agent_loop`: charges rover when it arrives at station with < 100% battery
+
+### `test_world.py`
+- Rewrote `TestCharge` to use `charge_rover()` instead of `execute_action("charge")`
+- Added tests: unknown agent, non-rover rejection, memory recording, charge-not-rover-action
+- Updated mission success tests to require station delivery
+- Added `test_pickup_away_from_station_no_success` and `test_mission_success_on_move_to_station_with_stone`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,26 @@
+# Task: Simplify Rover Actions
+
+## Changes
+
+### 1. Remove `check_ground` as an explicit action
+- [x] Remove from rover tools list in `world.py` WORLD init
+- [x] Remove from `execute_action` dispatcher (if present)
+- [x] Keep `check_ground()` function — it's used internally for auto-scan after moves
+- [x] Update tests: remove tests that call check_ground as an action
+- [x] Update agent context to clarify ground is auto-scanned
+
+### 2. Make `charge` a station-only action
+- [x] Remove `charge` from rover tools list in `world.py` WORLD init
+- [x] Add `charge_rover` tool to station's Mistral tools in `station.py`
+- [x] Station calls charge when rover is co-located
+- [x] Keep `_execute_charge` in world.py (station invokes it)
+- [x] Update `execute_action` to accept charge from station context
+- [x] Update tests for new charge flow
+- [x] Update rover agent context to say "return to station for charging"
+
+### 3. Carry over .kiro files
+- [x] Commit .kiro steering files
+
+### 4. Verify
+- [x] All tests pass
+- [x] Update Changelog.md


### PR DESCRIPTION
## Summary
- Removed `check_ground` and `charge` from rover actions — ground is auto-scanned after every move, charging is now station-only via `charge_rover()`
- Mission success now requires **delivering** target stones to the station, not just collecting them
- Enhanced mock rover to dig/pickup stones and navigate back to station when carrying target stone
- Added `.kiro` steering files and task tracking

## Test plan
- [x] All 107 tests pass (including new delivery-based mission tests, charge_rover tests, and charge-not-rover-action test)
- [ ] Manual verification: run simulation and confirm rovers return to station after collecting stones
- [ ] Verify auto-charge triggers when rover arrives at station

🤖 Generated with [Claude Code](https://claude.com/claude-code)