### PR TITLE
chore: standardize co-authoring to agent-one team

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -54,3 +54,7 @@
 ## Changelog
 
 <!-- Copy the entry you added to Changelog.md -->
+
+---
+
+Co-Authored-By: agent-one team <agent-one@yanok.ai>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,18 @@ Vite proxies `/api/*` to `http://localhost:4009` and `/ws` to `ws://localhost:40
 - If you need to look up the latest documentation for an external tool, e.g., Vercel, Supabase, etc., please include 'use context7' in your prompt
 - For each new task, please first create a plan in a markdown file in this repo such that we can always trace back at which stage of the implementation for this particular task we currenlty are by comparing the code and then what's in the plan. Also, divide each plan into smaller tasks and sub-tasks that **shall** be marked as completed in this markdown file if done so. -->
 
+## Co-Authoring (MANDATORY)
+
+All commits and PRs in this repo **must** use the agent-one team attribution:
+
+```
+Co-Authored-By: agent-one team <agent-one@yanok.ai>
+```
+
+- **Commits**: Append the `Co-Authored-By` trailer as the last line of every commit message
+- **PRs**: The PR template already includes the trailer at the bottom — do not remove it
+- **Do NOT** use personal or model-specific co-author lines (e.g., `Claude Opus`, `noreply@anthropic.com`)
+
 ## Semantic PR Logs (MANDATORY)
 
 Every PR description **must** follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. When creating a PR with `gh pr create`, auto-populate the semantic diff by running `git diff main...HEAD --stat` and `git diff main...HEAD --numstat` to compute file counts and line changes.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added (Co-Authoring Guidelines)
+
+- **Co-authoring standard**: All commits and PRs now use `Co-Authored-By: agent-one team <agent-one@yanok.ai>` — added to CLAUDE.md as mandatory rule and to PR template footer
+- Replaces per-model attribution (e.g., `Claude Opus`) with unified team identity
+
 ### Added (Semantic PR Logs)
 
 - **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`): standardized semantic PR format with change type checkboxes, semantic diff (Added/Changed/Removed), file impact table (files added/modified/deleted, lines +/-), core files listing, and test coverage section


### PR DESCRIPTION
## Summary

Standardizes all commit and PR attribution to `Co-Authored-By: agent-one team <agent-one@yanok.ai>`, replacing per-model lines.

## Change Type

- [x] `chore` — Build, CI, config, or tooling

## Semantic Diff

### Added
- `CLAUDE.md` — New "Co-Authoring (MANDATORY)" section with rules: use `agent-one team <agent-one@yanok.ai>` on all commits/PRs, never use personal or model-specific co-author lines

### Changed
- `.github/PULL_REQUEST_TEMPLATE.md` — Added `Co-Authored-By: agent-one team <agent-one@yanok.ai>` footer so every PR includes it by default
- `Changelog.md` — Added entry documenting the co-authoring standard

### Removed
- (none)

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 3 |
| Files deleted | 0 |
| Lines added | +21 |
| Lines removed | -0 |

### Core Files Modified
- `CLAUDE.md` — Added mandatory co-authoring section

### Tests
- (no test changes — documentation/config only)

## How to Test

1. Verify `CLAUDE.md` contains the "Co-Authoring (MANDATORY)" section
2. Verify `.github/PULL_REQUEST_TEMPLATE.md` ends with the `Co-Authored-By` line
3. Open a new PR — template should auto-include the team attribution footer

## Changelog

- **Co-authoring standard**: All commits and PRs now use `Co-Authored-By: agent-one team <agent-one@yanok.ai>`
- Replaces per-model attribution with unified team identity

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>