### PR TITLE
feat: always-on text narration with streaming

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Always-on text narration**: Mistral `magistral-medium-latest` generates narrative text regardless of ElevenLabs voice toggle — voice is now opt-in only
+- **Streaming narration**: text streams to UI via `narration_chunk` WebSocket events using Mistral `chat.stream()`, with typewriter effect in NarrationPlayer
+- Audio emotion tags (`[laughs]`, `[sighs]`, etc.) stripped from display text via `_strip_audio_tags()` — kept only for TTS synthesis
+- NarrationPlayer toggle relabeled to "Voice ON" / "Voice OFF" to clarify it controls audio only
+- Narration model upgraded from `mistral-small-latest` to `magistral-medium-latest`
 
 ### Changed
 

--- a/server/app/narrator.py
+++ b/server/app/narrator.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import re
 import time
 
 from elevenlabs import ElevenLabs
@@ -182,6 +183,22 @@ def _build_narration_prompt(events: list[dict], world_summary: str) -> str:
     return "\n".join(lines)
 
 
+# ── Text helpers ────────────────────────────────────────────────────────────
+
+_AUDIO_TAG_RE = re.compile(
+    r"\[(laughs|sighs|whispers|gasps|clears throat)\]",
+    re.IGNORECASE,
+)
+
+
+def _strip_audio_tags(text: str) -> str:
+    """Remove ElevenLabs emotion tags for text-only display."""
+    cleaned = _AUDIO_TAG_RE.sub("", text)
+    # Collapse any resulting double-spaces
+    cleaned = re.sub(r"  +", " ", cleaned)
+    return cleaned.strip()
+
+
 # ── ElevenLabs TTS ──────────────────────────────────────────────────────────
 
 
@@ -249,12 +266,12 @@ class Narrator:
         return self._elevenlabs
 
     async def feed(self, event: dict):
-        """Feed an event to the narrator. Non-blocking."""
-        if not self._enabled:
-            return
-        if not settings.elevenlabs_api_key:
-            return
+        """Feed an event to the narrator. Non-blocking.
 
+        Text narration is always generated regardless of the enabled flag.
+        The ``_enabled`` flag only controls whether ElevenLabs voice audio
+        is produced.
+        """
         weight = _is_interesting(event)
         if weight == 0:
             return
@@ -296,7 +313,7 @@ class Narrator:
         while self._running:
             try:
                 await asyncio.sleep(settings.narration_min_interval_seconds)
-                if self._event_buffer and self._enabled:
+                if self._event_buffer:
                     await self._process_batch()
             except asyncio.CancelledError:
                 break
@@ -349,9 +366,13 @@ class Narrator:
                     )
             world_summary = "\n".join(summary_parts)
 
-            # Generate narration text via Mistral
+            # Generate narration text via Mistral (streaming to UI)
             prompt = _build_narration_prompt(events, world_summary)
-            narration_text = await asyncio.to_thread(self._generate_text, prompt)
+
+            # Try streaming first; fall back to non-streaming on failure
+            narration_text = await self._generate_text_streaming(prompt)
+            if narration_text is None:
+                narration_text = await asyncio.to_thread(self._generate_text, prompt)
 
             if not narration_text:
                 logger.warning("Narrator: empty text from LLM")
@@ -359,39 +380,40 @@ class Narrator:
 
             logger.info("Narration: %s", narration_text)
 
-            # Convert to audio via ElevenLabs
-            elevenlabs = self._get_elevenlabs()
-            audio_bytes = None
-            if elevenlabs:
-                audio_bytes = await asyncio.to_thread(_generate_audio, narration_text, elevenlabs)
+            # Voice synthesis — only when narration is enabled
+            if self._enabled:
+                elevenlabs = self._get_elevenlabs()
+                audio_bytes = None
+                if elevenlabs:
+                    audio_bytes = await asyncio.to_thread(
+                        _generate_audio, narration_text, elevenlabs
+                    )
 
-            if not audio_bytes:
-                # Fallback: send text-only narration
-                await self._broadcast(
-                    {
-                        "source": "narrator",
-                        "type": "narration",
-                        "name": "narration",
-                        "payload": {
-                            "text": narration_text,
-                            "audio": None,
-                        },
-                    }
-                )
-                return
+                if audio_bytes:
+                    audio_b64 = base64.b64encode(audio_bytes).decode("ascii")
+                    await self._broadcast(
+                        {
+                            "source": "narrator",
+                            "type": "narration",
+                            "name": "narration",
+                            "payload": {
+                                "text": _strip_audio_tags(narration_text),
+                                "audio": audio_b64,
+                                "format": "mp3",
+                            },
+                        }
+                    )
+                    return
 
