### PR TITLE
feat: Dual-narrator dialogue system (Commander Rex + Dr. Nova)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added (Dual Narrators)
+
+- **Dual-narrator dialogue system**: Two narrators — Commander Rex (male, dry humor) and Dr. Nova (female, science enthusiast) — banter about mission events in real time
+  - `server/app/narrator.py` fully rewritten: new `NARRATOR_SYSTEM_PROMPT` defining both characters, `_parse_dialogue()` regex parser for `COMMANDER REX: ...` / `DR. NOVA: ...` output, `_generate_dialogue_audio()` using ElevenLabs Text-to-Dialogue API (`text_to_dialogue.convert()` with `DialogueInput` pairs), single-voice fallback via `_generate_audio_single()`
+  - WebSocket narration payload now includes `dialogue: [{speaker, text}, ...]` alongside flat `text` for backward compatibility
+  - `NarrationPlayer.vue` updated: speaker-labeled dialogue lines (REX in amber `#cc8844`, NOVA in teal `#44ccaa`), label changed from "NARRATOR" to "MISSION COMMS"
+  - Config: `narration_voice_id_male` (George), `narration_voice_id_female` (Rachel), `narration_model` (`mistral-medium-latest`)
+  - 14 new unit tests: `TestParseDialogue` (8 tests) and `TestStripAudioTags` (6 tests) covering dialogue parsing, speaker normalization, audio tag stripping
+
+### Changed (Dual Narrators)
+
+- Narration model switched from `magistral-medium-latest` to `mistral-medium-latest` (user-specified)
+- Narration max tokens increased from 200 to 350 to accommodate dialogue format
+- Config field `narration_voice_id` replaced with `narration_voice_id_male` and `narration_voice_id_female`
+
 ### Added
 
 - **GitHub → Discord webhook notifications**: New workflow `.github/workflows/discord-git-notify.yml` sends PR and main-branch push events to Discord channels

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -37,7 +37,9 @@ class Settings(BaseSettings):
     # ElevenLabs narration
     elevenlabs_api_key: str = ""
     narration_enabled: bool = False
-    narration_voice_id: str = "JBFqnCBsd6RMkjVDRZzb"  # George - warm narrator voice
+    narration_voice_id_male: str = "JBFqnCBsd6RMkjVDRZzb"  # George - Commander Rex
+    narration_voice_id_female: str = "21m00Tcm4TlvDq8ikWAM"  # Rachel - Dr. Nova
+    narration_model: str = "mistral-medium-latest"
     narration_min_interval_seconds: float = 5.0
 
 

--- a/server/app/narrator.py
+++ b/server/app/narrator.py
@@ -1,7 +1,8 @@
-"""Mars mission narrator — generates witty, dramatic TTS narration from simulation events.
+"""Mars mission narrator — dual-narrator dialogue via Mistral LLM + ElevenLabs TTS.
 
-Hooks into the broadcaster to intercept interesting events, generates narration text
-via Mistral LLM, converts to speech via ElevenLabs, and broadcasts audio to clients.
+Two narrators — Commander Rex (male) and Dr. Nova (female) — banter about
+mission events.  Mistral generates a labelled dialogue, which is converted to
+speech via the ElevenLabs Text-to-Dialogue API and broadcast over WebSocket.
 """
 
 from __future__ import annotations
@@ -12,7 +13,7 @@ import logging
 import re
 import time
 
-from elevenlabs import ElevenLabs
+from elevenlabs import DialogueInput, ElevenLabs
 from mistralai import Mistral
 
 from .config import settings
@@ -84,44 +85,59 @@ def _is_interesting(event: dict) -> int:
 # ── Narration text generation (Mistral) ─────────────────────────────────────
 
 NARRATOR_SYSTEM_PROMPT = """\
-You are the Mars Mission Narrator — a witty, warm, and occasionally dramatic \
-commentator for a live Mars rover exploration mission. Think David Attenborough \
-meets a space enthusiast podcaster.
+You are writing a DIALOGUE between two Mars Mission narrators who are \
+commentating on a live rover exploration mission together. They are a duo — \
+like a podcast team covering a space mission in real time.
 
