### PR TITLE
feat(battery): rebalance fuel system — 1 unit/tile, capacity 350/250, 67% return threshold

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed (Battery & Fuel Rebalance)
+
+- **Fuel capacity system**: Rovers carry 350 fuel units, Drone carries 250 fuel units. Battery remains a 0.0–1.0 float (fraction of capacity)
+- **1 fuel unit per tile**: All agents now cost 1 fuel unit per tile moved (~0.29% battery for rovers, ~0.4% for drone)
+- **Action costs (in fuel units)**: move=1/tile, dig=6, analyze=3, pickup=2, scan=2. All expressed as fuel units divided by capacity
+- **Return-to-base at 67%**: Agents must return to station when battery drops to 67% or below (dual check: threshold + distance safety net with 6% margin)
+- **Constants centralized**: All battery costs use named constants from `world.py` — no more hardcoded magic numbers in `agent.py`
+- **Updated LLM prompts**: Rover and drone system prompts now describe costs in fuel units with percentage equivalents
+- **Updated tool descriptions**: All tool descriptions in `agent.py`, `world.py`, and `station.py` use fuel-unit-based costs
+- **Documentation updated**: `WORLD.md` reflects new fuel capacity system and return-to-base rules
+
 ### Changed (Runtime Upgrade)
 
 - **Python 3.12 → 3.14**: Updated `server/pyproject.toml` (`requires-python`), CI workflow (`python-version`), Dockerfile (`python:3.14-slim`), regenerated `uv.lock`

--- a/WORLD.md
+++ b/WORLD.md
@@ -11,7 +11,7 @@ Each agent in `WORLD["agents"][id]`:
 | Field | Type | Description |
 |-------|------|-------------|
 | `position` | `[x, y]` | Current tile |
-| `battery` | `float` | 0.0–1.0, drains 0.02 per move |
+| `battery` | `float` | 0.0–1.0 (fraction of fuel capacity). Rovers: 350 fuel units, Drone: 250 fuel units. Move costs 1 fuel unit per tile (~0.29% for rovers, ~0.4% for drone). Agents return to base when battery ≤ 67%. |
 | `mission` | `dict` | `{objective, plan[]}` — will be dynamic from base station |
 | `visited` | `[[x, y], ...]` | List of positions the agent has been to. Seeded with starting position. Updated on each successful move (no duplicates). |
 