-            # Encode audio as base64 for WebSocket transport
-            audio_b64 = base64.b64encode(audio_bytes).decode("ascii")
-
+            # Text-only narration (no audio) — always sent
             await self._broadcast(
                 {
                     "source": "narrator",
                     "type": "narration",
                     "name": "narration",
                     "payload": {
-                        "text": narration_text,
-                        "audio": audio_b64,
-                        "format": "mp3",
+                        "text": _strip_audio_tags(narration_text),
+                        "audio": None,
                     },
                 }
             )
@@ -400,11 +422,14 @@ class Narrator:
             logger.exception("Narrator batch processing failed")
 
     def _generate_text(self, prompt: str) -> str | None:
-        """Call Mistral to generate narration text (runs in thread)."""
+        """Call Mistral to generate narration text (runs in thread).
+
+        Kept as a non-streaming fallback.
+        """
         try:
             client = self._get_mistral()
             response = client.chat.complete(
-                model="mistral-small-latest",
+                model="magistral-medium-latest",
                 messages=[
                     {"role": "system", "content": NARRATOR_SYSTEM_PROMPT},
                     {"role": "user", "content": prompt},
@@ -416,4 +441,46 @@ class Narrator:
             return text.strip() if text else None
         except Exception:
             logger.exception("Narrator LLM call failed")
+            return None
+
+    async def _generate_text_streaming(self, prompt: str) -> str | None:
+        """Stream narration text from Mistral, broadcasting chunks as they arrive.
+
+        Each chunk is sent to the UI as a ``narration_chunk`` event so the text
+        appears progressively.  Returns the full accumulated text when done.
+        """
+        try:
+            client = self._get_mistral()
+
+            stream = client.chat.stream(
+                model="magistral-medium-latest",
+                messages=[
+                    {"role": "system", "content": NARRATOR_SYSTEM_PROMPT},
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=200,
+                temperature=0.9,
+            )
+
+            full_text = ""
+            for event in stream:
+                chunk = event.data.choices[0].delta.content
+                if chunk:
+                    full_text += chunk
+                    # Broadcast each chunk for progressive display (stripped
+                    # of audio tags since these are for TTS only)
+                    await self._broadcast(
+                        {
+                            "source": "narrator",
+                            "type": "narration",
+                            "name": "narration_chunk",
+                            "payload": {
+                                "text": _strip_audio_tags(chunk),
+                            },
+                        }
+                    )
+
+            return full_text.strip() if full_text else None
+        except Exception:
+            logger.exception("Narrator streaming LLM call failed")
             return None

--- a/server/tests/test_narrator.py
+++ b/server/tests/test_narrator.py
@@ -220,18 +220,17 @@ class TestNarrator(unittest.IsolatedAsyncioTestCase):
         self.narrator.enabled = True
         self.assertTrue(self.narrator.enabled)
 
-    async def test_feed_skips_when_disabled(self):
+    async def test_feed_buffers_when_voice_disabled(self):
+        """Text narration always runs — disabling only skips voice."""
         self.narrator.enabled = False
         await self.narrator.feed({"name": "dig", "payload": {}})
-        self.assertEqual(len(self.narrator._event_buffer), 0)
+        self.assertEqual(len(self.narrator._event_buffer), 1)
 
-    @patch("app.narrator.settings")
-    async def test_feed_skips_without_api_key(self, mock_settings):
-        mock_settings.elevenlabs_api_key = ""
-        mock_settings.narration_enabled = True
+    async def test_feed_buffers_without_api_key(self):
+        """Text narration works even without ElevenLabs key."""
         narrator = Narrator(broadcast_fn=self.broadcast)
         await narrator.feed({"name": "dig", "payload": {}})
-        self.assertEqual(len(narrator._event_buffer), 0)
+        self.assertEqual(len(narrator._event_buffer), 1)
 
     async def test_feed_skips_uninteresting_event(self):
         self.narrator._enabled = True

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -33,7 +33,7 @@ async function resetSimulation() {
   }
 }
 
-const { events, connected, worldState, agentIds, agentEvents, narration } = useWebSocket({ onConnect: onWsConnect })
+const { events, connected, worldState, agentIds, agentEvents, narration, narrationChunk } = useWebSocket({ onConnect: onWsConnect })
 
 async function togglePause() {
   const endpoint = paused.value ? '/api/simulation/resume' : '/api/simulation/pause'
@@ -67,6 +67,7 @@ function agentData(id) {
 
     <NarrationPlayer
       :narration="narration"
+      :narration-chunk="narrationChunk"
       :narration-enabled="narrationEnabled"
       @toggle-narration="toggleNarration"
     />

--- a/ui/src/components/NarrationPlayer.vue
+++ b/ui/src/components/NarrationPlayer.vue
@@ -1,8 +1,12 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, onUnmounted } from 'vue'
 
 const props = defineProps({
   narration: {
+    type: Object,
+    default: null,
+  },
+  narrationChunk: {
     type: Object,
     default: null,
   },
@@ -17,9 +21,43 @@ const audioQueue = ref([])
 const isProcessing = ref(false)
 
 let currentAudio = null
+let typewriterQueue = []
+let typewriterTimer = null
+
+function startTypewriter() {
+  if (typewriterTimer) return
+  typewriterTimer = setInterval(() => {
+    if (typewriterQueue.length === 0) {
+      clearInterval(typewriterTimer)
+      typewriterTimer = null
+      return
+    }
+    currentText.value += typewriterQueue.shift()
+  }, 30)
+}
+
+function stopTypewriter() {
+  if (typewriterTimer) {
+    clearInterval(typewriterTimer)
+    typewriterTimer = null
+  }
+  typewriterQueue = []
+}
+
+onUnmounted(() => {
+  stopTypewriter()
+})
+
+watch(() => props.narrationChunk, (event) => {
+  if (!event || !event.text) return
+  const chars = event.text.split('')
+  typewriterQueue.push(...chars)
+  startTypewriter()
+})
 
 watch(() => props.narration, (event) => {
   if (!event) return
+  stopTypewriter()
   currentText.value = event.text || ''
 
   if (event.audio && props.narrationEnabled) {
@@ -135,10 +173,10 @@ function skipAudio() {
       <button
         class="toggle-btn"
         :class="{ off: !narrationEnabled }"
-        :title="narrationEnabled ? 'Mute narrator' : 'Unmute narrator'"
+        :title="narrationEnabled ? 'Turn voice off' : 'Turn voice on'"
         @click="emit('toggle-narration')"
       >
-        {{ narrationEnabled ? '🔊' : '🔇' }}
+        {{ narrationEnabled ? 'Voice ON' : 'Voice OFF' }}
       </button>
     </div>
   </div>
@@ -234,11 +272,13 @@ function skipAudio() {
 }
 
 .toggle-btn {
-  font-size: 0.9rem;
-  padding: 0.15rem 0.3rem;
+  font-family: 'Courier New', monospace;
+  font-size: 0.65rem;
+  padding: 0.2rem 0.5rem;
   border-radius: 3px;
-  border: 1px solid transparent;
-  background: none;
+  border: 1px solid #555;
+  background: #1a1a24;
+  color: #88cc88;
   cursor: pointer;
   opacity: 0.7;
   transition: opacity 0.2s;

--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -5,6 +5,7 @@ export function useWebSocket({ onConnect } = {}) {
   const connected = ref(false)
   const worldState = ref(null)
   const narration = ref(null)
+  const narrationChunk = ref(null)
   let ws = null
 
   const agentEvents = computed(() => {
@@ -39,6 +40,8 @@ export function useWebSocket({ onConnect } = {}) {
         worldState.value = event.payload
       } else if (event.source === 'narrator' && event.type === 'narration') {
         narration.value = event.payload
+      } else if (event.source === 'narrator' && event.type === 'narration_chunk') {
+        narrationChunk.value = event.payload
       } else {
         events.value.unshift(event)
         if (events.value.length > 200) {
@@ -65,5 +68,5 @@ export function useWebSocket({ onConnect } = {}) {
     if (ws) ws.close()
   })
 
-  return { events, connected, worldState, agentIds, agentEvents, narration }
+  return { events, connected, worldState, agentIds, agentEvents, narration, narrationChunk }
 }


### PR DESCRIPTION
## Summary
- Text narration via Mistral `magistral-medium-latest` now always generates regardless of ElevenLabs voice toggle
- Narration streams to UI via `narration_chunk` WebSocket events using `chat.stream()` with typewriter display effect
- Voice synthesis (ElevenLabs) remains opt-in only — toggle relabeled to "Voice ON/OFF"
- Audio emotion tags (`[laughs]`, `[sighs]`, etc.) stripped from display text, kept for TTS only

## Test plan
- [x] All 30 narrator tests pass (`rut tests/test_narrator.py`)
- [x] ESLint clean, UI builds successfully
- [x] Ruff lint + format clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)