### PR TITLE
fix(ui): broken map — undefined variable in WorldMap.vue

### DIFF
--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -214,7 +214,7 @@ function agentTransform(id) {
         <circle
           :r="REVEAL_RADIUS * TILE_SIZE"
           fill="none"
-          :stroke="agentColor(a.agent_id)"
+          :stroke="agentColor(id)"
           stroke-width="1"
           opacity="0.3"
           stroke-dasharray="4 3"


### PR DESCRIPTION
## Summary
- Visibility radius circle used `a.agent_id` (undefined) instead of `id` from the `v-for` loop
- This runtime error crashed the entire SVG, making the map invisible

## Test plan
- [x] UI builds successfully
- [ ] Map renders with rover dots and visibility radius circles

🤖 Generated with [Claude Code](https://claude.com/claude-code)