### PR TITLE
fix(ui): narration text not showing and voice toggle broken

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Upgraded TTS model to ElevenLabs v3**: replaced `eleven_flash_v2_5` with `eleven_v3` for premium voice quality with emotional expression
 - Updated narrator system prompt to leverage v3 audio tags (`[whispers]`, `[gasps]`, `[laughs]`, `[sighs]`, `[clears throat]`) for dramatic vocal inflection during mission narration
 
+### Fixed
+
+- **Narration text not appearing in UI**: WebSocket event handler matched narrator events on `event.type` instead of `event.name` — both full narration and streaming chunks share `type: "narration"` but differ on `name` (`"narration"` vs `"narration_chunk"`). Fixed in `useWebSocket.js`
+- **Voice toggle out of sync with server**: UI initialized `narrationEnabled` to `true` but server defaults to `false`. Fixed to `false` and added `/api/narration/status` fetch on WebSocket connect to sync toggle state
+
 ### Changed
 
 - **Always-on text narration**: Mistral `magistral-medium-latest` generates narrative text regardless of ElevenLabs voice toggle — voice is now opt-in only

--- a/specs/001-fix-narration-ui/checklists/requirements.md
+++ b/specs/001-fix-narration-ui/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Fix Narration Text Display & Voice Toggle
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan` or direct implementation.
+- Root cause analysis included in spec since this is a bug fix — identifies exact locations and fixes needed.

--- a/specs/001-fix-narration-ui/contracts/websocket-events.md
+++ b/specs/001-fix-narration-ui/contracts/websocket-events.md
@@ -1,0 +1,28 @@
+# WebSocket Event Contracts: Narrator Events
+
+## Event Routing Rules
+
+The WebSocket `onmessage` handler must route narrator events using BOTH `source` and `name`:
+
+```
+if source === "narrator" AND name === "narration"      → full narration handler
+if source === "narrator" AND name === "narration_chunk" → streaming chunk handler
+```
+
+**Do NOT** use `event.type` for discrimination — both event types share `type: "narration"`.
+
+## REST Endpoints
+
+### POST /api/narration/toggle
+
+Toggles voice synthesis on/off. Returns current state.
+
+**Response**: `{ "enabled": boolean }`
+
+### GET /api/narration/status
+
+Returns current voice synthesis state.
+
+**Response**: `{ "enabled": boolean }`
+
+**Usage**: Call on WebSocket connect to sync UI toggle state with server.

--- a/specs/001-fix-narration-ui/data-model.md
+++ b/specs/001-fix-narration-ui/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Fix Narration Text Display & Voice Toggle
+
+**Branch**: `001-fix-narration-ui` | **Date**: 2026-02-28
+
+## Entities
+
+### Narration Event (WebSocket message)
+
+Full narration broadcast after a batch of events is processed.
+
+| Field              | Type            | Description                                    |
+| ------------------ | --------------- | ---------------------------------------------- |
+| `source`           | string          | Always `"narrator"`                            |
+| `type`             | string          | Always `"narration"`                           |
+| `name`             | string          | `"narration"` for full events                  |
+| `payload.text`     | string          | Narration text (audio tags stripped)            |
+| `payload.audio`    | string \| null  | Base64-encoded MP3 audio (null if voice off)   |
+| `payload.format`   | string \| null  | `"mp3"` when audio present, omitted otherwise  |
+
+### Narration Chunk (WebSocket message)
+
+Streaming text fragment during LLM generation.
+
+| Field              | Type   | Description                           |
+| ------------------ | ------ | ------------------------------------- |
+| `source`           | string | Always `"narrator"`                   |
+| `type`             | string | Always `"narration"`                  |
+| `name`             | string | `"narration_chunk"` for chunks        |
+| `payload.text`     | string | Text fragment (audio tags stripped)    |
+
+### Voice Toggle State
+
+Server-side boolean controlling ElevenLabs TTS synthesis.
+
+| Field     | Type | Description                                      |
+| --------- | ---- | ------------------------------------------------ |
+| `enabled` | bool | `true` = voice synthesis active, `false` = text only |
+
+## Key Insight
+
+Both event types share `type: "narration"`. The `name` field is the discriminator:
+- `name: "narration"` → full narration with optional audio
+- `name: "narration_chunk"` → streaming text fragment

--- a/specs/001-fix-narration-ui/plan.md
+++ b/specs/001-fix-narration-ui/plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan: Fix Narration Text Display & Voice Toggle
+
+**Branch**: `001-fix-narration-ui` | **Date**: 2026-02-28 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-fix-narration-ui/spec.md`
+
+## Summary
+
+Fix 4 bugs preventing narration text from appearing in the UI and the voice toggle from working. The WebSocket event routing uses wrong field names for matching narrator events, and the voice toggle state is never synced from the server on page load.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+ (server), JavaScript/Vue 3 (UI)
+**Primary Dependencies**: FastAPI, Vue 3, Vite, Mistral AI SDK, ElevenLabs SDK
+**Storage**: N/A (in-memory state only)
+**Testing**: `rut` (unittest runner), ESLint
+**Target Platform**: Web browser (desktop/tablet/mobile)
+**Project Type**: Web application (full-stack)
+**Performance Goals**: Narration text visible within 5s of events
+**Constraints**: No new dependencies; minimal code changes (bug fix only)
+**Scale/Scope**: 4 targeted fixes across 2 UI files
+
+## Constitution Check
+
+*GATE: Constitution is unconfigured (blank template). No gates to evaluate. Proceeding.*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-fix-narration-ui/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output (trivial — no unknowns)
+├── data-model.md        # Phase 1 output (event schemas)
+├── contracts/           # Phase 1 output (WebSocket event contracts)
+└── tasks.md             # Phase 2 output (via /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+server/
+├── app/
+│   ├── narrator.py         # No changes needed (server-side is correct)
+│   └── main.py             # No changes needed (endpoints exist and work)
+└── tests/
+    └── test_narrator.py    # Verify existing tests still pass
+
+ui/
+└── src/
+    ├── App.vue                          # Fix: init narrationEnabled=false, fetch status on connect
+    ├── composables/useWebSocket.js      # Fix: match on event.name instead of event.type
+    └── components/NarrationPlayer.vue   # No changes needed (component logic is correct)
+```
+
+**Structure Decision**: Existing web application structure. Changes limited to 2 UI files only.
+
+## Complexity Tracking
+
+No violations — this is a minimal bug fix with 4 targeted line changes.

--- a/specs/001-fix-narration-ui/quickstart.md
+++ b/specs/001-fix-narration-ui/quickstart.md
@@ -1,0 +1,29 @@
+# Quickstart: Fix Narration Text Display & Voice Toggle
+
+## Changes Required
+
+### 1. Fix WebSocket event matching (useWebSocket.js)
+
+Change narrator event routing from `event.type` to `event.name`:
+- Line 41: `event.type === 'narration'` → `event.name === 'narration'`
+- Line 43: `event.type === 'narration_chunk'` → `event.name === 'narration_chunk'`
+
+### 2. Fix voice toggle initialization (App.vue)
+
+- Line 14: Change `ref(true)` → `ref(false)`
+- Add narration status fetch in `onWsConnect()` callback
+
+### 3. Verify
+
+```bash
+cd server && rut tests/test_narrator.py   # all 30 tests pass
+cd ui && npx eslint src/                   # zero warnings
+cd ui && npm run build                     # clean build
+```
+
+## Files Touched
+
+| File | Change |
+| ---- | ------ |
+| `ui/src/composables/useWebSocket.js` | Fix event name matching (2 lines) |
+| `ui/src/App.vue` | Init toggle to false, fetch status on connect (3 lines) |

--- a/specs/001-fix-narration-ui/research.md
+++ b/specs/001-fix-narration-ui/research.md
@@ -1,0 +1,27 @@
+# Research: Fix Narration Text Display & Voice Toggle
+
+**Branch**: `001-fix-narration-ui` | **Date**: 2026-02-28
+
+## Research Summary
+
+No unknowns or NEEDS CLARIFICATION items. All 4 bugs were identified through direct code inspection.
+
+## Decision 1: WebSocket Event Matching Strategy
+
+**Decision**: Match narrator events on `event.name` field instead of `event.type`
+
+**Rationale**: The server narrator broadcasts all events with `type: "narration"` and uses the `name` field to distinguish between `"narration"` (full text + optional audio) and `"narration_chunk"` (streaming text fragment). The UI WebSocket handler was incorrectly checking `event.type` for the chunk distinction, which always fails since both event types share `type: "narration"`.
+
+**Alternatives considered**:
+- Change server to use different `type` values — rejected because `type: "narration"` is the correct semantic grouping, and `name` is the discriminator per the project's event protocol
+- Add a separate field — rejected as unnecessary complexity
+
+## Decision 2: Voice Toggle State Initialization
+
+**Decision**: Initialize `narrationEnabled` to `false` and fetch actual state from `/api/narration/status` on WebSocket connect
+
+**Rationale**: Server defaults to `narration_enabled = False` (config.py). The UI was hardcoding `true`, creating an immediate state mismatch. Fetching on connect ensures the UI always reflects reality.
+
+**Alternatives considered**:
+- Include narration state in the WebSocket world state payload — rejected as it would require server changes and narration state is not part of world state
+- Use localStorage to persist toggle — rejected as it would still diverge from server state after restarts

--- a/specs/001-fix-narration-ui/spec.md
+++ b/specs/001-fix-narration-ui/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: Fix Narration Text Display & Voice Toggle
+
+**Feature Branch**: `001-fix-narration-ui`
+**Created**: 2026-02-28
+**Status**: Draft
+**Input**: User description: "check if all is implemented correctly, I can't see the narration wording and I also cannot turn on the sound, please check, I think the switch might not be correct"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See Narration Text During Simulation (Priority: P1)
+
+As a user watching the Mars simulation, I want to see narration text appearing in the narrator bar as mission events happen, so I can follow the dramatic commentary without needing audio.
+
+**Why this priority**: Core feature — if narration text never appears, the entire narration system is invisible to users.
+
+**Independent Test**: Start the simulation, wait for rover to perform actions (dig, check, move). Narration text should appear in the narrator bar with a typewriter streaming effect within 5 seconds of interesting events.
+
+**Acceptance Scenarios**:
+
+1. **Given** the simulation is running and a rover digs a stone, **When** the narrator generates text, **Then** the narration text streams into the narrator bar character-by-character
+2. **Given** the simulation is running, **When** no events have occurred yet, **Then** the narrator bar shows "Awaiting mission events..."
+3. **Given** narration text is streaming, **When** a new narration batch arrives, **Then** the previous text is replaced with the full text and new streaming begins
+
+---
+
+### User Story 2 - Toggle Voice Narration On/Off (Priority: P1)
+
+As a user, I want to toggle voice narration on and off using a clearly labeled button, so I can choose whether to hear audio narration or just read the text.
+
+**Why this priority**: Equal to P1 — the toggle is completely broken, preventing users from enabling voice even if they want it.
+
+**Independent Test**: Click the "Voice OFF" button. It should call the server, update to "Voice ON", and subsequent narrations should include audio playback. Click again to turn off.
+
+**Acceptance Scenarios**:
+
+1. **Given** voice is off (default), **When** I click the voice toggle button, **Then** the button changes to "Voice ON" and the server enables voice synthesis
+2. **Given** voice is on, **When** I click the voice toggle button, **Then** the button changes to "Voice OFF" and the server disables voice synthesis
+3. **Given** voice is on, **When** a narration event arrives with audio, **Then** the audio plays automatically
+4. **Given** voice is off, **When** a narration event arrives, **Then** only text is shown, no audio plays
+
+---
+
+### User Story 3 - Voice Toggle State Syncs on Page Load (Priority: P2)
+
+As a user, I want the voice toggle button to reflect the actual server state when I open or refresh the page, so I'm not confused by a mismatched UI.
+
+**Why this priority**: Prevents user confusion but is secondary to getting text and toggle working at all.
+
+**Independent Test**: Set voice to ON via toggle. Refresh the page. The toggle should still show "Voice ON" after reload.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server has narration voice enabled, **When** I load the page, **Then** the toggle shows "Voice ON"
+2. **Given** the server has narration voice disabled, **When** I load the page, **Then** the toggle shows "Voice OFF"
+
+---
+
+### Edge Cases
+
+- What happens when the WebSocket reconnects mid-narration? Text resets to idle state (handled by existing reconnect logic clearing events).
+- What happens when the toggle API call fails? Button state should not change — only update on successful server response.
+- What happens when narration chunks arrive but no final narration event follows? Partial text stays visible until next narration batch.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: WebSocket handler MUST correctly route narration chunk events by matching on `event.name === 'narration_chunk'` (not `event.type`)
+- **FR-002**: WebSocket handler MUST correctly route full narration events by matching on `event.name === 'narration'`
+- **FR-003**: Voice toggle button MUST call the server API and update the UI to reflect the actual server response
+- **FR-004**: On page load/reconnect, the UI MUST fetch the current voice status from the server and initialize the toggle accordingly
+- **FR-005**: Text narration MUST always display regardless of voice toggle state
+
+### Key Entities
+
+- **Narration Event**: Complete narration with text and optional audio (`source: "narrator", type: "narration", name: "narration", payload: {text, audio}`)
+- **Narration Chunk**: Streaming text fragment (`source: "narrator", type: "narration", name: "narration_chunk", payload: {text}`)
+- **Voice Toggle State**: Boolean server-side flag controlling ElevenLabs TTS synthesis
+
+## Root Cause Analysis
+
+| Bug | Location                | Issue                                                                                              | Fix                                                  |
+| --- | ----------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| #1  | useWebSocket.js:43      | Checks `event.type === 'narration_chunk'` but server sends `name: 'narration_chunk'`               | Match on `event.name === 'narration_chunk'`           |
+| #2  | useWebSocket.js:41      | Full narration matched by `type` only — ambiguous with chunks that share same `type`                | Match on `event.name === 'narration'`                 |
+| #3  | App.vue:14              | Hardcodes `narrationEnabled = ref(true)` but server defaults to `false`                            | Initialize to `false`, fetch from server on connect   |
+| #4  | App.vue (missing)       | No startup call to `/api/narration/status`                                                         | Add fetch in `onWsConnect` callback                   |
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Narration text appears in the narrator bar within 5 seconds of interesting simulation events occurring
+- **SC-002**: Voice toggle correctly reflects server state after every click and on page load
+- **SC-003**: All existing narrator tests continue to pass
+- **SC-004**: No console errors related to narration events during normal simulation operation

--- a/specs/001-fix-narration-ui/tasks.md
+++ b/specs/001-fix-narration-ui/tasks.md
@@ -1,0 +1,167 @@
+# Tasks: Fix Narration Text Display & Voice Toggle
+
+**Input**: Design documents from `/specs/001-fix-narration-ui/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Not explicitly requested. Existing server tests will be verified as part of validation.
+
+**Organization**: Tasks grouped by user story. US1 and US2 are both P1 but independent. US3 depends on US2.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No setup needed — this is a bug fix on an existing codebase. Branch already created.
+
+_(No tasks — project structure and dependencies already exist)_
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Fix the shared WebSocket event routing that blocks both text display (US1) and voice toggle (US2)
+
+**CRITICAL**: These fixes unblock all user stories
+
+- [x] T001 [P] Fix full narration event matching: change `event.type === 'narration'` to `event.name === 'narration'` in `ui/src/composables/useWebSocket.js` line 41
+- [x] T002 [P] Fix chunk event matching: change `event.type === 'narration_chunk'` to `event.name === 'narration_chunk'` in `ui/src/composables/useWebSocket.js` line 43
+
+**Checkpoint**: WebSocket now correctly routes narrator events — both full narrations and streaming chunks reach the UI components
+
+---
+
+## Phase 3: User Story 1 - See Narration Text During Simulation (Priority: P1)
+
+**Goal**: Narration text appears in the narrator bar with typewriter streaming as mission events happen
+
+**Independent Test**: Start simulation, wait for rover actions. Text should stream into narrator bar within 5 seconds.
+
+### Implementation for User Story 1
+
+- [x] T003 [US1] Verify narration text displays after T001+T002 fixes by checking NarrationPlayer.vue watcher logic handles both `narrationChunk` and `narration` props correctly in `ui/src/components/NarrationPlayer.vue`
+
+**Checkpoint**: Narration text streams into narrator bar during simulation. "Awaiting mission events..." shows when idle.
+
+---
+
+## Phase 4: User Story 2 - Toggle Voice Narration On/Off (Priority: P1)
+
+**Goal**: Voice toggle button correctly calls server and reflects actual state
+
+**Independent Test**: Click "Voice OFF" button → changes to "Voice ON" → server enables voice synthesis. Click again to disable.
+
+### Implementation for User Story 2
+
+- [x] T004 [US2] Change `narrationEnabled` initialization from `ref(true)` to `ref(false)` in `ui/src/App.vue` line 14
+
+**Checkpoint**: Toggle button starts as "Voice OFF" (matching server default), clicking it correctly toggles server state and button label.
+
+---
+
+## Phase 5: User Story 3 - Voice Toggle State Syncs on Page Load (Priority: P2)
+
+**Goal**: On page load or WebSocket reconnect, UI fetches actual voice state from server
+
+**Independent Test**: Enable voice via toggle, refresh page, toggle should still show "Voice ON"
+
+### Implementation for User Story 3
+
+- [x] T005 [US3] Add `/api/narration/status` fetch in `onWsConnect()` callback to sync `narrationEnabled` with server state in `ui/src/App.vue`
+
+**Checkpoint**: Voice toggle always reflects server state on page load and reconnect.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation and changelog
+
+- [x] T006 Run existing server narrator tests: `cd server && rut tests/test_narrator.py` — all 30 must pass
+- [x] T007 [P] Run UI lint: `cd ui && npx eslint src/` — zero warnings
+- [x] T008 [P] Run UI build: `cd ui && npm run build` — clean build
+- [x] T009 Update `Changelog.md` with bug fix details
+- [ ] T010 Commit, push, create PR, verify CI green, merge to main
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: No dependencies — start immediately
+- **US1 (Phase 3)**: Depends on T001+T002 (foundational WebSocket fixes)
+- **US2 (Phase 4)**: Independent of US1 — only depends on foundational phase
+- **US3 (Phase 5)**: Independent of US1 — can run in parallel with US2
+- **Polish (Phase 6)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on T001, T002 (WebSocket routing fixes)
+- **US2 (P1)**: Independent — only touches App.vue line 14
+- **US3 (P2)**: Independent — only touches App.vue onWsConnect
+
+### Within Each User Story
+
+- US1: Verification only (fix is in foundational phase)
+- US2: Single line change
+- US3: Single function addition
+
+### Parallel Opportunities
+
+- T001 and T002 are in the same file but different lines — can be done together in one edit
+- T004 and T005 are in the same file (App.vue) — do sequentially
+- T006, T007, T008 validation tasks can all run in parallel
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Both WebSocket fixes in one edit pass (same file):
+Task T001: "Fix narration event matching in useWebSocket.js line 41"
+Task T002: "Fix chunk event matching in useWebSocket.js line 43"
+```
+
+## Parallel Example: Validation
+
+```bash
+# All validation tasks in parallel:
+Task T006: "Run server narrator tests"
+Task T007: "Run UI lint"
+Task T008: "Run UI build"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + Foundational)
+
+1. Complete Phase 2: Fix WebSocket routing (T001, T002)
+2. Complete Phase 3: Verify text appears (T003)
+3. **STOP and VALIDATE**: Narration text now visible in UI
+
+### Full Fix
+
+1. T001+T002: Fix WebSocket routing
+2. T003: Verify text display
+3. T004: Fix toggle default
+4. T005: Add status sync on connect
+5. T006+T007+T008: Validate all checks pass
+6. T009: Update changelog
+7. T010: Ship via PR
+
+---
+
+## Notes
+
+- Total: 10 tasks (2 foundational, 1 US1, 1 US2, 1 US3, 5 polish)
+- All code changes are in 2 UI files only — server code is correct
+- No new dependencies or files needed
+- Existing 30 narrator tests must continue to pass

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -11,12 +11,21 @@ import NarrationPlayer from './components/NarrationPlayer.vue'
 
 const selectedAgent = ref(null)
 const paused = ref(false)