-Your style:
-- Natural, conversational tone — like narrating a nature documentary, but on Mars
-- Sprinkle in humor and personality: puns, light jokes, genuine excitement
-- When things go wrong (low battery, failed actions), get dramatic and suspenseful
-- When discoveries happen, convey wonder and curiosity
-- Reference agents by name (Rover, Station) — they're characters in an adventure
-- Keep narrations SHORT: 1-3 sentences max. This is live commentary, not an essay
-- Vary your style: sometimes a quick quip, sometimes a dramatic pause, sometimes \
-genuine awe
+THE NARRATORS:
+- COMMANDER REX: A seasoned mission veteran. Pragmatic, dry humor, loves a \
+good pun. Speaks with authority but never takes himself too seriously. When \
+things go wrong he stays calm but dramatic — "Well, folks, this is what we \
+in the business call a 'situation'." Think Jeff Goldblum narrating a nature \
+documentary on Mars.
+- DR. NOVA: A brilliant planetary scientist. Curious, witty, genuinely \
+excited about every rock and reading. She cracks jokes, geeks out over \
+geology, and adds the scientific color. When discoveries happen she can \
+barely contain her excitement. Think a fun science podcaster who also \
+happens to have a PhD.
+
+DIALOGUE FORMAT (STRICT):
+Each line MUST start with the speaker name followed by a colon:
+COMMANDER REX: [their line]
+DR. NOVA: [their line]
+
+RULES:
+- Write 2-4 lines of dialogue total (alternating speakers)
+- They REACT to each other — build on what the other says, crack jokes, \
+disagree playfully, finish each other's thoughts
+- Keep each line SHORT (1-2 sentences max)
+- Be conversational and natural — like two friends watching a Mars mission
+- When things go wrong (low battery, failed actions): Rex stays cool, Nova \
+gets worried, they play off each other's energy
+- When discoveries happen: Nova geeks out, Rex makes a quip
 - NEVER use hashtags, emojis, or markdown formatting
+- Vary who speaks first — sometimes Rex starts, sometimes Nova
 
-Audio emotion tags:
-You MUST use ElevenLabs audio tags to add vocal emotion and expression. Wrap \
-words or phrases in these tags to control how they sound:
-- [laughs] — use after a joke or funny observation
-- [sighs] — use for exasperation, relief, or dramatic weight
-- [whispers] — use for suspense, secrets, or quiet tension
-- [gasps] — use for sudden discoveries or shocking news
-- [clears throat] — use for transitions or when composing yourself
+Audio emotion tags (use sparingly, on key moments):
+- [laughs] — after a joke
+- [sighs] — exasperation or relief
+- [whispers] — suspense
+- [gasps] — sudden discoveries
+- [clears throat] — transitions
 