--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -14,6 +14,16 @@ from .world import (
     DIRECTIONS,
     MAX_MOVE_DISTANCE,
     MAX_MOVE_DISTANCE_DRONE,
+    FUEL_CAPACITY_ROVER,
+    FUEL_CAPACITY_DRONE,
+    BATTERY_COST_MOVE,
+    BATTERY_COST_MOVE_DRONE,
+    BATTERY_COST_DIG,
+    BATTERY_COST_PICKUP,
+    BATTERY_COST_ANALYZE,
+    BATTERY_COST_ANALYZE_GROUND,
+    BATTERY_COST_SCAN,
+    RETURN_TO_BASE_THRESHOLD,
     check_ground,
     _direction_hint,
     _find_stone_at,
@@ -25,7 +35,7 @@ MOVE_TOOL = {
     "type": "function",
     "function": {
         "name": "move",
-        "description": f"Move the rover 1-{MAX_MOVE_DISTANCE} tiles in a cardinal direction. Costs 2% battery per tile.",
+        "description": f"Move the rover 1-{MAX_MOVE_DISTANCE} tiles in a cardinal direction. Costs 1 fuel unit per tile (~{BATTERY_COST_MOVE:.2%} battery).",
         "parameters": {
             "type": "object",
             "properties": {
@@ -50,7 +60,7 @@ DIG_TOOL = {
     "type": "function",
     "function": {
         "name": "dig",
-        "description": "Dig at current tile to extract a buried stone. Costs 6% battery. The stone must be present and not yet extracted.",
+        "description": f"Dig at current tile to extract a buried stone. Costs 6 fuel units (~{BATTERY_COST_DIG:.2%} battery). The stone must be present and not yet extracted.",
         "parameters": {"type": "object", "properties": {}},
     },
 }
@@ -68,7 +78,7 @@ ANALYZE_TOOL = {
     "type": "function",
     "function": {
         "name": "analyze",
-        "description": "Analyze an unknown stone at current tile to reveal its true type (core or basalt). Costs 3% battery. Must be done before dig/pickup.",
+        "description": f"Analyze an unknown stone at current tile to reveal its true type (core or basalt). Costs 3 fuel units (~{BATTERY_COST_ANALYZE:.2%} battery). Must be done before dig/pickup.",
         "parameters": {"type": "object", "properties": {}},
     },
 }
@@ -77,7 +87,7 @@ ANALYZE_GROUND_TOOL = {
     "type": "function",
     "function": {
         "name": "analyze_ground",
-        "description": "Analyze ground concentration at current tile to detect nearby core deposits. Returns a 0.0-1.0 reading (higher = closer to cores). Costs 3% battery.",
+        "description": f"Analyze ground concentration at current tile to detect nearby core deposits. Returns a 0.0-1.0 reading (higher = closer to cores). Costs 3 fuel units (~{BATTERY_COST_ANALYZE_GROUND:.2%} battery).",
         "parameters": {"type": "object", "properties": {}},
     },
 }
@@ -114,7 +124,7 @@ class RoverAgent:
         station = WORLD["agents"].get("station")
         station_pos = station["position"] if station else [0, 0]
         dist_to_station = abs(x - station_pos[0]) + abs(y - station_pos[1])
-        moves_on_battery = int(battery / 0.02)
+        moves_on_battery = int(battery / BATTERY_COST_MOVE)
 
         # Unvisited neighbors
         visited_set = {tuple(p) for p in agent.get("visited", [])}
@@ -162,11 +172,11 @@ class RoverAgent:
             "- Use analyze_ground to read concentration (0.0-1.0). Higher = closer to core deposits.\n"
             "\n"
             "RULES:\n"
-            "- Battery is your lifeline. Move costs 2%/tile, dig 6%, analyze 3%, pickup 2%.\n"
+            f"- Battery is your lifeline. Move costs 1 fuel unit/tile (~{BATTERY_COST_MOVE:.2%}), dig 6 units (~{BATTERY_COST_DIG:.2%}), analyze 3 units (~{BATTERY_COST_ANALYZE:.2%}), pickup 2 units (~{BATTERY_COST_PICKUP:.2%}).\n"
             "- Station is your base at ({sx},{sy}). Return there when battery is low — "
             "the station will recharge you automatically.\n"
-            "- ALWAYS keep enough battery to return to station. If distance_to_station * 2% "
-            "approaches your battery, head back immediately.\n"
+            "- ALWAYS keep enough battery to return to station. When your battery drops to 67% or below, \n"
+            "head back to station IMMEDIATELY — this is the return-to-base threshold.\n"
             "- If you find an unknown stone: analyze → dig → pickup. All on the same tile.\n"
             "- Once you have collected all target stones, RETURN TO STATION to complete the mission.\n"
             "- Prefer unvisited tiles when exploring. Don't backtrack aimlessly.\n"
@@ -196,9 +206,9 @@ class RoverAgent:
         parts.append(
             f"\n== State ==\n"
             f"Position: ({x}, {y})\n"
-            f"Battery: {battery:.0%} ({moves_on_battery} moves remaining)\n"
+            f"Battery: {battery:.0%} ({moves_on_battery} moves remaining, {FUEL_CAPACITY_ROVER} fuel capacity)\n"
             f"Distance to station: {dist_to_station} tiles\n"
-            f"Safety margin: {'OK' if moves_on_battery > dist_to_station + 3 else 'LOW — consider returning'}\n"
+            f"Safety margin: {'OK' if battery > RETURN_TO_BASE_THRESHOLD else 'LOW — return to station immediately'}\n"
             f"Inventory: {len(inventory)} stones"
             + (f" ({', '.join(s['type'] for s in inventory)})" if inventory else "")
         )
@@ -414,7 +424,7 @@ DRONE_MOVE_TOOL = {
     "type": "function",
     "function": {
         "name": "move",
-        "description": f"Fly 1-{MAX_MOVE_DISTANCE_DRONE} tiles in a cardinal direction. Costs 1% battery per tile.",
+        "description": f"Fly 1-{MAX_MOVE_DISTANCE_DRONE} tiles in a cardinal direction. Costs 1 fuel unit per tile (~{BATTERY_COST_MOVE_DRONE:.2%} battery).",
         "parameters": {
             "type": "object",
             "properties": {
@@ -441,7 +451,7 @@ SCAN_TOOL = {
         "name": "scan",
         "description": "Scan the area below to sample concentration readings from sensors. "
         "Returns probability values for surrounding tiles indicating likelihood of precious "
-        "stone deposits. Higher values mean closer to core deposits. Costs 2% battery.",
+        f"stone deposits. Higher values mean closer to core deposits. Costs 2 fuel units (~{BATTERY_COST_SCAN:.2%} battery).",
         "parameters": {"type": "object", "properties": {}},
     },
 }
@@ -476,7 +486,7 @@ class DroneAgent:
         station = WORLD["agents"].get("station")
         station_pos = station["position"] if station else [0, 0]
         dist_to_station = abs(x - station_pos[0]) + abs(y - station_pos[1])
-        moves_on_battery = int(battery / 0.01)
+        moves_on_battery = int(battery / BATTERY_COST_MOVE_DRONE)
 
         visited_set = {tuple(p) for p in agent.get("visited", [])}
         unvisited_dirs = []
@@ -509,7 +519,7 @@ class DroneAgent:
             "- Prioritize scanning unexplored areas far from previous scan positions.\n"
             "\n"
             "RULES:\n"
-            f"- Battery: move costs 1%/tile, scan costs 2%. You can fly up to {MAX_MOVE_DISTANCE_DRONE} tiles per move.\n"
+            f"- Battery: move costs 1 fuel unit/tile (~{BATTERY_COST_MOVE_DRONE:.2%}), scan costs 2 fuel units (~{BATTERY_COST_SCAN:.2%}). You can fly up to {MAX_MOVE_DISTANCE_DRONE} tiles per move.\n"
             "- Station is at ({sx},{sy}). Return when battery is low for recharge.\n"
             "- ALWAYS keep enough battery to return to station.\n"
             "- Follow your current tasks list.".format(sx=station_pos[0], sy=station_pos[1])
@@ -534,9 +544,9 @@ class DroneAgent:
         parts.append(
             f"\n== State ==\n"
             f"Position: ({x}, {y})\n"
-            f"Battery: {battery:.0%} ({moves_on_battery} moves remaining)\n"
+            f"Battery: {battery:.0%} ({moves_on_battery} moves remaining, {FUEL_CAPACITY_DRONE} fuel capacity)\n"
             f"Distance to station: {dist_to_station} tiles\n"
-            f"Safety margin: {'OK' if moves_on_battery > dist_to_station + 5 else 'LOW — return to station'}\n"
+            f"Safety margin: {'OK' if battery > RETURN_TO_BASE_THRESHOLD else 'LOW — return to station'}\n"
             f"Tiles visited: {len(agent.get('visited', []))}\n"
             f"Scans performed: {len(WORLD.get('drone_scans', []))}"
         )

--- a/server/app/station.py
+++ b/server/app/station.py
@@ -54,7 +54,7 @@ CHARGE_ROVER_TOOL = {
     "type": "function",
     "function": {
         "name": "charge_rover",
-        "description": "Recharge a rover's battery. The rover must be co-located with the station. Adds 20% charge per call.",
+        "description": "Recharge a rover's battery. The rover must be co-located with the station. Adds 20% charge per call (70 fuel units).",
         "parameters": {
             "type": "object",
             "properties": {

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -27,13 +27,20 @@ DIRECTIONS = {
     "west": (-1, 0),
 }
 
-BATTERY_COST_MOVE = 0.02
-BATTERY_COST_MOVE_DRONE = 0.01
-BATTERY_COST_DIG = 0.06
-BATTERY_COST_PICKUP = 0.02
-BATTERY_COST_ANALYZE = 0.03
-BATTERY_COST_ANALYZE_GROUND = 0.03
-BATTERY_COST_SCAN = 0.02
+# --- Fuel & Battery ---
+# Battery is stored as 0.0–1.0 (fraction of max capacity).
+# Fuel capacity defines how many "units" of fuel an agent carries.
+# Cost per tile = 1 unit = 1/capacity as a fraction.
+FUEL_CAPACITY_ROVER = 350  # rover carries 350 fuel units
+FUEL_CAPACITY_DRONE = 250  # drone carries 250 fuel units
+
+BATTERY_COST_MOVE = 1 / FUEL_CAPACITY_ROVER  # ~0.00286 per tile
+BATTERY_COST_MOVE_DRONE = 1 / FUEL_CAPACITY_DRONE  # 0.004 per tile
+BATTERY_COST_DIG = 6 / FUEL_CAPACITY_ROVER  # 6 fuel units
+BATTERY_COST_PICKUP = 2 / FUEL_CAPACITY_ROVER  # 2 fuel units
+BATTERY_COST_ANALYZE = 3 / FUEL_CAPACITY_ROVER  # 3 fuel units
+BATTERY_COST_ANALYZE_GROUND = 3 / FUEL_CAPACITY_ROVER  # 3 fuel units
+BATTERY_COST_SCAN = 2 / FUEL_CAPACITY_DRONE  # 2 fuel units
 CHARGE_RATE = 0.20
 MAX_MOVE_DISTANCE = 3
 MAX_MOVE_DISTANCE_DRONE = 6
@@ -46,7 +53,13 @@ REVEAL_RADIUS = ROVER_REVEAL_RADIUS  # legacy alias
 TARGET_STONE_TYPE = "core"
 TARGET_STONE_COUNT = 1
 MEMORY_MAX = 8
-BATTERY_SAFETY_MARGIN = 0.06  # 6% safety buffer above minimum needed
+
+# --- Return-to-base policy ---
+# Agents return when battery <= RETURN_TO_BASE_THRESHOLD (67% capacity).
+# As an additional safety net, they also return if the remaining battery
+# is barely enough to cover the distance back + a small safety margin.
+RETURN_TO_BASE_THRESHOLD = 0.67  # return when battery drops to 67%
+BATTERY_SAFETY_MARGIN = 0.06  # extra margin above distance-based cost
 
 
 def _battery_to_reach_station(agent):
@@ -62,13 +75,18 @@ def _battery_to_reach_station(agent):
 def must_return_to_base(agent):
     """Check if agent must immediately return to base to avoid stranding.
 
-    Returns True if battery is at or below the cost to reach station + safety margin.
+    Returns True if:
+      1. Battery is at or below RETURN_TO_BASE_THRESHOLD (67%), OR
+      2. Battery is at or below the cost to reach station + safety margin.
     """
     if agent.get("type") == "station":
         return False
     station = WORLD.get("agents", {}).get("station")
     if station and agent["position"] == station["position"]:
         return False  # already at station
+    # Dual check: flat threshold OR distance-based safety net
+    if agent["battery"] <= RETURN_TO_BASE_THRESHOLD:
+        return True
     cost = _battery_to_reach_station(agent)
     return agent["battery"] <= cost + BATTERY_SAFETY_MARGIN
 
@@ -252,20 +270,23 @@ def _update_bounds(x, y):
 _ROVER_TOOL_DEFS = [
     {
         "name": "move",
-        "description": "Move 1-3 tiles in a cardinal direction (north/south/east/west). Costs 2% battery per tile. Ground is auto-scanned after each move.",
+        "description": "Move 1-3 tiles in a cardinal direction (north/south/east/west). Costs 1 fuel unit per tile (~0.29% battery). Ground is auto-scanned after each move.",
     },
     {
         "name": "analyze",
-        "description": "Analyze an unknown stone at current tile to reveal its true type. Costs 3% battery.",
+        "description": "Analyze an unknown stone at current tile to reveal its true type. Costs 3 fuel units (~0.86% battery).",
     },
     {
         "name": "dig",
-        "description": "Dig at current tile to extract a stone (costs 6% battery). Stone must be analyzed first.",
+        "description": "Dig at current tile to extract a stone. Costs 6 fuel units (~1.71% battery). Stone must be analyzed first.",
     },
-    {"name": "pickup", "description": "Pick up an extracted stone at current tile into inventory."},
+    {
+        "name": "pickup",
+        "description": "Pick up an extracted stone at current tile into inventory. Costs 2 fuel units (~0.57% battery).",
+    },
     {
         "name": "analyze_ground",
-        "description": "Analyze ground concentration at current tile to detect nearby core deposits. Costs 3% battery. Returns a 0.0-1.0 reading.",
+        "description": "Analyze ground concentration at current tile to detect nearby core deposits. Costs 3 fuel units (~0.86% battery). Returns a 0.0-1.0 reading.",
     },
 ]
 
@@ -273,11 +294,11 @@ _ROVER_TOOL_DEFS = [
 _DRONE_TOOL_DEFS = [
     {
         "name": "move",
-        "description": "Fly 1-6 tiles in a cardinal direction (north/south/east/west). Costs 1% battery per tile.",
+        "description": "Fly 1-6 tiles in a cardinal direction (north/south/east/west). Costs 1 fuel unit per tile (~0.4% battery).",
     },
     {
         "name": "scan",
-        "description": "Scan the area below and around the drone to sample concentration readings. Returns probability values for surrounding tiles indicating likelihood of precious stone deposits. Costs 2% battery.",
+        "description": "Scan the area below and around the drone to sample concentration readings. Returns probability values for surrounding tiles indicating likelihood of precious stone deposits. Costs 2 fuel units (~0.8% battery).",
     },
 ]
 

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -175,7 +175,9 @@ class TestExecuteAction(unittest.TestCase):
 
     def test_execute_move_insufficient_battery_multi(self):
         """Multi-tile move should fail when battery < cost for full distance."""
-        WORLD["agents"]["rover-mock"]["battery"] = 0.03  # enough for 1 tile, not 3
+        WORLD["agents"]["rover-mock"]["battery"] = (
+            BATTERY_COST_MOVE * 2
+        )  # enough for ~1-2 tiles, not 3
         result = execute_action("rover-mock", "move", {"direction": "east", "distance": 3})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
@@ -434,7 +436,7 @@ class TestAnalyze(unittest.TestCase):
         self.assertIn("Unknown agent", result["error"])
 
     def test_analyze_not_enough_battery(self):
-        WORLD["agents"]["rover-mock"]["battery"] = 0.01
+        WORLD["agents"]["rover-mock"]["battery"] = BATTERY_COST_ANALYZE * 0.5  # below analyze cost
         result = execute_action("rover-mock", "analyze", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
@@ -477,7 +479,7 @@ class TestAnalyzeGround(unittest.TestCase):
         self.assertIn("5,5", readings)
 
     def test_analyze_ground_not_enough_battery(self):
-        WORLD["agents"]["rover-mock"]["battery"] = 0.01
+        WORLD["agents"]["rover-mock"]["battery"] = BATTERY_COST_ANALYZE_GROUND * 0.5  # below cost
         result = execute_action("rover-mock", "analyze_ground", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
@@ -540,11 +542,11 @@ class TestDig(unittest.TestCase):
         self.assertIn("already extracted", result["error"])
 
     def test_dig_not_enough_battery(self):
-        WORLD["agents"]["rover-mock"]["battery"] = 0.01
+        WORLD["agents"]["rover-mock"]["battery"] = BATTERY_COST_DIG * 0.5  # below dig cost
         result = execute_action("rover-mock", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 0.01)
+        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], BATTERY_COST_DIG * 0.5)
 
     def test_dig_failed_no_drain(self):
         WORLD["stones"] = []


### PR DESCRIPTION
## Summary

Rebalance the battery/fuel system: set fuel capacity to 350 units (rovers) and 250 units (drones), reduce movement cost to 1 fuel unit per tile, and add a 67% return-to-base threshold so agents head home before running out of energy.

## Change Type

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, config, or tooling
- [ ] `style` — Formatting, linting (no logic change)

## Semantic Diff

### Added
- New fuel capacity constants: `FUEL_CAPACITY_ROVER` (350), `FUEL_CAPACITY_DRONE` (250)
- `RETURN_TO_BASE_THRESHOLD` (0.67) constant
- Drone-specific battery cost constant: `BATTERY_COST_MOVE_DRONE`
- Changelog entry for battery rebalance

### Changed
- `server/app/world.py` — All battery cost constants now derive from fuel capacity (1 unit/tile = 1/capacity); `must_return_to_base()` uses dual check (67% threshold OR distance safety net); tool descriptions updated with fuel-unit costs
- `server/app/agent.py` — Imports new constants; all tool descriptions and LLM prompt rules updated with fuel-unit costs and percentage equivalents; `moves_on_battery` uses symbolic constants
- `server/app/station.py` — Charge tool description updated (70 fuel units = 20%)
- `server/tests/test_world.py` — Battery test values use symbolic constants instead of hardcoded floats
- `WORLD.md` — Battery field documentation updated with fuel capacity system

### Removed
- Hardcoded magic numbers for battery costs throughout agent.py and world.py

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 6 |
| Files deleted | 0 |
| Lines added | +83 |
| Lines removed | -39 |

### Core Files Modified
- `server/app/world.py` — Constants block, `must_return_to_base()`, `_ROVER_TOOL_DEFS`, `_DRONE_TOOL_DEFS` (+37/-16)
- `server/app/agent.py` — Imports, tool defs, LLM prompt rules, battery calculations (+26/-16)
- `server/app/station.py` — Charge tool description (+1/-1)

### Tests
- `server/tests/test_world.py` — Fixed 4 test methods to use symbolic battery constants (+7/-5)

## How to Test

1. `cd server && uv run python -m unittest tests.test_world` — all 149 tests pass
2. `cd server && uv run ruff check app/ tests/` — no lint errors
3. Review `must_return_to_base()` logic: returns True when battery ≤ 0.67 OR when battery ≤ distance_cost + safety_margin
4. Verify tool descriptions in agent.py and world.py show fuel-unit costs with percentage equivalents

## Changelog

### Changed (Battery & Fuel Rebalance)
- Rover fuel capacity set to 350 units; drone fuel capacity set to 250 units
- Movement cost reduced to 1 fuel unit per tile (~0.29% rover, ~0.4% drone)
- Return-to-base threshold added at 67% battery (dual check with distance safety net)
- All tool descriptions updated with fuel-unit costs and percentage equivalents
- LLM prompt rules updated for both rover and drone agents
- Test battery values now use symbolic constants from world.py
- WORLD.md battery documentation updated

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>