### PR TITLE
fix(release): sync pyproject.toml version in release PRs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -36,3 +36,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added Release Please annotation to FastAPI app version in `server/app/main.py` to prevent version drift across releases
 - Updated rover task planning in `server/app/world.py` to keep revealed-tile filtering lint-clean in CI
 - Applied Ruff formatting to `server/app/world.py` and `server/tests/test_world.py` to keep merge-ref CI formatting checks green
+- Fixed Release Please TOML version path in `release-please-config.json` so `server/pyproject.toml` bumps on every release

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,11 @@
       "include-component-in-tag": false,
       "pull-request-title-pattern": "chore: release ${version}",
       "extra-files": [
-        "server/pyproject.toml",
+        {
+          "type": "toml",
+          "path": "server/pyproject.toml",
+          "jsonpath": "$.project.version"
+        },
         "server/app/main.py",
         "ui/package.json",
         "ui/package-lock.json"


### PR DESCRIPTION
## Summary
- update `release-please-config.json` to use explicit TOML path mapping for `server/pyproject.toml`
- ensure release-please bumps `$.project.version` instead of trying `$.version`
- record the fix in `Changelog.md`

## Why
Release PR #7 showed version bumps for UI/API metadata but not `server/pyproject.toml`.
This change closes that gap so server package version stays consistent in every release.

## Verification
- `python3 -m json.tool release-please-config.json`
- `python3 -m json.tool .release-please-manifest.json`