-Place tags INLINE in your narration text. Examples:
-- "[whispers] Something's moving out there... [gasps] Wait — is that a core sample?!"
-- "Battery at twelve percent. [sighs] Our little rover's running on fumes."
-- "[laughs] Basalt again! The Red Planet really knows how to tease."
-- "[clears throat] Mission control has spoken — new objective incoming."
-- "[gasps] We did it! [laughs] Ladies and gentlemen, core sample secured!"
-
-Use these tags naturally — not on every sentence, but to punch up key emotional \
-moments. The voice synthesizer will render them as actual vocal expressions.
+Example dialogue:
+COMMANDER REX: [clears throat] Well, our little rover just hit twelve \
+percent battery. That's what I'd call... optimistically low.
+DR. NOVA: [sighs] Optimistically low? Rex, that's critically low! It \
+needs to get back to station before it becomes the galaxy's most expensive \
+paperweight.
+COMMANDER REX: [laughs] Expensive paperweight. I'm stealing that one.
+DR. NOVA: You're welcome. Now can we please focus on getting it home?
 """
 
 
 def _build_narration_prompt(events: list[dict], world_summary: str) -> str:
-    """Build a prompt for Mistral to generate narration text from batched events."""
+    """Build a prompt for Mistral to generate dialogue from batched events."""
     lines = ["Here are the latest events from the Mars mission:\n"]
 
     for event in events:
@@ -174,13 +190,44 @@ def _build_narration_prompt(events: list[dict], world_summary: str) -> str:
 
     lines.append(f"\nCurrent world context:\n{world_summary}")
     lines.append(
-        "\nGenerate a short, natural narration (1-3 sentences) for these events. "
-        "Be conversational and engaging. If multiple events happened, weave them "
-        "into a cohesive narrative. Use audio emotion tags like [whispers], [gasps], "
-        "[laughs], [sighs] to add vocal expression at key moments."
+        "\nWrite a short dialogue (2-4 lines) between COMMANDER REX and "
+        "DR. NOVA reacting to these events. Be conversational, funny, and "
+        "engaging. Use audio emotion tags on key moments."
     )
 
     return "\n".join(lines)
+
+
+# ── Dialogue parsing ────────────────────────────────────────────────────────
+
+# Match lines like "COMMANDER REX: text" or "DR. NOVA: text"
+_SPEAKER_RE = re.compile(
+    r"^(COMMANDER REX|DR\.?\s*NOVA)\s*:\s*(.+)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Speaker name normalisation map
+_SPEAKER_NAMES = {
+    "commander rex": "COMMANDER REX",
+    "dr. nova": "DR. NOVA",
+    "dr nova": "DR. NOVA",
+}
+
+
+def _parse_dialogue(text: str) -> list[tuple[str, str]]:
+    """Parse LLM output into [(speaker, line), ...] tuples.
+
+    Returns an empty list if no valid dialogue lines are found.
+    """
+    matches = _SPEAKER_RE.findall(text)
+    if not matches:
+        return []
+
+    result: list[tuple[str, str]] = []
+    for raw_speaker, line in matches:
+        speaker = _SPEAKER_NAMES.get(raw_speaker.lower().strip(), raw_speaker.upper())
+        result.append((speaker, line.strip()))
+    return result
 
 
 # ── Text helpers ────────────────────────────────────────────────────────────
@@ -201,17 +248,30 @@ def _strip_audio_tags(text: str) -> str:
 
 # ── ElevenLabs TTS ──────────────────────────────────────────────────────────
 
+# Map speaker names to config voice IDs
+_VOICE_MAP = {
+    "COMMANDER REX": lambda: settings.narration_voice_id_male,
+    "DR. NOVA": lambda: settings.narration_voice_id_female,
+}
 
-def _generate_audio(text: str, client: ElevenLabs) -> bytes | None:
-    """Convert narration text to MP3 audio bytes via ElevenLabs."""
+
+def _generate_dialogue_audio(dialogue: list[tuple[str, str]], client: ElevenLabs) -> bytes | None:
+    """Convert dialogue to MP3 via ElevenLabs Text-to-Dialogue API."""
+    if not dialogue:
+        return None
+
+    inputs = []
+    for speaker, line in dialogue:
+        voice_getter = _VOICE_MAP.get(speaker)
+        voice_id = voice_getter() if voice_getter else settings.narration_voice_id_male
+        inputs.append(DialogueInput(text=line, voice_id=voice_id))
+
     try:
-        audio_iter = client.text_to_speech.convert(
-            voice_id=settings.narration_voice_id,
-            text=text,
+        audio_iter = client.text_to_dialogue.convert(
+            inputs=inputs,
             model_id="eleven_v3",
             output_format="mp3_22050_32",
         )
-        # convert returns an iterator of bytes chunks
         chunks = []
         for chunk in audio_iter:
             if isinstance(chunk, bytes):
@@ -220,7 +280,28 @@ def _generate_audio(text: str, client: ElevenLabs) -> bytes | None:
             return b"".join(chunks)
         return None
     except Exception:
-        logger.exception("ElevenLabs TTS failed")
+        logger.exception("ElevenLabs Text-to-Dialogue failed")
+        return None
+
+
+def _generate_audio_single(text: str, client: ElevenLabs) -> bytes | None:
+    """Fallback: single-voice TTS when dialogue parsing fails."""
+    try:
+        audio_iter = client.text_to_speech.convert(
+            voice_id=settings.narration_voice_id_male,
+            text=text,
+            model_id="eleven_v3",
+            output_format="mp3_22050_32",
+        )
+        chunks = []
+        for chunk in audio_iter:
+            if isinstance(chunk, bytes):
+                chunks.append(chunk)
+        if chunks:
+            return b"".join(chunks)
+        return None
+    except Exception:
+        logger.exception("ElevenLabs single-voice TTS failed")
         return None
 
 
@@ -228,7 +309,7 @@ def _generate_audio(text: str, client: ElevenLabs) -> bytes | None:
 
 
 class Narrator:
-    """Async narrator that batches events, generates narration, and broadcasts audio."""
+    """Async narrator that batches events, generates dialogue, and broadcasts audio."""
 
     def __init__(self, broadcast_fn):
         self._broadcast = broadcast_fn
@@ -293,7 +374,7 @@ class Narrator:
             return
         self._running = True
         self._task = asyncio.create_task(self._processing_loop())
-        logger.info("Narrator started")
+        logger.info("Narrator started (dual-narrator mode)")
 
     def stop(self):
         """Stop the narrator."""
@@ -336,7 +417,7 @@ class Narrator:
         await self._process_batch()
 
     async def _process_batch(self):
-        """Take all buffered events, generate narration, broadcast audio."""
+        """Take all buffered events, generate dialogue, broadcast audio."""
         async with self._lock:
             if not self._event_buffer:
                 return
@@ -353,7 +434,8 @@ class Narrator:
             mission = WORLD.get("mission", {})
             summary_parts = [
                 f"Mission status: {mission.get('status', 'unknown')}",
-                f"Target: {mission.get('target_count', '?')} {mission.get('target_type', '?')} stones "
+                f"Target: {mission.get('target_count', '?')} "
+                f"{mission.get('target_type', '?')} stones "
                 f"({mission.get('collected_count', 0)} collected)",
             ]
             for aid, agent in agents.items():
@@ -366,7 +448,7 @@ class Narrator:
                     )
             world_summary = "\n".join(summary_parts)
 
-            # Generate narration text via Mistral (streaming to UI)
+            # Generate narration dialogue via Mistral (streaming to UI)
             prompt = _build_narration_prompt(events, world_summary)
 
             # Try streaming first; fall back to non-streaming on failure
@@ -380,14 +462,42 @@ class Narrator:
 
             logger.info("Narration: %s", narration_text)
 
+            # Parse dialogue lines
+            dialogue = _parse_dialogue(narration_text)
+
+            # Build structured payload
+            if dialogue:
+                dialogue_payload = [
+                    {
+                        "speaker": speaker,
+                        "text": _strip_audio_tags(line),
+                    }
+                    for speaker, line in dialogue
+                ]
+                flat_text = " ".join(f"{d['speaker']}: {d['text']}" for d in dialogue_payload)
+            else:
+                # Fallback: no parseable dialogue, treat as single narrator
+                dialogue_payload = [
+                    {
+                        "speaker": "COMMANDER REX",
+                        "text": _strip_audio_tags(narration_text),
+                    }
+                ]
+                flat_text = _strip_audio_tags(narration_text)
+
             # Voice synthesis — only when narration is enabled
             if self._enabled:
                 elevenlabs = self._get_elevenlabs()
                 audio_bytes = None
                 if elevenlabs:
-                    audio_bytes = await asyncio.to_thread(
-                        _generate_audio, narration_text, elevenlabs
-                    )
+                    if dialogue:
+                        audio_bytes = await asyncio.to_thread(
+                            _generate_dialogue_audio, dialogue, elevenlabs
+                        )
+                    else:
+                        audio_bytes = await asyncio.to_thread(
+                            _generate_audio_single, narration_text, elevenlabs
+                        )
 
                 if audio_bytes:
                     audio_b64 = base64.b64encode(audio_bytes).decode("ascii")
@@ -397,7 +507,8 @@ class Narrator:
                             "type": "narration",
                             "name": "narration",
                             "payload": {
-                                "text": _strip_audio_tags(narration_text),
+                                "text": flat_text,
+                                "dialogue": dialogue_payload,
                                 "audio": audio_b64,
                                 "format": "mp3",
                             },
@@ -412,7 +523,8 @@ class Narrator:
                     "type": "narration",
                     "name": "narration",
                     "payload": {
-                        "text": _strip_audio_tags(narration_text),
+                        "text": flat_text,
+                        "dialogue": dialogue_payload,
                         "audio": None,
                     },
                 }
@@ -422,19 +534,19 @@ class Narrator:
             logger.exception("Narrator batch processing failed")
 
     def _generate_text(self, prompt: str) -> str | None:
-        """Call Mistral to generate narration text (runs in thread).
+        """Call Mistral to generate narration dialogue (runs in thread).
 
         Kept as a non-streaming fallback.
         """
         try:
             client = self._get_mistral()
             response = client.chat.complete(
-                model="magistral-medium-latest",
+                model=settings.narration_model,
                 messages=[
                     {"role": "system", "content": NARRATOR_SYSTEM_PROMPT},
                     {"role": "user", "content": prompt},
                 ],
-                max_tokens=200,
+                max_tokens=350,
                 temperature=0.9,
             )
             text = response.choices[0].message.content
