### PR TITLE
chore: add semantic PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,56 @@
+## Summary
+
+<!-- One-sentence description of what this PR does and why -->
+
+## Change Type
+
+<!-- Check all that apply -->
+- [ ] `feat` — New feature
+- [ ] `fix` — Bug fix
+- [ ] `refactor` — Code restructuring (no behavior change)
+- [ ] `perf` — Performance improvement
+- [ ] `docs` — Documentation only
+- [ ] `test` — Adding or updating tests
+- [ ] `chore` — Build, CI, config, or tooling
+- [ ] `style` — Formatting, linting (no logic change)
+
+## Semantic Diff
+
+### Added
+<!-- New files, features, endpoints, components, tests -->
+-
+
+### Changed
+<!-- Modified files and what changed in each -->
+-
+
+### Removed
+<!-- Deleted files, deprecated code, removed features -->
+-
+
+## File Impact
+
+| Metric | Count |
+|--------|-------|
+| Files added | 0 |
+| Files modified | 0 |
+| Files deleted | 0 |
+| Lines added | +0 |
+| Lines removed | -0 |
+
+### Core Files Modified
+<!-- List only files in app/, src/, or config that carry business logic -->
+-
+
+### Tests
+<!-- List test files added or modified -->
+-
+
+## How to Test
+
+<!-- Steps to verify this PR works -->
+1.
+
+## Changelog
+
+<!-- Copy the entry you added to Changelog.md -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,22 @@ Vite proxies `/api/*` to `http://localhost:4009` and `/ws` to `ws://localhost:40
 - If you need to look up the latest documentation for an external tool, e.g., Vercel, Supabase, etc., please include 'use context7' in your prompt
 - For each new task, please first create a plan in a markdown file in this repo such that we can always trace back at which stage of the implementation for this particular task we currenlty are by comparing the code and then what's in the plan. Also, divide each plan into smaller tasks and sub-tasks that **shall** be marked as completed in this markdown file if done so. -->
 
+## Semantic PR Logs (MANDATORY)
+
+Every PR description **must** follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. When creating a PR with `gh pr create`, auto-populate the semantic diff by running `git diff main...HEAD --stat` and `git diff main...HEAD --numstat` to compute file counts and line changes.
+
+### How to Generate PR Body
+
+1. **Compute stats** from `git diff main...HEAD`:
+   - `--stat` for file list
+   - `--numstat` for added/removed lines per file
+   - `--diff-filter=A` for added files, `--diff-filter=M` for modified, `--diff-filter=D` for deleted
+2. **Classify each file** into Added / Changed / Removed sections
+3. **Core files** = any file under `server/app/`, `ui/src/`, or root config (`CLAUDE.md`, `SPEC.md`, `pyproject.toml`, `package.json`)
+4. **Test files** = any file under `*/tests/` or matching `*.test.*` / `*.spec.*`
+5. **Fill the File Impact table** with actual counts
+6. **Copy Changelog.md entry** into the Changelog section
+
 ## Workflow Orchestration
 
 ### 1. Plan Mode Default

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added (Semantic PR Logs)
+
+- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`): standardized semantic PR format with change type checkboxes, semantic diff (Added/Changed/Removed), file impact table (files added/modified/deleted, lines +/-), core files listing, and test coverage section
+- **CLAUDE.md instructions** for auto-generating PR bodies: computes git diff stats, classifies files by filter (A/M/D), identifies core vs test files, and fills the template programmatically
+
 ### Added (Dual Narrators)
 
 - **Dual-narrator dialogue system**: Two narrators — Commander Rex (male, dry humor) and Dr. Nova (female, science enthusiast) — banter about mission events in real time


### PR DESCRIPTION
## Summary

Adds a standardized PR template and CLAUDE.md instructions to ensure every PR includes a semantic diff, file impact metrics, and core file tracking.

## Change Type

- [x] `chore` — Build, CI, config, or tooling

## Semantic Diff

### Added
- `.github/PULL_REQUEST_TEMPLATE.md` — PR template with semantic sections: change type checkboxes, Added/Changed/Removed diff, file impact table, core files list, test files list, changelog entry
- `CLAUDE.md` — "Semantic PR Logs" section with instructions for auto-populating PR body from `git diff` stats

### Changed
- `Changelog.md` — Added entry documenting the new PR template and CLAUDE.md instructions

### Removed
- (none)

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 1 |
| Files modified | 2 |
| Files deleted | 0 |
| Lines added | +77 |
| Lines removed | -0 |

### Core Files Modified
- `CLAUDE.md` — Added "Semantic PR Logs" section with file classification rules and auto-generation steps

### Tests
- (no test changes — documentation/config only)

## How to Test

1. Open a new PR on this repo — the template should auto-populate
2. Verify the template renders with all sections: Summary, Change Type, Semantic Diff, File Impact, Core Files, Tests, How to Test, Changelog

## Changelog

- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`): standardized semantic PR format with change type checkboxes, semantic diff, file impact table, core files listing, and test coverage section
- **CLAUDE.md instructions** for auto-generating PR bodies from git diff stats

---
Generated with [Claude Code](https://claude.com/claude-code)