-const narrationEnabled = ref(true)
+const narrationEnabled = ref(false)
 
 
-function onWsConnect() {
+async function onWsConnect() {
   paused.value = false
   fetch('/api/simulation/reset', { method: 'POST' })
+  try {
+    const res = await fetch('/api/narration/status')
+    if (res.ok) {
+      const data = await res.json()
+      narrationEnabled.value = data.enabled
+    }
+  } catch {
+    // Server may not be ready yet — keep default
+  }
 }
 
 async function toggleNarration() {

--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -38,9 +38,9 @@ export function useWebSocket({ onConnect } = {}) {
       const event = JSON.parse(msg.data)
       if (event.source === 'world' && event.name === 'state') {
         worldState.value = event.payload
-      } else if (event.source === 'narrator' && event.type === 'narration') {
+      } else if (event.source === 'narrator' && event.name === 'narration') {
         narration.value = event.payload
-      } else if (event.source === 'narrator' && event.type === 'narration_chunk') {
+      } else if (event.source === 'narrator' && event.name === 'narration_chunk') {
         narrationChunk.value = event.payload
       } else {
         events.value.unshift(event)


### PR DESCRIPTION
## Summary
- Fix WebSocket event matching in `useWebSocket.js`: narrator events matched on `event.type` which was ambiguous (both full narration and chunks share `type: "narration"`). Changed to match on `event.name` which correctly discriminates `"narration"` vs `"narration_chunk"`
- Fix voice toggle state: initialized to `true` in UI but server defaults to `false`. Changed to `false` and added `/api/narration/status` fetch on WebSocket connect
- Full spec, plan, and task tracking in `specs/001-fix-narration-ui/`

## Root Causes
| Bug | File | Fix |
|-----|------|-----|
| Text not showing | useWebSocket.js:41,43 | `event.type` → `event.name` |
| Toggle out of sync | App.vue:14 | `ref(true)` → `ref(false)` |
| No state sync on load | App.vue:17 | Added `/api/narration/status` fetch |

## Test plan
- [x] 30/30 narrator tests pass
- [x] ESLint clean (zero warnings)
- [x] UI builds successfully
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)