@@ -444,7 +556,7 @@ class Narrator:
             return None
 
     async def _generate_text_streaming(self, prompt: str) -> str | None:
-        """Stream narration text from Mistral, broadcasting chunks as they arrive.
+        """Stream narration from Mistral, broadcasting chunks as they arrive.
 
         Each chunk is sent to the UI as a ``narration_chunk`` event so the text
         appears progressively.  Returns the full accumulated text when done.
@@ -453,12 +565,12 @@ class Narrator:
             client = self._get_mistral()
 
             stream = client.chat.stream(
-                model="magistral-medium-latest",
+                model=settings.narration_model,
                 messages=[
                     {"role": "system", "content": NARRATOR_SYSTEM_PROMPT},
                     {"role": "user", "content": prompt},
                 ],
-                max_tokens=200,
+                max_tokens=350,
                 temperature=0.9,
             )
 

--- a/server/tests/test_narrator.py
+++ b/server/tests/test_narrator.py
@@ -1,4 +1,4 @@
-"""Tests for app.narrator — event filtering, prompt building, narrator lifecycle."""
+"""Tests for app.narrator — event filtering, prompt building, dialogue parsing, narrator lifecycle."""
 
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,6 +8,8 @@ from app.narrator import (
     Narrator,
     _build_narration_prompt,
     _is_interesting,
+    _parse_dialogue,
+    _strip_audio_tags,
 )
 
 
@@ -280,3 +282,87 @@ class TestNarrator(unittest.IsolatedAsyncioTestCase):
         self.narrator.start()
         task2 = self.narrator._task
         self.assertIs(task1, task2)
+
+
+class TestParseDialogue(unittest.TestCase):
+    """Test dialogue parsing from LLM output."""
+
+    def test_basic_dialogue(self):
+        text = (
+            "COMMANDER REX: Well, our rover just hit a new zone.\n"
+            "DR. NOVA: Exciting! Let's see what we find."
+        )
+        result = _parse_dialogue(text)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], ("COMMANDER REX", "Well, our rover just hit a new zone."))
+        self.assertEqual(result[1], ("DR. NOVA", "Exciting! Let's see what we find."))
+
+    def test_empty_text_returns_empty(self):
+        self.assertEqual(_parse_dialogue(""), [])
+
+    def test_no_speakers_returns_empty(self):
+        self.assertEqual(_parse_dialogue("Just some random text without labels."), [])
+
+    def test_single_speaker(self):
+        text = "COMMANDER REX: Solo line here."
+        result = _parse_dialogue(text)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], "COMMANDER REX")
+
+    def test_case_insensitive_speakers(self):
+        text = "commander rex: lowercase works\ndr. nova: also lowercase"
+        result = _parse_dialogue(text)
+        self.assertEqual(len(result), 2)
+        # Should normalize to uppercase
+        self.assertEqual(result[0][0], "COMMANDER REX")
+        self.assertEqual(result[1][0], "DR. NOVA")
+
+    def test_dr_nova_without_period(self):
+        text = "DR NOVA: No period variant."
+        result = _parse_dialogue(text)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], "DR. NOVA")
+
+    def test_audio_tags_preserved_in_parse(self):
+        """Parsing should preserve audio tags — stripping happens separately."""
+        text = "COMMANDER REX: [laughs] That's a good one."
+        result = _parse_dialogue(text)
+        self.assertEqual(len(result), 1)
+        self.assertIn("[laughs]", result[0][1])
+
+    def test_multiline_dialogue(self):
+        text = (
+            "COMMANDER REX: First line.\n"
+            "DR. NOVA: Second line.\n"
+            "COMMANDER REX: Third line.\n"
+            "DR. NOVA: Fourth line."
+        )
+        result = _parse_dialogue(text)
+        self.assertEqual(len(result), 4)
+
+
+class TestStripAudioTags(unittest.TestCase):
+    """Test audio tag stripping for text display."""
+
+    def test_strips_laughs(self):
+        self.assertEqual(_strip_audio_tags("[laughs] That's funny"), "That's funny")
+
+    def test_strips_multiple_tags(self):
+        text = "[sighs] Well [clears throat] let me think [gasps] wow!"
+        result = _strip_audio_tags(text)
+        self.assertEqual(result, "Well let me think wow!")
+
+    def test_strips_whispers(self):
+        self.assertEqual(_strip_audio_tags("[whispers] Can you hear me?"), "Can you hear me?")
+
+    def test_no_tags_unchanged(self):
+        text = "Just normal text here."
+        self.assertEqual(_strip_audio_tags(text), text)
+
+    def test_case_insensitive(self):
+        self.assertEqual(_strip_audio_tags("[LAUGHS] funny"), "funny")
+
+    def test_collapses_double_spaces(self):
+        text = "Before [sighs] after"
+        result = _strip_audio_tags(text)
+        self.assertNotIn("  ", result)

--- a/tasks/dual-narrators.md
+++ b/tasks/dual-narrators.md
@@ -1,0 +1,38 @@
+# Dual Narrators Feature Plan
+
+## Overview
+Upgrade the single-narrator system to a **dual-narrator dialogue** between a male and female commentator who interact, crack jokes, and create an engaging back-and-forth narrative about Mars mission events.
+
+## Architecture
+
+### Current State
+- Single narrator (George, voice_id `JBFqnCBsd6RMkjVDRZzb`)
+- Mistral LLM (`magistral-medium-latest`) generates 1-3 sentence monologue
+- ElevenLabs `text_to_speech.convert()` generates single-voice audio
+- WebSocket payload: `{text, audio, format}`
+
+### Target State
+- Two narrators: **Commander Rex** (male, George) + **Dr. Nova** (female, Rachel)
+- Mistral LLM (`mistral-medium-latest`) generates a dialogue with speaker labels
+- ElevenLabs **Text-to-Dialogue API** (`text_to_dialogue.convert()`) generates multi-voice audio in one call
+- WebSocket payload: `{dialogue: [{speaker, text}], audio, format}`
+
+### Key Design Decisions
+1. **Text-to-Dialogue API** — ElevenLabs has a native `/v1/text-to-dialogue/convert` endpoint that takes `DialogueInput(text=..., voice_id=...)` pairs and returns a single audio stream with both voices. No need to splice audio manually.
+2. **LLM generates structured dialogue** — Prompt Mistral to output `COMMANDER REX: ...` / `DR. NOVA: ...` lines, then parse into dialogue inputs.
+3. **Model upgrade** — Switch from `magistral-medium-latest` to `mistral-medium-latest` per user request.
+4. **Backward-compatible payload** — Include both `text` (flat string for legacy) and `dialogue` (structured array) in the narration payload.
+
+## Tasks
+
+- [x] Create this plan
+- [x] **Config** — Added `narration_voice_id_male`, `narration_voice_id_female`, `narration_model` to `config.py`
+- [x] **Narrator system prompt** — Rewritten with Commander Rex and Dr. Nova characters, dialogue format rules, audio emotion tags
+- [x] **Dialogue generation** — `_parse_dialogue()` with regex `_SPEAKER_RE`, speaker normalization via `_SPEAKER_NAMES`
+- [x] **TTS** — `_generate_dialogue_audio()` using `text_to_dialogue.convert()` with `DialogueInput` pairs; `_generate_audio_single()` as fallback
+- [x] **Streaming** — Streaming chunks broadcast as flat text (typewriter); full dialogue structure sent in final `narration` event
+- [x] **WebSocket payload** — `{text, dialogue: [{speaker, text}], audio, format}` with backward-compatible flat `text`
+- [x] **NarrationPlayer.vue** — Speaker labels (REX amber, NOVA teal), dialogue block layout, "MISSION COMMS" label, responsive mobile styles
+- [x] **Tests** — 14 new tests: `TestParseDialogue` (8) + `TestStripAudioTags` (6); all 44 narrator tests pass
+- [x] **Changelog** — Documented dual-narrator feature in `Changelog.md`
+- [ ] **PR** — Commit, push, create PR to main

--- a/ui/src/components/NarrationPlayer.vue
+++ b/ui/src/components/NarrationPlayer.vue
@@ -17,6 +17,7 @@ const emit = defineEmits(['toggle-narration'])
 
 const isPlaying = ref(false)
 const currentText = ref('')
+const dialogueLines = ref([])
 const audioQueue = ref([])
 const isProcessing = ref(false)
 
@@ -59,6 +60,18 @@ watch(() => props.narration, (event) => {
   if (!event) return
   stopTypewriter()
   currentText.value = event.text || ''
+
+  // Parse structured dialogue if available
+  if (event.dialogue && Array.isArray(event.dialogue) && event.dialogue.length > 0) {
+    dialogueLines.value = event.dialogue.map(d => ({
+      speaker: d.speaker,
+      text: d.text,
+      label: d.speaker === 'COMMANDER REX' ? 'REX' : 'NOVA',
+      color: d.speaker === 'COMMANDER REX' ? '#cc8844' : '#44ccaa',
+    }))
+  } else {
+    dialogueLines.value = []
+  }
 
   if (event.audio && props.narrationEnabled) {
     audioQueue.value.push(event.audio)
@@ -145,11 +158,28 @@ function skipAudio() {
         class="narrator-icon"
         :class="{ active: isPlaying }"
       >🎙</span>
-      <span class="narrator-label">NARRATOR</span>
+      <span class="narrator-label">MISSION COMMS</span>
     </div>
 
     <div
-      v-if="currentText"
+      v-if="dialogueLines.length > 0"
+      class="narration-text dialogue-block"
+    >
+      <div
+        v-for="(line, idx) in dialogueLines"
+        :key="idx"
+        class="dialogue-line"
+      >
+        <span
+          class="speaker-label"
+          :style="{ color: line.color }"
+        >{{ line.label }}:</span>
+        <span class="speaker-text">{{ line.text }}</span>
+      </div>
+    </div>
+
+    <div
+      v-else-if="currentText"
       class="narration-text"
     >
       {{ currentText }}
@@ -237,6 +267,9 @@ function skipAudio() {
   line-height: 1.4;
   min-width: 0;
   overflow: hidden;
+}
+
+.narration-text:not(.dialogue-block) {
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -246,6 +279,34 @@ function skipAudio() {
 .narration-text.idle {
   color: #333;
   font-style: normal;
+}
+
+.dialogue-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-style: normal;
+}
+
+.dialogue-line {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  line-height: 1.4;
+}
+
+.speaker-label {
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.speaker-text {
+  color: #c8c8d0;
+  font-style: italic;
 }
 
 .narration-controls {
@@ -300,7 +361,14 @@ function skipAudio() {
   .narration-text {
     order: 3;
     width: 100%;
+    flex-basis: 100%;
+  }
+  .narration-text:not(.dialogue-block) {
     -webkit-line-clamp: 3;
+  }
+  .dialogue-line {
+    flex-direction: column;
+    gap: 0.15rem;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- Replace single narrator with **dual-character dialogue system** — Commander Rex (male, dry humor) and Dr. Nova (female, science enthusiast) banter about Mars mission events in real time
- Rewrite `narrator.py` with new system prompt, `_parse_dialogue()` regex parser, and ElevenLabs **Text-to-Dialogue API** (`text_to_dialogue.convert()`) for multi-voice audio
- Update `NarrationPlayer.vue` with speaker-labeled dialogue lines (REX in amber, NOVA in teal) and "MISSION COMMS" branding

## Changes

### Server
- **`server/app/narrator.py`** — Full rewrite: dual-narrator system prompt with character definitions, `_parse_dialogue()` with regex `_SPEAKER_RE`, `_generate_dialogue_audio()` using `DialogueInput` pairs, `_generate_audio_single()` fallback, voice mapping via `_VOICE_MAP`, structured `dialogue` payload in WebSocket broadcasts
- **`server/app/config.py`** — `narration_voice_id` replaced with `narration_voice_id_male` (George) + `narration_voice_id_female` (Rachel), added `narration_model` (`mistral-medium-latest`)
- **`server/tests/test_narrator.py`** — 14 new tests: `TestParseDialogue` (8) + `TestStripAudioTags` (6) — all 44 narrator tests pass

### Frontend
- **`ui/src/components/NarrationPlayer.vue`** — Dialogue block with speaker labels (colored, bold), three-way conditional (dialogue / flat text / idle), responsive mobile layout, label updated to "MISSION COMMS"

### Docs
- **`Changelog.md`** — Documented dual-narrator feature
- **`tasks/dual-narrators.md`** — Feature plan with architecture decisions

## Verification
- 44/44 narrator tests pass
- Ruff lint + format clean
- UI builds successfully (vite)