### PR TITLE
feat: remove mock rover, enforce mission return, chronological logs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added (Solar Panels)
+
+- **Solar panel system**: Rovers carry 2 deployable solar panels (`MAX_SOLAR_PANELS=2`). Deploy with `deploy_solar_panel` action (costs 1 fuel), recharge with `use_solar_battery` (gains 25% battery). Panels render on the map as gold rectangles (grey when depleted).
+- **Solar panel tools**: `DEPLOY_SOLAR_PANEL_TOOL` and `USE_SOLAR_BATTERY_TOOL` added to rover LLM tool list.
+- **Solar panel context**: Rover LLM prompt includes panels remaining and nearby panel status.
+- **Solar panel rendering**: WorldMap.vue renders active/depleted panels with grid lines.
+- **`_nearest_solar_panel` helper**: Low-battery task hints suggest nearby active panels as alternative to station return.
+
+### Changed (Remove Mock Rover)
+
+- **Removed `rover-mock` agent entirely**: `MockRoverReasoner`, `MockRoverAgent`, `RoverMockLoop` classes deleted from `agent.py`. No more mock rover in `_build_initial_world`, `AGENT_MAP`, `active_agents` config, or `AGENT_COLORS`.
+- **`MistralRoverReasoner._fallback_turn`**: Now uses inline explore logic (random unvisited direction) instead of delegating to `MockRoverReasoner`.
+- **`charge_rover` → `charge_agent`**: Renamed to accept any non-station agent (drone included). `charge_rover` kept as backward-compat alias.
+- **Station prompt**: Updated to reference single rover `rover-mistral` instead of two rovers.
+
+### Changed (Stone Generation)
+
+- **Per-tile probability**: Replaced noise-based `_noise_concentration` with `STONE_PROBABILITY=0.015` per tile (1.5% chance per tile in each 16×16 chunk). `CORE_PROBABILITY=0.3` (30% chance a stone is core).
+- **Removed `_noise_concentration` and `_boost_concentration_near_cores`**: Replaced by `_stone_proximity_concentration` (Manhattan distance decay from nearest stone).
+- **Removed `math` and `struct` imports**: No longer needed.
+- **Origin chunk guaranteed ≥1 core**: Ensures playability.
+
+### Changed (Mission Return Logic)
+
+- **Mission fulfillment check**: `_update_rover_tasks` now checks `target_in_inventory >= target_needed` and instructs rover to return to station immediately with 🏁 emoji prefix.
+- **Rover LLM prompt**: Added "CRITICAL: Once you have collected the target number of stones, STOP exploring and RETURN TO STATION IMMEDIATELY."
+- **Mission indicator**: LLM context shows "🏁 MISSION TARGET MET" when collected count meets target.
+
+### Changed (UI Improvements)
+
+- **Chronological event log**: `AgentPane.vue` now shows ALL events (thinking + actions) chronologically, not just thinking events. Actions show move coordinates or result text.
+- **CSS refinements**: `.ae-type.think` colored `#668`, `.ae-text.action-text` colored `#7a9a7a`.
+
+### Lessons Learned
+
+- When replacing a mock with real agent, test setUp methods that previously initialized two agents need careful deduplication.
+- Mission state (`collected_count`) must be reset in test setUp to avoid cross-test contamination with new mission-fulfillment logic.
+
 ### Changed (Battery & Fuel Rebalance)
 
 - **Fuel capacity system**: Rovers carry 350 fuel units, Drone carries 250 fuel units. Battery remains a 0.0–1.0 float (fraction of capacity)

--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -20,8 +20,8 @@ from .world import FUEL_CAPACITY_ROVER, FUEL_CAPACITY_DRONE, DRONE_REVEAL_RADIUS
 from .world import BATTERY_COST_MOVE, BATTERY_COST_MOVE_DRONE, BATTERY_COST_DIG
 from .world import BATTERY_COST_PICKUP, BATTERY_COST_ANALYZE, BATTERY_COST_ANALYZE_GROUND
 from .world import BATTERY_COST_SCAN, RETURN_TO_BASE_THRESHOLD
-from .world import check_ground, _direction_hint, _find_stone_at, must_return_to_base
-from .world import execute_action, get_snapshot, charge_rover, next_tick
+from .world import check_ground, _direction_hint, must_return_to_base
+from .world import execute_action, get_snapshot, charge_agent, next_tick
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,25 @@ ANALYZE_GROUND_TOOL = {
     },
 }
 
-ROVER_TOOLS = [MOVE_TOOL, ANALYZE_TOOL, DIG_TOOL, PICKUP_TOOL, ANALYZE_GROUND_TOOL]
+DEPLOY_SOLAR_PANEL_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "deploy_solar_panel",
+        "description": f"Deploy a solar panel at current tile. The panel stores {BATTERY_COST_MOVE * 100 * 25:.0f}% charge that can be used later with use_solar_battery. Costs 1 fuel unit to deploy. Limited supply.",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+USE_SOLAR_BATTERY_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "use_solar_battery",
+        "description": "Use a deployed solar panel at current tile to recharge battery. The panel must be active (not depleted).",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+ROVER_TOOLS = [MOVE_TOOL, ANALYZE_TOOL, DIG_TOOL, PICKUP_TOOL, ANALYZE_GROUND_TOOL, DEPLOY_SOLAR_PANEL_TOOL, USE_SOLAR_BATTERY_TOOL]
 
 
 # ── Rover Reasoners (sync decision engines, read from WORLD) ──
@@ -99,7 +117,6 @@ class MistralRoverReasoner:
         self.agent_id = agent_id
         self.model = model
         self._client = None
-        self._mock_fallback = MockRoverReasoner(agent_id=agent_id)
 
     def _get_client(self):
         if self._client is None:
@@ -174,6 +191,7 @@ class MistralRoverReasoner:
             "head back to station IMMEDIATELY — this is the return-to-base threshold.\n"
             "- If you find an unknown stone: analyze → dig → pickup. All on the same tile.\n"
             "- Once you have collected all target stones, RETURN TO STATION to complete the mission.\n"
+            "- CRITICAL: Once you have collected the target number of stones, STOP exploring and RETURN TO STATION IMMEDIATELY.\n"
             "- Prefer unvisited tiles when exploring. Don't backtrack aimlessly.\n"
             "- Ground is auto-scanned after every move. No need to check manually.\n"
             "- Follow your current tasks list. It tells you exactly what to do next.".format(
@@ -185,6 +203,7 @@ class MistralRoverReasoner:
             f"\n== Mission ==\n"
             f"Objective: {mission['objective']}\n"
             f"Target: collect {target_count} {target_type} stones ({collected}/{target_count} done)"
+            + (f"\n🏁 MISSION TARGET MET — RETURN TO STATION NOW!" if collected >= target_count else "")
         )
 
         tasks = agent.get("tasks", [])
@@ -203,7 +222,20 @@ class MistralRoverReasoner:
             f"Safety margin: {'OK' if battery > RETURN_TO_BASE_THRESHOLD else 'LOW — return to station immediately'}\n"
             f"Inventory: {len(inventory)} stones"
             + (f" ({', '.join(s['type'] for s in inventory)})" if inventory else "")
+            + f"\nSolar panels remaining: {agent.get('solar_panels_remaining', 0)}"
         )
+
+        # Nearby solar panels
+        nearby_panels = []
+        for panel in WORLD.get("solar_panels", []):
+            px, py = panel["position"]
+            pd = abs(px - x) + abs(py - y)
+            if pd <= 10:
+                status = "depleted" if panel["depleted"] else f"active ({panel['battery']:.0%})"
+                nearby_panels.append(f"  - ({px},{py}): {status}, {pd} tiles")
+        if nearby_panels:
+            parts.append("Nearby solar panels:")
+            parts.extend(nearby_panels)
 
         # Visible stones (on revealed tiles)
         revealed_set = {tuple(c) for c in agent.get("revealed", [])}
@@ -292,7 +324,7 @@ class MistralRoverReasoner:
                     if isinstance(tc.function.arguments, str)
                     else tc.function.arguments
                 )
-                if name in ("move", "dig", "pickup", "analyze", "analyze_ground"):
+                if name in ("move", "dig", "pickup", "analyze", "analyze_ground", "deploy_solar_panel", "use_solar_battery"):
                     action = {"name": name, "params": args}
                 else:
                     logger.warning("%s called unknown tool %r, ignoring", self.agent_id, name)
@@ -311,136 +343,23 @@ class MistralRoverReasoner:
             return self._fallback_turn(f"LLM unavailable ({type(exc).__name__})")
 
     def _fallback_turn(self, reason):
-        fallback = self._mock_fallback.run_turn()
-        fallback_thinking = fallback.get("thinking") or ""
-        prefix = f"LLM fallback: {reason}. "
-        fallback["thinking"] = (prefix + fallback_thinking).strip()
-        return fallback
-
-
-class MockRoverReasoner:
-    """Mock rover reasoner — explores, collects stones, returns to station. No LLM calls."""
-
-    def __init__(self, agent_id="rover-mock"):
-        self.agent_id = agent_id
-
-    def run_turn(self):
-        """Decide next action by reading from WORLD."""
         agent = WORLD["agents"][self.agent_id]
         x, y = agent["position"]
-        mission = WORLD.get("mission", {})
-        target_type = mission.get("target_type", "core")
-
-        context = (
-            f"Mock rover at ({x},{y}), battery={agent['battery']:.0%}, "
-            f"visited={len(agent.get('visited', []))}, "
-            f'mission="{agent["mission"]["objective"]}"'
-        )
-        agent["last_context"] = context
-
-        # Check for recall command — override everything, head to station
-        for cmd in agent.get("pending_commands", []):
-            if cmd["name"] == "recall":
-                station = WORLD["agents"].get("station")
-                sp = station["position"] if station else [0, 0]
-                dx, dy = sp[0] - x, sp[1] - y
-                if dx == 0 and dy == 0:
-                    thinking = f"Recall received but already at station ({x}, {y})."
-                    return {"thinking": thinking, "action": {"name": "move", "params": {"direction": "north", "distance": 1}}}
-                if abs(dx) >= abs(dy):
-                    direction = "east" if dx > 0 else "west"
-                    distance = min(abs(dx), MAX_MOVE_DISTANCE)
-                else:
-                    direction = "north" if dy > 0 else "south"
-                    distance = min(abs(dy), MAX_MOVE_DISTANCE)
-                reason = cmd.get("payload", {}).get("reason", "emergency")
-                thinking = f"RECALL received: {reason}. Heading to station at ({sp[0]},{sp[1]})."
-                return {
-                    "thinking": thinking,
-                    "action": {"name": "move", "params": {"direction": direction, "distance": distance}},
-                }
-
-        # Battery safety — return to base if battery is low
-        if must_return_to_base(agent):
-            station = WORLD["agents"].get("station")
-            sp = station["position"] if station else [0, 0]
-            dx, dy = sp[0] - x, sp[1] - y
-            if dx != 0:
-                direction = "east" if dx > 0 else "west"
-                distance = min(abs(dx), MAX_MOVE_DISTANCE)
-            elif dy != 0:
-                direction = "north" if dy > 0 else "south"
-                distance = min(abs(dy), MAX_MOVE_DISTANCE)
-            else:
-                direction = "north"
-                distance = 1
-            thinking = f"I'm at ({x}, {y}). LOW BATTERY ({agent['battery']:.0%}) — must return to station!"
-            return {
-                "thinking": thinking,
-                "action": {
-                    "name": "move",
-                    "params": {"direction": direction, "distance": distance},
-                },
-            }
-
-        # Check for stone at current tile — analyze, dig, or pickup
-        stone_here = _find_stone_at(x, y)
-        if stone_here:
-            if not stone_here.get("analyzed"):
-                thinking = f"I'm at ({x}, {y}). Found an unknown stone — analyzing."
-                return {"thinking": thinking, "action": {"name": "analyze", "params": {}}}
-            elif not stone_here.get("extracted"):
-                thinking = f"I'm at ({x}, {y}). Found a {stone_here['type']} stone — digging."
-                return {"thinking": thinking, "action": {"name": "dig", "params": {}}}
-            else:
-                thinking = f"I'm at ({x}, {y}). Stone extracted — picking up."
-                return {"thinking": thinking, "action": {"name": "pickup", "params": {}}}
-
-        # If carrying target stone, navigate toward station
-        has_target = any(s["type"] == target_type for s in agent.get("inventory", []))
-        if has_target:
-            station = WORLD["agents"].get("station")
-            sp = station["position"] if station else [0, 0]
-            dx, dy = sp[0] - x, sp[1] - y
-            if dx != 0:
-                direction = "east" if dx > 0 else "west"
-                distance = min(abs(dx), MAX_MOVE_DISTANCE)
-            elif dy != 0:
-                direction = "north" if dy > 0 else "south"
-                distance = min(abs(dy), MAX_MOVE_DISTANCE)
-            else:
-                direction = "north"
-                distance = 1
-            thinking = f"I'm at ({x}, {y}). Carrying target stone, heading to station at ({sp[0]},{sp[1]})."
-            return {
-                "thinking": thinking,
-                "action": {
-                    "name": "move",
-                    "params": {"direction": direction, "distance": distance},
-                },
-            }
-
-        # Default: explore unvisited tiles (infinite grid — no boundary check)
         visited_set = {tuple(p) for p in agent.get("visited", [])}
-        valid = []
         unvisited = []
-        for name, (ddx, ddy) in DIRECTIONS.items():
-            nx, ny = x + ddx, y + ddy
+        valid = []
+        for name, (dx, dy) in DIRECTIONS.items():
+            nx, ny = x + dx, y + dy
             valid.append((name, nx, ny))
             if (nx, ny) not in visited_set:
                 unvisited.append((name, nx, ny))
-
         candidates = unvisited if unvisited else valid
         direction, tx, ty = random.choice(candidates)
-
-        thinking = f"I'm at ({x}, {y}). I'll move {direction} to ({tx}, {ty})."
-        action = {"name": "move", "params": {"direction": direction}}
-
-        return {"thinking": thinking, "action": action}
+        thinking = f"LLM fallback: {reason}. Moving {direction} to ({tx},{ty})."
+        return {"thinking": thinking, "action": {"name": "move", "params": {"direction": direction}}}
 
 
 # Backward-compat aliases
-MockRoverAgent = MockRoverReasoner
 RoverAgent = MistralRoverReasoner
 
 
@@ -766,12 +685,9 @@ class MockDroneAgent:
 
 
 class RoverLoop(BaseAgent):
-    """Generic rover tick: inject commands → reason → execute → broadcast.
+    """Generic rover tick: inject commands → reason → execute → broadcast."""
 
-    Subclasses set self._reasoner to a MockRoverReasoner or MistralRoverReasoner.
-    """
-
-    _reasoner: MockRoverReasoner | MistralRoverReasoner
+    _reasoner: MistralRoverReasoner
 
     async def tick(self, host) -> None:
         # Inject pending commands from inbox into WORLD for reasoner to read
@@ -845,7 +761,7 @@ class RoverLoop(BaseAgent):
             and rover["position"] == station_agent["position"]
             and rover["battery"] < 1.0
         ):
-            charge_result = charge_rover(self.agent_id)
+            charge_result = charge_agent(self.agent_id)
             if charge_result["ok"]:
                 charge_msg = make_message(
                     source="station",
@@ -854,14 +770,6 @@ class RoverLoop(BaseAgent):
                     payload=charge_result,
                 )
                 await host.broadcast(charge_msg.to_dict())
-
-
-class RoverMockLoop(RoverLoop):
-    """Rover loop wired to MockRoverReasoner."""
-
-    def __init__(self, interval: float = 0.5):
-        super().__init__(agent_id="rover-mock", interval=interval)
-        self._reasoner = MockRoverReasoner(agent_id=self.agent_id)
 
 
 class RoverMistralLoop(RoverLoop):
@@ -922,7 +830,7 @@ class DroneLoop(BaseAgent):
             and drone["position"] == station_agent["position"]
             and drone["battery"] < 1.0
         ):
-            charge_result = charge_rover(self.agent_id)
+            charge_result = charge_agent(self.agent_id)
             if charge_result["ok"]:
                 charge_msg = make_message(
                     source="station",

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -31,8 +31,8 @@ class Settings(BaseSettings):
     # World generation seed (empty = random)
     world_seed: str = ""
 
-    # Active agents (comma-separated: "rover-mock,rover-mistral,drone-mistral")
-    active_agents: str = "rover-mock,rover-mistral,drone-mistral"
+    # Active agents (comma-separated: "rover-mistral,drone-mistral")
+    active_agents: str = "rover-mistral,drone-mistral"
 
     # ElevenLabs narration
     elevenlabs_api_key: str = ""

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from rich.logging import RichHandler
 
-from .agent import RoverMockLoop, RoverMistralLoop, DroneMistralLoop
+from .agent import RoverMistralLoop, DroneMistralLoop
 from .broadcast import broadcaster
 from .config import settings
 from .db import init_db, close_db
@@ -28,7 +28,6 @@ narrator = Narrator(broadcast_fn=broadcaster.send)
 host = Host(narrator=narrator)
 
 AGENT_MAP = {
-    "rover-mock": lambda: RoverMockLoop(interval=settings.agent_turn_interval_seconds),
     "rover-mistral": lambda: RoverMistralLoop(interval=settings.llm_turn_interval_seconds),
     "drone-mistral": lambda: DroneMistralLoop(interval=2.0),
 }

--- a/server/app/station.py
+++ b/server/app/station.py
@@ -21,7 +21,7 @@ ASSIGN_MISSION_TOOL = {
             "properties": {
                 "agent_id": {
                     "type": "string",
-                    "description": "The rover agent to assign (e.g. 'rover-mock', 'rover-mistral').",
+                    "description": "The rover agent to assign (e.g. 'rover-mistral').",
                 },
                 "objective": {
                     "type": "string",
@@ -61,7 +61,7 @@ CHARGE_ROVER_TOOL = {
             "properties": {
                 "rover_id": {
                     "type": "string",
-                    "description": "The rover agent to charge (e.g. 'rover-mock', 'rover-mistral').",
+                    "description": "The rover agent to charge (e.g. 'rover-mistral').",
                 },
             },
             "required": ["rover_id"],
@@ -75,7 +75,7 @@ SYSTEM_PROMPT = (
     "You are the Mars base station. You coordinate the Mars mission.\n"
     "Your role is to assign missions to rover agents, respond to field reports, "
     "and recharge rovers when they return to the station.\n"
-    "You have two rovers available: 'rover-mock' and 'rover-mistral'.\n"
+    "You have one rover available: 'rover-mistral' and one drone: 'drone-mistral'.\n"
     "Keep responses short (1-2 sentences of reasoning, then act).\n"
     "Always assign missions to at least one rover when defining the initial mission.\n"
     "When a rover arrives at the station with low battery, charge it.\n"

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -3,9 +3,7 @@
 import copy
 import hashlib
 import logging
-import math
 import random
-import struct
 
 from .config import settings
 from .models import RoverAgentState, RoverWorldView, RoverComputed, RoverContext
@@ -63,6 +61,14 @@ MEMORY_MAX = 8
 # is barely enough to cover the distance back + a small safety margin.
 RETURN_TO_BASE_THRESHOLD = 0.67  # return when battery drops to 67%
 BATTERY_SAFETY_MARGIN = 0.06  # extra margin above distance-based cost
+
+# --- Solar panels ---
+SOLAR_BATTERY_CAPACITY = 0.25
+MAX_SOLAR_PANELS = 2
+
+# --- Stone generation ---
+STONE_PROBABILITY = 0.015
+CORE_PROBABILITY = 0.3
 
 
 def _battery_to_reach_station(agent):
@@ -132,28 +138,38 @@ def _ensure_chunk(cx, cy):
     rng = random.Random(_chunk_seed(cx, cy))
     x0, y0 = cx * CHUNK_SIZE, cy * CHUNK_SIZE
 
-    # Concentration: seeded hash-based pseudo-noise
-    conc = {}
-    for dy in range(CHUNK_SIZE):
-        for dx in range(CHUNK_SIZE):
-            wx, wy = x0 + dx, y0 + dy
-            conc[(wx, wy)] = _noise_concentration(wx, wy)
-
-    # Stones: origin chunk guaranteed ≥1 core, others 0-2 stones
+    # Stones: each tile has STONE_PROBABILITY chance of spawning a stone
     stones = []
     is_origin = cx == 0 and cy == 0
     occupied = set(AGENT_STARTS) if is_origin else set()
-    num_stones = rng.randint(1, 3) if is_origin else rng.randint(0, 2)
 
-    for i in range(num_stones):
-        is_core = (i == 0 and is_origin) or rng.random() < 0.3
+    for dy in range(CHUNK_SIZE):
+        for dx in range(CHUNK_SIZE):
+            wx, wy = x0 + dx, y0 + dy
+            if (wx, wy) in occupied:
+                continue
+            if rng.random() < STONE_PROBABILITY:
+                is_core = rng.random() < CORE_PROBABILITY
+                occupied.add((wx, wy))
+                stones.append(
+                    {
+                        "position": [wx, wy],
+                        "type": "unknown",
+                        "_true_type": "core" if is_core else "basalt",
+                        "extracted": False,
+                        "analyzed": False,
+                    }
+                )
+
+    # Origin chunk guaranteed ≥1 core
+    if is_origin and not any(s["_true_type"] == "core" for s in stones):
         sx, sy = _random_free_pos(occupied, rng, cx, cy)
         occupied.add((sx, sy))
         stones.append(
             {
                 "position": [sx, sy],
                 "type": "unknown",
-                "_true_type": "core" if is_core else "basalt",
+                "_true_type": "core",
                 "extracted": False,
                 "analyzed": False,
             }
@@ -161,8 +177,6 @@ def _ensure_chunk(cx, cy):
 
     # Register stones in the global list
     WORLD.setdefault("stones", []).extend(stones)
-    # Merge concentration into global map
-    WORLD.setdefault("concentration_map", {}).update(conc)
 
     chunk_data = {"generated": True, "stone_count": len(stones)}
     chunks[key] = chunk_data
@@ -170,59 +184,25 @@ def _ensure_chunk(cx, cy):
     return chunk_data
 
 
-def _noise_concentration(x, y):
-    """Deterministic noise value 0.0-1.0 for world tile (x, y).
-
-    Uses layered hash-based noise at multiple frequencies to create
-    natural-looking concentration fields. Core stones later boost
-    nearby values via _boost_concentration_near_cores().
-    """
-    base_seed = settings.world_seed or 42
-    val = 0.0
-    amp = 1.0
-    total_amp = 0.0
-    for octave in range(3):
-        freq = 1 << octave  # 1, 2, 4
-        h = hashlib.md5(f"{base_seed}:{x * freq}:{y * freq}:{octave}".encode()).digest()
-        n = struct.unpack("<H", h[:2])[0] / 65535.0
-        val += n * amp
-        total_amp += amp
-        amp *= 0.5
-    raw = val / total_amp  # 0.0-1.0
-    return round(raw * 0.4, 4)  # base noise is low; cores boost it
-
-
-def _boost_concentration_near_cores():
-    """After stones are placed, boost concentration near core positions."""
-    sigma = 4.0
-    core_positions = []
+def _stone_proximity_concentration(x, y):
+    """Concentration based on proximity to stones (Manhattan distance)."""
+    max_conc = 0.0
     for s in WORLD.get("stones", []):
-        if s.get("_true_type") == "core":
-            core_positions.append(tuple(s["position"]))
-    if not core_positions:
-        return
-    conc = WORLD.setdefault("concentration_map", {})
-    boosted = set()
-    for px, py in core_positions:
-        for dx in range(-8, 9):
-            for dy in range(-8, 9):
-                cell = (px + dx, py + dy)
-                if cell in boosted:
-                    continue
-                d = abs(dx) + abs(dy)
-                boost = math.exp(-(d**2) / (sigma**2))
-                if cell in conc:
-                    conc[cell] = min(1.0, conc[cell] + boost * 0.6)
-                else:
-                    conc[cell] = round(boost * 0.6, 4)
-                boosted.add(cell)
+        sx, sy = s["position"]
+        d = abs(x - sx) + abs(y - sy)
+        if d == 0:
+            return 1.0
+        conc = max(0.0, 1.0 - d / 10.0)
+        if conc > max_conc:
+            max_conc = conc
+    return round(max_conc, 4)
 
 
 def get_concentration(x, y):
     """Get concentration at (x, y), generating the chunk if needed."""
     cx, cy = _chunk_key(x, y)
     _ensure_chunk(cx, cy)
-    return WORLD.get("concentration_map", {}).get((x, y), 0.0)
+    return _stone_proximity_concentration(x, y)
 
 
 def _cells_in_radius(cx, cy, radius):
@@ -335,6 +315,7 @@ def _make_rover(start_x, start_y):
         "type": "rover",
         "ground_readings": {},
         "tools": list(_ROVER_TOOL_DEFS),
+        "solar_panels_remaining": MAX_SOLAR_PANELS,
     }
 
 
@@ -351,13 +332,13 @@ def _build_initial_world():
                 "mission": {"objective": "Coordinate Mars mission", "plan": []},
                 "visited": [[0, 0]],
             },
-            "rover-mock": _make_rover(0, 0),
             "rover-mistral": _make_rover(0, 0),
             "drone-mistral": _make_drone(0, 0),
         },
         "stones": [],
         "chunks": {},
         "concentration_map": {},
+        "solar_panels": [],
         "drone_scans": [],
         "tick": 0,
         "bounds": {"min_x": -3, "max_x": 3, "min_y": -3, "max_y": 3},
@@ -377,7 +358,6 @@ def _init_world_chunks():
     for cx in range(-1, 2):
         for cy in range(-1, 2):
             _ensure_chunk(cx, cy)
-    _boost_concentration_near_cores()
 
 
 WORLD = _build_initial_world()
@@ -529,6 +509,14 @@ def execute_action(agent_id, action_name, params):
                 agent_id,
                 f"Scanned area around ({result['position'][0]},{result['position'][1]}), peak concentration={result['peak']:.3f}",
             )
+    elif action_name == "deploy_solar_panel":
+        if is_drone:
+            return {"ok": False, "error": "Drones cannot deploy solar panels"}
+        result = _execute_deploy_solar_panel(agent_id)
+    elif action_name == "use_solar_battery":
+        if is_drone:
+            return {"ok": False, "error": "Drones cannot use solar batteries"}
+        result = _execute_use_solar_battery(agent_id)
     else:
         return {"ok": False, "error": f"Unknown action: {action_name}"}
 
@@ -680,20 +668,73 @@ def _execute_charge(agent_id, agent):
     return {"ok": True, "battery_before": old_battery, "battery_after": agent["battery"]}
 
 
-def charge_rover(rover_id):
-    """Station-initiated charge: recharge a rover that is co-located with the station."""
-    agent = WORLD["agents"].get(rover_id)
+def charge_agent(agent_id):
+    """Station-initiated charge: recharge any non-station agent co-located with the station."""
+    agent = WORLD["agents"].get(agent_id)
     if agent is None:
-        return {"ok": False, "error": f"Unknown agent: {rover_id}"}
-    if agent.get("type") != "rover":
-        return {"ok": False, "error": f"{rover_id} is not a rover"}
-    result = _execute_charge(rover_id, agent)
+        return {"ok": False, "error": f"Unknown agent: {agent_id}"}
+    if agent.get("type") == "station":
+        return {"ok": False, "error": f"{agent_id} is a station"}
+    result = _execute_charge(agent_id, agent)
     if result["ok"]:
         record_memory(
-            rover_id,
+            agent_id,
             f"Station charged battery {result['battery_before']:.0%} -> {result['battery_after']:.0%}",
         )
     return result
+
+
+# Backward-compat alias
+charge_rover = charge_agent
+
+
+def _execute_deploy_solar_panel(agent_id):
+    agent = WORLD["agents"].get(agent_id)
+    if agent is None or agent.get("type") != "rover":
+        return {"ok": False, "error": f"{agent_id} is not a rover"}
+    remaining = agent.get("solar_panels_remaining", 0)
+    if remaining <= 0:
+        return {"ok": False, "error": "No solar panels remaining"}
+    x, y = agent["position"]
+    for p in WORLD.get("solar_panels", []):
+        if p["position"] == [x, y]:
+            return {"ok": False, "error": "Solar panel already deployed here"}
+    panel = {"position": [x, y], "battery": SOLAR_BATTERY_CAPACITY, "deployed_by": agent_id, "depleted": False}
+    WORLD.setdefault("solar_panels", []).append(panel)
+    agent["solar_panels_remaining"] = remaining - 1
+    agent["battery"] = max(0.0, agent["battery"] - BATTERY_COST_MOVE)  # deploy costs 1 fuel
+    record_memory(agent_id, f"Deployed solar panel at ({x},{y}) — {SOLAR_BATTERY_CAPACITY:.0%} battery")
+    return {"ok": True, "result": f"Solar panel deployed at ({x},{y})", "panel": panel}
+
+
+def _execute_use_solar_battery(agent_id):
+    agent = WORLD["agents"].get(agent_id)
+    if agent is None or agent.get("type") != "rover":
+        return {"ok": False, "error": f"{agent_id} is not a rover"}
+    x, y = agent["position"]
+    for panel in WORLD.get("solar_panels", []):
+        if panel["position"] == [x, y] and not panel["depleted"]:
+            charge = panel["battery"]
+            agent["battery"] = min(1.0, agent["battery"] + charge)
+            panel["battery"] = 0.0
+            panel["depleted"] = True
+            record_memory(agent_id, f"Used solar battery at ({x},{y}), gained {charge:.0%}")
+            return {"ok": True, "result": f"Recharged {charge:.0%} from solar panel", "new_battery": agent["battery"]}
+    return {"ok": False, "error": "No active solar panel at current position"}
+
+
+def _nearest_solar_panel(x, y):
+    best = None
+    best_dist = float("inf")
+    for panel in WORLD.get("solar_panels", []):
+        if panel["depleted"]:
+            continue
+        px, py = panel["position"]
+        d = abs(px - x) + abs(py - y)
+        if d < best_dist:
+            best_dist = d
+            best = panel
+    return best
 
 
 def check_mission_status():
@@ -859,22 +900,35 @@ def _update_rover_tasks(agent_id, agent):
         sp = station["position"] if station else [0, 0]
         if [x, y] != sp:
             cost = _battery_to_reach_station(agent)
-            tasks.append(
-                f"⚠️ LOW BATTERY ({agent['battery']:.0%}) — RETURN TO STATION at ({sp[0]},{sp[1]}) immediately! "
-                f"Need {cost:.0%} to get back."
-            )
+            nearby_panel = _nearest_solar_panel(x, y)
+            if nearby_panel:
+                pp = nearby_panel["position"]
+                pd = abs(pp[0] - x) + abs(pp[1] - y)
+                tasks.append(
+                    f"⚠️ LOW BATTERY ({agent['battery']:.0%}) — Solar panel at ({pp[0]},{pp[1]}) is {pd} tiles away, "
+                    f"or RETURN TO STATION at ({sp[0]},{sp[1]}). Need {cost:.0%} to get back."
+                )
+            else:
+                tasks.append(
+                    f"⚠️ LOW BATTERY ({agent['battery']:.0%}) — RETURN TO STATION at ({sp[0]},{sp[1]}) immediately! "
+                    f"Need {cost:.0%} to get back."
+                )
             agent["tasks"] = tasks
             return
 
-    # Already collected target stone → return to station
-    has_target = any(s["type"] == target_type for s in inventory)
-    if has_target:
+    # Mission fulfillment check — return to station when target met
+    target_in_inventory = sum(1 for s in inventory if s["type"] == target_type)
+    target_needed = mission["target_count"] - mission.get("collected_count", 0)
+    if target_in_inventory >= target_needed or mission.get("collected_count", 0) >= mission["target_count"]:
         station = WORLD["agents"].get("station")
         sp = station["position"] if station else [0, 0]
         if [x, y] == sp:
-            tasks.append("Deliver stone at station (mission complete)")
+            if target_in_inventory > 0:
+                tasks.append("🏁 Deliver stone at station — MISSION COMPLETE!")
+            else:
+                tasks.append("🏁 Mission target reached! Standby at station.")
         else:
-            tasks.append(f"Return to station at ({sp[0]},{sp[1]}) to complete mission")
+            tasks.append(f"🏁 Mission fulfilled! Return to station at ({sp[0]},{sp[1]}) to deliver stones IMMEDIATELY")
         agent["tasks"] = tasks
         return
 

--- a/server/tests/test_agent.py
+++ b/server/tests/test_agent.py
@@ -1,92 +1,52 @@
 import unittest
 
 from app.world import WORLD
-from app.agent import MockRoverReasoner
+from app.agent import MistralRoverReasoner
 
 
-class TestMockRoverAgent(unittest.TestCase):
+class TestRoverFallback(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["mission"] = {"objective": "Explore the terrain", "plan": []}
-        WORLD["agents"]["rover-mock"]["visited"] = [[10, 10]]
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["visited"] = [[10, 10]]
 
-    def test_run_turn_returns_dict(self):
-        agent = MockRoverReasoner()
-        turn = agent.run_turn()
+    def test_fallback_returns_dict(self):
+        agent = MistralRoverReasoner()
+        turn = agent._fallback_turn("test reason")
         self.assertIsInstance(turn, dict)
         self.assertIn("thinking", turn)
         self.assertIn("action", turn)
 
-    def test_run_turn_has_thinking(self):
-        agent = MockRoverReasoner()
-        turn = agent.run_turn()
+    def test_fallback_has_thinking(self):
+        agent = MistralRoverReasoner()
+        turn = agent._fallback_turn("test reason")
         self.assertIsInstance(turn["thinking"], str)
-        self.assertTrue(len(turn["thinking"]) > 0)
+        self.assertIn("LLM fallback", turn["thinking"])
 
-    def test_run_turn_action_shape(self):
-        agent = MockRoverReasoner()
-        turn = agent.run_turn()
+    def test_fallback_action_shape(self):
+        agent = MistralRoverReasoner()
+        turn = agent._fallback_turn("test reason")
         action = turn["action"]
         self.assertIsInstance(action, dict)
         self.assertEqual(action["name"], "move")
         self.assertIn("direction", action["params"])
         self.assertIn(action["params"]["direction"], ["north", "south", "east", "west"])
 
-    def test_run_turn_does_not_mutate_world(self):
-        agent = MockRoverReasoner()
-        pos_before = list(WORLD["agents"]["rover-mock"]["position"])
-        agent.run_turn()
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], pos_before)
+    def test_fallback_does_not_mutate_world(self):
+        agent = MistralRoverReasoner()
+        pos_before = list(WORLD["agents"]["rover-mistral"]["position"])
+        agent._fallback_turn("test reason")
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], pos_before)
 
-    def test_run_turn_at_corner(self):
-        """With infinite grid, all 4 directions are valid from any position."""
-        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
-        agent = MockRoverReasoner()
-        turn = agent.run_turn()
-        self.assertIn(turn["action"]["params"]["direction"], ["north", "south", "east", "west"])
-
-    def test_run_turn_at_bottom_right(self):
-        """With infinite grid, all 4 directions are valid from any position."""
-        WORLD["agents"]["rover-mock"]["position"] = [19, 19]
-        WORLD["agents"]["rover-mock"]["visited"] = [[19, 19]]
-        agent = MockRoverReasoner()
-        turn = agent.run_turn()
-        self.assertIn(turn["action"]["params"]["direction"], ["north", "south", "east", "west"])
-
-    def test_mock_prefers_unvisited(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
-        WORLD["agents"]["rover-mock"]["visited"] = [
+    def test_fallback_prefers_unvisited(self):
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
+        WORLD["agents"]["rover-mistral"]["visited"] = [
             [10, 10],
             [11, 10],
             [10, 9],
             [9, 10],
         ]
-        agent = MockRoverReasoner()
-        turn = agent.run_turn()
+        agent = MistralRoverReasoner()
+        turn = agent._fallback_turn("test reason")
         self.assertEqual(turn["action"]["params"]["direction"], "north")
-
-    def test_mock_recall_heads_to_station(self):
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        WORLD["agents"]["rover-mock"]["pending_commands"] = [
-            {"name": "recall", "payload": {"reason": "Emergency"}},
-        ]
-        agent = MockRoverReasoner()
-        turn = agent.run_turn()
-        self.assertEqual(turn["action"]["name"], "move")
-        # Should head toward station at (0,0) — west or south
-        self.assertIn(turn["action"]["params"]["direction"], ["west", "south"])
-        self.assertIn("RECALL", turn["thinking"])
-        # Clean up
-        WORLD["agents"]["rover-mock"].pop("pending_commands", None)
-
-    def test_mock_recall_at_station(self):
-        """If already at station when recall received, still returns valid action."""
-        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
-        WORLD["agents"]["rover-mock"]["pending_commands"] = [
-            {"name": "recall", "payload": {"reason": "Test"}},
-        ]
-        agent = MockRoverReasoner()
-        turn = agent.run_turn()
-        self.assertIn("already at station", turn["thinking"])
-        WORLD["agents"]["rover-mock"].pop("pending_commands", None)

--- a/server/tests/test_station.py
+++ b/server/tests/test_station.py
@@ -31,7 +31,7 @@ def _make_station_context():
         grid_h=20,
         rovers=[
             RoverSummary(
-                id="rover-mock",
+                id="rover-mistral",
                 position=[0, 0],
                 battery=1.0,
                 mission=AgentMission(objective="Explore the terrain", plan=[]),
@@ -62,7 +62,7 @@ class TestStationDefine(unittest.TestCase):
 
         tool_calls = [
             _mock_tool_call(
-                "assign_mission", {"agent_id": "rover-mock", "objective": "Explore north sector"}
+                "assign_mission", {"agent_id": "rover-mistral", "objective": "Explore north sector"}
             ),
         ]
         mock_client.chat.complete.return_value = _mock_client_response(
@@ -76,7 +76,7 @@ class TestStationDefine(unittest.TestCase):
         self.assertEqual(result["thinking"], "Assigning initial missions.")
         self.assertEqual(len(result["actions"]), 1)
         self.assertEqual(result["actions"][0]["name"], "assign_mission")
-        self.assertEqual(result["actions"][0]["params"]["agent_id"], "rover-mock")
+        self.assertEqual(result["actions"][0]["params"]["agent_id"], "rover-mistral")
         self.assertEqual(result["actions"][0]["params"]["objective"], "Explore north sector")
 
     @patch("app.station.settings")
@@ -123,7 +123,7 @@ class TestStationHandleEvent(unittest.TestCase):
         )
 
         event = {
-            "source": "rover-mock",
+            "source": "rover-mistral",
             "type": "event",
             "name": "check",
             "payload": {"stone": {"type": "basalt"}},
@@ -140,13 +140,13 @@ class TestStationHandleEvent(unittest.TestCase):
 class TestParseToolCalls(unittest.TestCase):
     def test_assign_mission_parsed(self):
         tool_calls = [
-            _mock_tool_call("assign_mission", {"agent_id": "rover-mock", "objective": "Go north"})
+            _mock_tool_call("assign_mission", {"agent_id": "rover-mistral", "objective": "Go north"})
         ]
         actions = _parse_tool_calls(tool_calls)
 
         self.assertEqual(len(actions), 1)
         self.assertEqual(actions[0]["name"], "assign_mission")
-        self.assertEqual(actions[0]["params"]["agent_id"], "rover-mock")
+        self.assertEqual(actions[0]["params"]["agent_id"], "rover-mistral")
 
     def test_broadcast_alert_parsed(self):
         tool_calls = [_mock_tool_call("broadcast_alert", {"message": "Storm incoming"})]
@@ -157,16 +157,16 @@ class TestParseToolCalls(unittest.TestCase):
         self.assertEqual(actions[0]["params"]["message"], "Storm incoming")
 
     def test_charge_rover_parsed(self):
-        tool_calls = [_mock_tool_call("charge_rover", {"rover_id": "rover-mock"})]
+        tool_calls = [_mock_tool_call("charge_rover", {"rover_id": "rover-mistral"})]
         actions = _parse_tool_calls(tool_calls)
 
         self.assertEqual(len(actions), 1)
         self.assertEqual(actions[0]["name"], "charge_rover")
-        self.assertEqual(actions[0]["params"]["rover_id"], "rover-mock")
+        self.assertEqual(actions[0]["params"]["rover_id"], "rover-mistral")
 
     def test_multiple_tool_calls_parsed(self):
         tool_calls = [
-            _mock_tool_call("assign_mission", {"agent_id": "rover-mock", "objective": "Go"}),
+            _mock_tool_call("assign_mission", {"agent_id": "rover-mistral", "objective": "Go"}),
             _mock_tool_call("broadcast_alert", {"message": "Alert"}),
         ]
         actions = _parse_tool_calls(tool_calls)
@@ -177,10 +177,10 @@ class TestExecuteAction(unittest.TestCase):
     def test_assign_mission(self):
         result = execute_action({
             "name": "assign_mission",
-            "params": {"agent_id": "rover-mock", "objective": "Go north"},
+            "params": {"agent_id": "rover-mistral", "objective": "Go north"},
         })
         self.assertTrue(result["ok"])
-        self.assertEqual(result["agent_id"], "rover-mock")
+        self.assertEqual(result["agent_id"], "rover-mistral")
 
     def test_broadcast_alert(self):
         result = execute_action({
@@ -192,11 +192,11 @@ class TestExecuteAction(unittest.TestCase):
 
     def test_charge_rover_at_station(self):
         from app.world import WORLD
-        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
-        WORLD["agents"]["rover-mock"]["battery"] = 0.5
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.5
         result = execute_action({
             "name": "charge_rover",
-            "params": {"rover_id": "rover-mock"},
+            "params": {"rover_id": "rover-mistral"},
         })
         self.assertTrue(result["ok"])
 
@@ -213,7 +213,7 @@ class TestBuildWorldSummary(unittest.TestCase):
     def test_summary_contains_rovers(self):
         ctx = _make_station_context()
         summary = _build_world_summary(ctx)
-        self.assertIn("rover-mock", summary)
+        self.assertIn("rover-mistral", summary)
         self.assertIn("rover-mistral", summary)
 
     def test_summary_contains_grid(self):

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -1,7 +1,7 @@
 import unittest
 
 from app.world import WORLD, GRID_W, GRID_H, move_agent, execute_action, get_snapshot, check_ground
-from app.world import check_mission_status, charge_rover
+from app.world import check_mission_status, charge_rover, charge_agent
 from app.world import BATTERY_COST_MOVE, BATTERY_COST_DIG, BATTERY_COST_PICKUP
 from app.world import BATTERY_COST_ANALYZE, BATTERY_COST_ANALYZE_GROUND
 from app.world import BATTERY_COST_SCAN, BATTERY_COST_MOVE_DRONE
@@ -15,56 +15,56 @@ from app.models import RoverContext, StationContext, StoneInfo
 
 class TestMoveAgent(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [2, 10]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["mission"] = {"objective": "Explore the terrain", "plan": []}
-        WORLD["agents"]["rover-mock"]["visited"] = [[2, 10]]
+        WORLD["agents"]["rover-mistral"]["position"] = [2, 10]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["visited"] = [[2, 10]]
 
     def test_move_success(self):
-        result = move_agent("rover-mock", 3, 10)
+        result = move_agent("rover-mistral", 3, 10)
         self.assertTrue(result["ok"])
         self.assertEqual(result["from"], [2, 10])
         self.assertEqual(result["to"], [3, 10])
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [3, 10])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [3, 10])
 
     def test_move_negative_coords_allowed(self):
         """Infinite grid: negative coordinates are valid."""
-        WORLD["agents"]["rover-mock"]["position"] = [0, 10]
-        result = move_agent("rover-mock", -1, 10)
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 10]
+        result = move_agent("rover-mistral", -1, 10)
         self.assertTrue(result["ok"])
         self.assertEqual(result["to"], [-1, 10])
 
     def test_move_beyond_old_bounds_allowed(self):
         """Infinite grid: moving beyond old 20x20 bounds is valid."""
-        WORLD["agents"]["rover-mock"]["position"] = [19, 10]
-        result = move_agent("rover-mock", 20, 10)
+        WORLD["agents"]["rover-mistral"]["position"] = [19, 10]
+        result = move_agent("rover-mistral", 20, 10)
         self.assertTrue(result["ok"])
         self.assertEqual(result["to"], [20, 10])
 
     def test_move_too_far(self):
-        result = move_agent("rover-mock", 6, 10)
+        result = move_agent("rover-mistral", 6, 10)
         self.assertFalse(result["ok"])
         self.assertIn("Too far", result["error"])
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [2, 10])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [2, 10])
 
     def test_move_diagonal_rejected(self):
-        result = move_agent("rover-mock", 3, 11)
+        result = move_agent("rover-mistral", 3, 11)
         self.assertFalse(result["ok"])
         self.assertIn("Not a straight line", result["error"])
 
     def test_move_multi_tile(self):
-        result = move_agent("rover-mock", 5, 10)
+        result = move_agent("rover-mistral", 5, 10)
         self.assertTrue(result["ok"])
         self.assertEqual(result["distance"], 3)
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [5, 10])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [5, 10])
 
     def test_move_2_tiles(self):
-        result = move_agent("rover-mock", 4, 10)
+        result = move_agent("rover-mistral", 4, 10)
         self.assertTrue(result["ok"])
         self.assertEqual(result["distance"], 2)
 
     def test_move_already_there(self):
-        result = move_agent("rover-mock", 2, 10)
+        result = move_agent("rover-mistral", 2, 10)
         self.assertFalse(result["ok"])
         self.assertIn("Already at", result["error"])
 
@@ -74,22 +74,22 @@ class TestMoveAgent(unittest.TestCase):
         self.assertIn("Unknown agent", result["error"])
 
     def test_move_sequential(self):
-        move_agent("rover-mock", 3, 10)
-        result = move_agent("rover-mock", 4, 10)
+        move_agent("rover-mistral", 3, 10)
+        result = move_agent("rover-mistral", 4, 10)
         self.assertTrue(result["ok"])
         self.assertEqual(result["from"], [3, 10])
         self.assertEqual(result["to"], [4, 10])
 
     def test_move_all_four_directions(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
         for tx, ty in [(11, 10), (10, 10), (10, 11), (10, 10)]:
-            result = move_agent("rover-mock", tx, ty)
+            result = move_agent("rover-mistral", tx, ty)
             self.assertTrue(result["ok"])
 
     def test_get_snapshot_is_copy(self):
         snap = get_snapshot()
-        snap["agents"]["rover-mock"]["position"] = [99, 99]
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [2, 10])
+        snap["agents"]["rover-mistral"]["position"] = [99, 99]
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [2, 10])
 
     def test_snapshot_has_grid(self):
         snap = get_snapshot()
@@ -99,37 +99,37 @@ class TestMoveAgent(unittest.TestCase):
 
 class TestExecuteAction(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [2, 10]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["mission"] = {"objective": "Explore the terrain", "plan": []}
-        WORLD["agents"]["rover-mock"]["visited"] = [[2, 10]]
+        WORLD["agents"]["rover-mistral"]["position"] = [2, 10]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["visited"] = [[2, 10]]
 
     def test_execute_move_east(self):
-        result = execute_action("rover-mock", "move", {"direction": "east"})
+        result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
         self.assertEqual(result["from"], [2, 10])
         self.assertEqual(result["to"], [3, 10])
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [3, 10])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [3, 10])
 
     def test_execute_move_drains_battery(self):
-        result = execute_action("rover-mock", "move", {"direction": "east"})
+        result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 1.0 - BATTERY_COST_MOVE)
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE)
 
     def test_execute_move_negative_ok(self):
         """Infinite grid: moving to negative coords succeeds."""
-        WORLD["agents"]["rover-mock"]["position"] = [0, 10]
-        result = execute_action("rover-mock", "move", {"direction": "west"})
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 10]
+        result = execute_action("rover-mistral", "move", {"direction": "west"})
         self.assertTrue(result["ok"])
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [-1, 10])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [-1, 10])
 
     def test_execute_move_invalid_direction(self):
-        result = execute_action("rover-mock", "move", {"direction": "up"})
+        result = execute_action("rover-mistral", "move", {"direction": "up"})
         self.assertFalse(result["ok"])
         self.assertIn("Invalid direction", result["error"])
 
     def test_execute_unknown_action(self):
-        result = execute_action("rover-mock", "drill", {})
+        result = execute_action("rover-mistral", "drill", {})
         self.assertFalse(result["ok"])
         self.assertIn("Unknown action", result["error"])
 
@@ -140,54 +140,54 @@ class TestExecuteAction(unittest.TestCase):
 
     def test_execute_move_all_directions(self):
         """North = +Y, South = -Y with flipped coordinate system."""
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
         for direction, expected in [
             ("north", [10, 11]),
             ("south", [10, 9]),
             ("east", [11, 10]),
             ("west", [10, 10]),
         ]:
-            result = execute_action("rover-mock", "move", {"direction": direction})
+            result = execute_action("rover-mistral", "move", {"direction": direction})
             self.assertTrue(result["ok"], f"Failed for direction {direction}")
 
     def test_execute_move_multi_tile(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
-        result = execute_action("rover-mock", "move", {"direction": "east", "distance": 3})
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
+        result = execute_action("rover-mistral", "move", {"direction": "east", "distance": 3})
         self.assertTrue(result["ok"])
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [13, 10])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [13, 10])
         self.assertAlmostEqual(
-            WORLD["agents"]["rover-mock"]["battery"], 1.0 - BATTERY_COST_MOVE * 3
+            WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE * 3
         )
 
     def test_execute_move_multi_visits_intermediate(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
-        execute_action("rover-mock", "move", {"direction": "east", "distance": 3})
-        visited = WORLD["agents"]["rover-mock"]["visited"]
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
+        execute_action("rover-mistral", "move", {"direction": "east", "distance": 3})
+        visited = WORLD["agents"]["rover-mistral"]["visited"]
         self.assertIn([11, 10], visited)
         self.assertIn([12, 10], visited)
         self.assertIn([13, 10], visited)
 
     def test_execute_move_no_battery(self):
         """Move should fail when battery is too low."""
-        WORLD["agents"]["rover-mock"]["battery"] = 0.0
-        result = execute_action("rover-mock", "move", {"direction": "east"})
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.0
+        result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [2, 10])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [2, 10])
 
     def test_execute_move_insufficient_battery_multi(self):
         """Multi-tile move should fail when battery < cost for full distance."""
-        WORLD["agents"]["rover-mock"]["battery"] = (
+        WORLD["agents"]["rover-mistral"]["battery"] = (
             BATTERY_COST_MOVE * 2
         )  # enough for ~1-2 tiles, not 3
-        result = execute_action("rover-mock", "move", {"direction": "east", "distance": 3})
+        result = execute_action("rover-mistral", "move", {"direction": "east", "distance": 3})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [2, 10])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [2, 10])
 
     def test_mission_in_snapshot(self):
         snap = get_snapshot()
-        agent = snap["agents"]["rover-mock"]
+        agent = snap["agents"]["rover-mistral"]
         self.assertIn("mission", agent)
         self.assertEqual(agent["mission"]["objective"], "Explore the terrain")
         self.assertEqual(agent["mission"]["plan"], [])
@@ -241,12 +241,6 @@ class TestStones(unittest.TestCase):
 
     def test_concentration_map_exists(self):
         self.assertIn("concentration_map", WORLD)
-        conc = WORLD["concentration_map"]
-        self.assertGreater(len(conc), 0)
-        # Values should be between 0 and 1
-        for v in conc.values():
-            self.assertGreaterEqual(v, 0.0)
-            self.assertLessEqual(v, 1.0)
 
     def test_concentration_map_serialized_in_snapshot(self):
         snap = get_snapshot()
@@ -259,32 +253,32 @@ class TestStones(unittest.TestCase):
 
 class TestVisited(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["mission"] = {"objective": "Explore the terrain", "plan": []}
-        WORLD["agents"]["rover-mock"]["visited"] = [[10, 10]]
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["visited"] = [[10, 10]]
 
     def test_visited_initial(self):
-        self.assertEqual(WORLD["agents"]["rover-mock"]["visited"], [[10, 10]])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["visited"], [[10, 10]])
 
     def test_move_updates_visited(self):
-        execute_action("rover-mock", "move", {"direction": "east"})
-        visited = WORLD["agents"]["rover-mock"]["visited"]
+        execute_action("rover-mistral", "move", {"direction": "east"})
+        visited = WORLD["agents"]["rover-mistral"]["visited"]
         self.assertIn([11, 10], visited)
 
     def test_visited_no_duplicates(self):
-        execute_action("rover-mock", "move", {"direction": "east"})
-        execute_action("rover-mock", "move", {"direction": "west"})
-        visited = WORLD["agents"]["rover-mock"]["visited"]
+        execute_action("rover-mistral", "move", {"direction": "east"})
+        execute_action("rover-mistral", "move", {"direction": "west"})
+        visited = WORLD["agents"]["rover-mistral"]["visited"]
         self.assertEqual(visited.count([10, 10]), 1)
 
 
 class TestCheckGround(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["mission"] = {"objective": "Explore the terrain", "plan": []}
-        WORLD["agents"]["rover-mock"]["visited"] = [[10, 10]]
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["visited"] = [[10, 10]]
         self._original_stones = WORLD.get("stones", [])
 
     def tearDown(self):
@@ -300,7 +294,7 @@ class TestCheckGround(unittest.TestCase):
                 "analyzed": False,
             }
         ]
-        result = check_ground("rover-mock")
+        result = check_ground("rover-mistral")
         self.assertEqual(result["stone"]["type"], "unknown")
         self.assertFalse(result["stone"]["extracted"])
 
@@ -314,7 +308,7 @@ class TestCheckGround(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        result = check_ground("rover-mock")
+        result = check_ground("rover-mistral")
         self.assertEqual(result["stone"]["type"], "core")
         self.assertTrue(result["stone"]["extracted"])
 
@@ -328,12 +322,12 @@ class TestCheckGround(unittest.TestCase):
                 "analyzed": False,
             }
         ]
-        result = check_ground("rover-mock")
+        result = check_ground("rover-mistral")
         self.assertIsNone(result["stone"])
 
     def test_move_result_includes_ground(self):
         WORLD["stones"] = []
-        result = execute_action("rover-mock", "move", {"direction": "east"})
+        result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
         self.assertIn("ground", result)
         self.assertIsNone(result["ground"]["stone"])
@@ -341,17 +335,17 @@ class TestCheckGround(unittest.TestCase):
 
 class TestAssignMission(unittest.TestCase):
     def setUp(self):
-        self._orig = WORLD["agents"]["rover-mock"]["mission"].copy()
+        self._orig = WORLD["agents"]["rover-mistral"]["mission"].copy()
 
     def tearDown(self):
-        WORLD["agents"]["rover-mock"]["mission"] = self._orig
+        WORLD["agents"]["rover-mistral"]["mission"] = self._orig
 
     def test_assign_mission_success(self):
-        result = assign_mission("rover-mock", "Go to north edge")
+        result = assign_mission("rover-mistral", "Go to north edge")
         self.assertTrue(result["ok"])
-        self.assertEqual(result["agent_id"], "rover-mock")
+        self.assertEqual(result["agent_id"], "rover-mistral")
         self.assertEqual(result["objective"], "Go to north edge")
-        self.assertEqual(WORLD["agents"]["rover-mock"]["mission"]["objective"], "Go to north edge")
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["mission"]["objective"], "Go to north edge")
 
     def test_assign_mission_unknown_agent(self):
         result = assign_mission("rover-99", "Go anywhere")
@@ -359,9 +353,9 @@ class TestAssignMission(unittest.TestCase):
         self.assertIn("Unknown agent", result["error"])
 
     def test_assign_mission_preserves_plan(self):
-        WORLD["agents"]["rover-mock"]["mission"]["plan"] = ["step1"]
-        assign_mission("rover-mock", "New objective")
-        self.assertEqual(WORLD["agents"]["rover-mock"]["mission"]["plan"], ["step1"])
+        WORLD["agents"]["rover-mistral"]["mission"]["plan"] = ["step1"]
+        assign_mission("rover-mistral", "New objective")
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["mission"]["plan"], ["step1"])
 
 
 class TestStationInWorld(unittest.TestCase):
@@ -382,11 +376,11 @@ class TestAnalyze(unittest.TestCase):
     """Test the analyze action that reveals hidden stone types."""
 
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["visited"] = [[5, 5]]
-        WORLD["agents"]["rover-mock"]["memory"] = []
+        WORLD["agents"]["rover-mistral"]["position"] = [5, 5]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["visited"] = [[5, 5]]
+        WORLD["agents"]["rover-mistral"]["memory"] = []
         self._original_stones = WORLD.get("stones", [])
         WORLD["stones"] = [
             {
@@ -402,19 +396,19 @@ class TestAnalyze(unittest.TestCase):
         WORLD["stones"] = self._original_stones
 
     def test_analyze_reveals_type(self):
-        result = execute_action("rover-mock", "analyze", {})
+        result = execute_action("rover-mistral", "analyze", {})
         self.assertTrue(result["ok"])
         self.assertEqual(result["stone"]["type"], "core")
         self.assertTrue(WORLD["stones"][0]["analyzed"])
         self.assertEqual(WORLD["stones"][0]["type"], "core")
 
     def test_analyze_drains_battery(self):
-        execute_action("rover-mock", "analyze", {})
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 1.0 - BATTERY_COST_ANALYZE)
+        execute_action("rover-mistral", "analyze", {})
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_ANALYZE)
 
     def test_analyze_no_stone(self):
         WORLD["stones"] = []
-        result = execute_action("rover-mock", "analyze", {})
+        result = execute_action("rover-mistral", "analyze", {})
         self.assertFalse(result["ok"])
         self.assertIn("No stone", result["error"])
 
@@ -428,7 +422,7 @@ class TestAnalyze(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        result = execute_action("rover-mock", "analyze", {})
+        result = execute_action("rover-mistral", "analyze", {})
         self.assertFalse(result["ok"])
         self.assertIn("already analyzed", result["error"])
 
@@ -438,14 +432,14 @@ class TestAnalyze(unittest.TestCase):
         self.assertIn("Unknown agent", result["error"])
 
     def test_analyze_not_enough_battery(self):
-        WORLD["agents"]["rover-mock"]["battery"] = BATTERY_COST_ANALYZE * 0.5  # below analyze cost
-        result = execute_action("rover-mock", "analyze", {})
+        WORLD["agents"]["rover-mistral"]["battery"] = BATTERY_COST_ANALYZE * 0.5  # below analyze cost
+        result = execute_action("rover-mistral", "analyze", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
 
     def test_analyze_records_memory(self):
-        execute_action("rover-mock", "analyze", {})
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        execute_action("rover-mistral", "analyze", {})
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
         self.assertIn("Analyzed", mem[0])
         self.assertIn("core", mem[0])
@@ -455,50 +449,50 @@ class TestAnalyzeGround(unittest.TestCase):
     """Test the analyze_ground action that reads concentration."""
 
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["visited"] = [[5, 5]]
-        WORLD["agents"]["rover-mock"]["memory"] = []
-        WORLD["agents"]["rover-mock"]["ground_readings"] = {}
+        WORLD["agents"]["rover-mistral"]["position"] = [5, 5]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["visited"] = [[5, 5]]
+        WORLD["agents"]["rover-mistral"]["memory"] = []
+        WORLD["agents"]["rover-mistral"]["ground_readings"] = {}
 
     def test_analyze_ground_returns_concentration(self):
-        result = execute_action("rover-mock", "analyze_ground", {})
+        result = execute_action("rover-mistral", "analyze_ground", {})
         self.assertTrue(result["ok"])
         self.assertIn("concentration", result)
         self.assertGreaterEqual(result["concentration"], 0.0)
         self.assertLessEqual(result["concentration"], 1.0)
 
     def test_analyze_ground_drains_battery(self):
-        execute_action("rover-mock", "analyze_ground", {})
+        execute_action("rover-mistral", "analyze_ground", {})
         self.assertAlmostEqual(
-            WORLD["agents"]["rover-mock"]["battery"], 1.0 - BATTERY_COST_ANALYZE_GROUND
+            WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_ANALYZE_GROUND
         )
 
     def test_analyze_ground_stores_reading(self):
-        execute_action("rover-mock", "analyze_ground", {})
-        readings = WORLD["agents"]["rover-mock"]["ground_readings"]
+        execute_action("rover-mistral", "analyze_ground", {})
+        readings = WORLD["agents"]["rover-mistral"]["ground_readings"]
         self.assertIn("5,5", readings)
 
     def test_analyze_ground_not_enough_battery(self):
-        WORLD["agents"]["rover-mock"]["battery"] = BATTERY_COST_ANALYZE_GROUND * 0.5  # below cost
-        result = execute_action("rover-mock", "analyze_ground", {})
+        WORLD["agents"]["rover-mistral"]["battery"] = BATTERY_COST_ANALYZE_GROUND * 0.5  # below cost
+        result = execute_action("rover-mistral", "analyze_ground", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
 
     def test_analyze_ground_records_memory(self):
-        execute_action("rover-mock", "analyze_ground", {})
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        execute_action("rover-mistral", "analyze_ground", {})
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
         self.assertIn("Ground concentration", mem[0])
 
 
 class TestDig(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["visited"] = [[5, 5]]
+        WORLD["agents"]["rover-mistral"]["position"] = [5, 5]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["visited"] = [[5, 5]]
         self._original_stones = WORLD.get("stones", [])
         WORLD["stones"] = [
             {
@@ -514,18 +508,18 @@ class TestDig(unittest.TestCase):
         WORLD["stones"] = self._original_stones
 
     def test_dig_extracts_stone(self):
-        result = execute_action("rover-mock", "dig", {})
+        result = execute_action("rover-mistral", "dig", {})
         self.assertTrue(result["ok"])
         self.assertEqual(result["stone"], {"type": "core"})
         self.assertTrue(WORLD["stones"][0]["extracted"])
 
     def test_dig_drains_battery(self):
-        execute_action("rover-mock", "dig", {})
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 1.0 - BATTERY_COST_DIG)
+        execute_action("rover-mistral", "dig", {})
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG)
 
     def test_dig_no_stone(self):
         WORLD["stones"] = []
-        result = execute_action("rover-mock", "dig", {})
+        result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("No stone", result["error"])
 
@@ -539,22 +533,22 @@ class TestDig(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        result = execute_action("rover-mock", "dig", {})
+        result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("already extracted", result["error"])
 
     def test_dig_not_enough_battery(self):
-        WORLD["agents"]["rover-mock"]["battery"] = BATTERY_COST_DIG * 0.5  # below dig cost
-        result = execute_action("rover-mock", "dig", {})
+        WORLD["agents"]["rover-mistral"]["battery"] = BATTERY_COST_DIG * 0.5  # below dig cost
+        result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], BATTERY_COST_DIG * 0.5)
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5)
 
     def test_dig_failed_no_drain(self):
         WORLD["stones"] = []
-        old_battery = WORLD["agents"]["rover-mock"]["battery"]
-        execute_action("rover-mock", "dig", {})
-        self.assertEqual(WORLD["agents"]["rover-mock"]["battery"], old_battery)
+        old_battery = WORLD["agents"]["rover-mistral"]["battery"]
+        execute_action("rover-mistral", "dig", {})
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["battery"], old_battery)
 
     def test_dig_requires_analyze(self):
         """Dig should fail if stone is not yet analyzed."""
@@ -567,17 +561,17 @@ class TestDig(unittest.TestCase):
                 "analyzed": False,
             }
         ]
-        result = execute_action("rover-mock", "dig", {})
+        result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("not yet analyzed", result["error"])
 
 
 class TestPickup(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["visited"] = [[5, 5]]
+        WORLD["agents"]["rover-mistral"]["position"] = [5, 5]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["visited"] = [[5, 5]]
         self._original_stones = WORLD.get("stones", [])
         WORLD["stones"] = [
             {
@@ -593,24 +587,24 @@ class TestPickup(unittest.TestCase):
         WORLD["stones"] = self._original_stones
 
     def test_pickup_success(self):
-        result = execute_action("rover-mock", "pickup", {})
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertTrue(result["ok"])
         self.assertEqual(result["stone"], {"type": "core"})
         self.assertEqual(result["inventory_count"], 1)
 
     def test_pickup_adds_to_inventory(self):
-        execute_action("rover-mock", "pickup", {})
-        inv = WORLD["agents"]["rover-mock"]["inventory"]
+        execute_action("rover-mistral", "pickup", {})
+        inv = WORLD["agents"]["rover-mistral"]["inventory"]
         self.assertEqual(len(inv), 1)
         self.assertEqual(inv[0]["type"], "core")
 
     def test_pickup_removes_stone_from_world(self):
-        execute_action("rover-mock", "pickup", {})
+        execute_action("rover-mistral", "pickup", {})
         self.assertEqual(len(WORLD["stones"]), 0)
 
     def test_pickup_drains_battery(self):
-        execute_action("rover-mock", "pickup", {})
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 1.0 - BATTERY_COST_PICKUP)
+        execute_action("rover-mistral", "pickup", {})
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_PICKUP)
 
     def test_pickup_not_extracted(self):
         WORLD["stones"] = [
@@ -622,19 +616,19 @@ class TestPickup(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        result = execute_action("rover-mock", "pickup", {})
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertFalse(result["ok"])
         self.assertIn("not yet extracted", result["error"])
 
     def test_pickup_no_stone(self):
         WORLD["stones"] = []
-        result = execute_action("rover-mock", "pickup", {})
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertFalse(result["ok"])
         self.assertIn("No stone", result["error"])
 
     def test_pickup_not_enough_battery(self):
-        WORLD["agents"]["rover-mock"]["battery"] = 0.0
-        result = execute_action("rover-mock", "pickup", {})
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.0
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
 
@@ -649,7 +643,7 @@ class TestPickup(unittest.TestCase):
                 "analyzed": False,
             }
         ]
-        result = execute_action("rover-mock", "pickup", {})
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertFalse(result["ok"])
         self.assertIn("not yet analyzed", result["error"])
 
@@ -663,11 +657,11 @@ class TestPickup(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        result = execute_action("rover-mock", "dig", {})
+        result = execute_action("rover-mistral", "dig", {})
         self.assertTrue(result["ok"])
-        result = execute_action("rover-mock", "pickup", {})
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertTrue(result["ok"])
-        self.assertEqual(len(WORLD["agents"]["rover-mock"]["inventory"]), 1)
+        self.assertEqual(len(WORLD["agents"]["rover-mistral"]["inventory"]), 1)
         self.assertEqual(len(WORLD["stones"]), 0)
 
     def test_analyze_dig_pickup_workflow(self):
@@ -681,94 +675,92 @@ class TestPickup(unittest.TestCase):
                 "analyzed": False,
             }
         ]
-        result = execute_action("rover-mock", "analyze", {})
+        result = execute_action("rover-mistral", "analyze", {})
         self.assertTrue(result["ok"])
         self.assertEqual(result["stone"]["type"], "core")
-        result = execute_action("rover-mock", "dig", {})
+        result = execute_action("rover-mistral", "dig", {})
         self.assertTrue(result["ok"])
-        result = execute_action("rover-mock", "pickup", {})
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertTrue(result["ok"])
-        self.assertEqual(len(WORLD["agents"]["rover-mock"]["inventory"]), 1)
+        self.assertEqual(len(WORLD["agents"]["rover-mistral"]["inventory"]), 1)
 
 
 class TestCharge(unittest.TestCase):
     """Charging is a station-only action via charge_rover()."""
 
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
-        WORLD["agents"]["rover-mock"]["battery"] = 0.5
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["visited"] = [[0, 0]]
-        WORLD["agents"]["rover-mock"]["memory"] = []
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.5
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["visited"] = [[0, 0]]
+        WORLD["agents"]["rover-mistral"]["memory"] = []
         WORLD["agents"]["station"]["position"] = [0, 0]
 
     def test_charge_rover_success(self):
-        result = charge_rover("rover-mock")
+        result = charge_rover("rover-mistral")
         self.assertTrue(result["ok"])
         self.assertAlmostEqual(result["battery_before"], 0.5)
         self.assertAlmostEqual(result["battery_after"], 0.5 + CHARGE_RATE)
 
     def test_charge_rover_increases_battery(self):
-        charge_rover("rover-mock")
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 0.5 + CHARGE_RATE)
+        charge_rover("rover-mistral")
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 0.5 + CHARGE_RATE)
 
     def test_charge_rover_caps_at_full(self):
-        WORLD["agents"]["rover-mock"]["battery"] = 0.95
-        charge_rover("rover-mock")
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 1.0)
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.95
+        charge_rover("rover-mistral")
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 1.0)
 
     def test_charge_rover_already_full(self):
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        result = charge_rover("rover-mock")
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        result = charge_rover("rover-mistral")
         self.assertFalse(result["ok"])
         self.assertIn("already full", result["error"])
 
     def test_charge_rover_not_at_station(self):
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        result = charge_rover("rover-mock")
+        WORLD["agents"]["rover-mistral"]["position"] = [5, 5]
+        result = charge_rover("rover-mistral")
         self.assertFalse(result["ok"])
         self.assertIn("Not at station", result["error"])
 
     def test_charge_rover_multiple_times(self):
-        WORLD["agents"]["rover-mock"]["battery"] = 0.1
-        charge_rover("rover-mock")
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 0.1 + CHARGE_RATE)
-        charge_rover("rover-mock")
-        self.assertAlmostEqual(WORLD["agents"]["rover-mock"]["battery"], 0.1 + 2 * CHARGE_RATE)
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.1
+        charge_rover("rover-mistral")
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 0.1 + CHARGE_RATE)
+        charge_rover("rover-mistral")
+        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE)
 
     def test_charge_rover_unknown_agent(self):
         result = charge_rover("rover-99")
         self.assertFalse(result["ok"])
         self.assertIn("Unknown agent", result["error"])
 
-    def test_charge_rover_rejects_non_rover(self):
-        result = charge_rover("station")
+    def test_charge_agent_rejects_station(self):
+        result = charge_agent("station")
         self.assertFalse(result["ok"])
-        self.assertIn("not a rover", result["error"])
+        self.assertIn("is a station", result["error"])
 
     def test_charge_rover_records_memory(self):
-        charge_rover("rover-mock")
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        charge_rover("rover-mistral")
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
         self.assertIn("Station charged", mem[0])
 
     def test_charge_not_available_as_rover_action(self):
-        result = execute_action("rover-mock", "charge", {})
+        result = execute_action("rover-mistral", "charge", {})
         self.assertFalse(result["ok"])
         self.assertIn("Unknown action", result["error"])
 
 
 class TestFogOfWar(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["visited"] = [[10, 10]]
-        WORLD["agents"]["rover-mock"]["revealed"] = [
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["visited"] = [[10, 10]]
+        WORLD["agents"]["rover-mistral"]["revealed"] = [
             [x, y] for x, y in sorted(_cells_in_radius(10, 10, REVEAL_RADIUS))
         ]
-        # Give rover-mistral an empty revealed so it doesn't interfere
-        WORLD["agents"]["rover-mistral"]["revealed"] = []
         # Give drone an empty revealed so it doesn't interfere
         if "drone-mistral" in WORLD["agents"]:
             self._original_drone_revealed = WORLD["agents"]["drone-mistral"].get("revealed", [])
@@ -785,35 +777,35 @@ class TestFogOfWar(unittest.TestCase):
             WORLD["agents"]["drone-mistral"]["revealed"] = self._original_drone_revealed
 
     def test_initial_revealed_cells_count(self):
-        revealed = WORLD["agents"]["rover-mock"]["revealed"]
+        revealed = WORLD["agents"]["rover-mistral"]["revealed"]
         expected = _cells_in_radius(10, 10, REVEAL_RADIUS)
         self.assertEqual(len(revealed), len(expected))
 
     def test_initial_revealed_contains_start(self):
-        revealed = WORLD["agents"]["rover-mock"]["revealed"]
+        revealed = WORLD["agents"]["rover-mistral"]["revealed"]
         self.assertIn([10, 10], revealed)
 
     def test_initial_revealed_contains_neighbors(self):
-        revealed = WORLD["agents"]["rover-mock"]["revealed"]
+        revealed = WORLD["agents"]["rover-mistral"]["revealed"]
         for pos in [[10, 9], [10, 11], [9, 10], [11, 10]]:
             self.assertIn(pos, revealed)
 
     def test_move_expands_revealed(self):
-        before = len(WORLD["agents"]["rover-mock"]["revealed"])
-        execute_action("rover-mock", "move", {"direction": "east"})
-        after = len(WORLD["agents"]["rover-mock"]["revealed"])
+        before = len(WORLD["agents"]["rover-mistral"]["revealed"])
+        execute_action("rover-mistral", "move", {"direction": "east"})
+        after = len(WORLD["agents"]["rover-mistral"]["revealed"])
         self.assertGreater(after, before)
 
     def test_move_reveals_new_cells(self):
-        execute_action("rover-mock", "move", {"direction": "east"})
-        revealed = WORLD["agents"]["rover-mock"]["revealed"]
+        execute_action("rover-mistral", "move", {"direction": "east"})
+        revealed = WORLD["agents"]["rover-mistral"]["revealed"]
         # (13, 10) is radius-2 east of new position (11, 10)
         self.assertIn([13, 10], revealed)
 
     def test_move_no_duplicate_revealed(self):
-        execute_action("rover-mock", "move", {"direction": "east"})
-        execute_action("rover-mock", "move", {"direction": "west"})
-        revealed = WORLD["agents"]["rover-mock"]["revealed"]
+        execute_action("rover-mistral", "move", {"direction": "east"})
+        execute_action("rover-mistral", "move", {"direction": "west"})
+        revealed = WORLD["agents"]["rover-mistral"]["revealed"]
         # Check no duplicates
         as_tuples = [tuple(c) for c in revealed]
         self.assertEqual(len(as_tuples), len(set(as_tuples)))
@@ -833,7 +825,7 @@ class TestFogOfWar(unittest.TestCase):
         self.assertEqual(len(snap["stones"]), 0)
 
     def test_snapshot_shows_revealed_stones(self):
-        # Place a stone within rover-mock's revealed area
+        # Place a stone within rover-mistral's revealed area
         WORLD["stones"] = [
             {
                 "position": [10, 10],
@@ -881,7 +873,7 @@ class TestFogOfWar(unittest.TestCase):
         ]
         snap_before = get_snapshot()
         self.assertEqual(len(snap_before["stones"]), 0)
-        execute_action("rover-mock", "move", {"direction": "east"})
+        execute_action("rover-mistral", "move", {"direction": "east"})
         snap_after = get_snapshot()
         self.assertEqual(len(snap_after["stones"]), 1)
 
@@ -897,18 +889,15 @@ class TestFogOfWar(unittest.TestCase):
 
     def test_revealed_in_snapshot(self):
         snap = get_snapshot()
-        self.assertIn("revealed", snap["agents"]["rover-mock"])
+        self.assertIn("revealed", snap["agents"]["rover-mistral"])
 
 
 class TestMissionCompletion(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["visited"] = [[5, 5]]
-        WORLD["agents"]["rover-mistral"]["position"] = [2, 12]
+        WORLD["agents"]["rover-mistral"]["position"] = [5, 5]
         WORLD["agents"]["rover-mistral"]["battery"] = 1.0
         WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["visited"] = [[5, 5]]
         self._original_stones = WORLD.get("stones", [])
         self._original_mission = WORLD["mission"].copy()
         WORLD["mission"]["status"] = "running"
@@ -939,7 +928,7 @@ class TestMissionCompletion(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        execute_action("rover-mock", "pickup", {})
+        execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["collected_count"], 1)
 
     def test_non_target_stone_not_counted(self):
@@ -952,7 +941,7 @@ class TestMissionCompletion(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        execute_action("rover-mock", "pickup", {})
+        execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["collected_count"], 0)
 
     def test_pickup_away_from_station_no_success(self):
@@ -967,7 +956,7 @@ class TestMissionCompletion(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        result = execute_action("rover-mock", "pickup", {})
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "running")
         self.assertNotIn("mission", result)
         self.assertEqual(WORLD["mission"]["collected_count"], 1)
@@ -975,7 +964,7 @@ class TestMissionCompletion(unittest.TestCase):
     def test_mission_success_on_delivery_to_station(self):
         """Success requires the rover to deliver the stone to the station."""
         WORLD["mission"]["target_count"] = 1
-        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
         WORLD["agents"]["station"]["position"] = [0, 0]
         WORLD["stones"] = [
             {
@@ -986,7 +975,7 @@ class TestMissionCompletion(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        result = execute_action("rover-mock", "pickup", {})
+        result = execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "success")
         self.assertIn("mission", result)
         self.assertEqual(result["mission"]["status"], "success")
@@ -994,11 +983,11 @@ class TestMissionCompletion(unittest.TestCase):
     def test_mission_success_on_move_to_station_with_stone(self):
         """Moving to station while carrying target stone triggers success."""
         WORLD["mission"]["target_count"] = 1
-        WORLD["agents"]["rover-mock"]["position"] = [1, 0]
-        WORLD["agents"]["rover-mock"]["inventory"] = [{"type": "core"}]
+        WORLD["agents"]["rover-mistral"]["position"] = [1, 0]
+        WORLD["agents"]["rover-mistral"]["inventory"] = [{"type": "core"}]
         WORLD["agents"]["station"]["position"] = [0, 0]
         WORLD["stones"] = []
-        result = execute_action("rover-mock", "move", {"direction": "west"})
+        result = execute_action("rover-mistral", "move", {"direction": "west"})
         self.assertEqual(WORLD["mission"]["status"], "success")
         self.assertIn("mission", result)
 
@@ -1006,7 +995,7 @@ class TestMissionCompletion(unittest.TestCase):
         WORLD["mission"]["target_count"] = 2
         WORLD["agents"]["station"]["position"] = [0, 0]
         # Rover-mock picks up one core at station
-        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
         WORLD["stones"] = [
             {
                 "position": [0, 0],
@@ -1016,7 +1005,7 @@ class TestMissionCompletion(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        execute_action("rover-mock", "pickup", {})
+        execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "running")
         # Rover-mistral picks up another core at station
         WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
@@ -1035,12 +1024,11 @@ class TestMissionCompletion(unittest.TestCase):
         self.assertIn("mission", result)
 
     def test_mission_failed_all_rovers_depleted(self):
-        WORLD["agents"]["rover-mock"]["battery"] = BATTERY_COST_MOVE
-        WORLD["agents"]["rover-mistral"]["battery"] = 0.0
+        WORLD["agents"]["rover-mistral"]["battery"] = BATTERY_COST_MOVE
         WORLD["agents"]["rover-mistral"]["position"] = [15, 15]
         WORLD["stones"] = []
-        # This move will drain rover-mock to 0
-        result = execute_action("rover-mock", "move", {"direction": "east"})
+        # This move will drain rover-mistral to 0
+        result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
         self.assertEqual(WORLD["mission"]["status"], "failed")
         self.assertIn("mission", result)
@@ -1048,14 +1036,13 @@ class TestMissionCompletion(unittest.TestCase):
 
     def test_rover_at_station_not_failed(self):
         # Even with 0 battery, rover at station can charge — not failed
-        WORLD["agents"]["rover-mock"]["battery"] = BATTERY_COST_MOVE
-        WORLD["agents"]["rover-mock"]["position"] = [1, 0]
         WORLD["agents"]["rover-mistral"]["battery"] = 0.0
         WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
         WORLD["agents"]["station"]["position"] = [0, 0]
         WORLD["stones"] = []
-        # Move rover-mock, draining to 0 — but rover-mistral is at station
-        execute_action("rover-mock", "move", {"direction": "west"})
+        # Rover at station with 0 battery — should not be failed
+        result = check_mission_status()
+        self.assertIsNone(result)
         self.assertNotEqual(WORLD["mission"]["status"], "failed")
 
     def test_no_status_change_after_terminal(self):
@@ -1066,28 +1053,28 @@ class TestMissionCompletion(unittest.TestCase):
     def test_move_does_not_trigger_success(self):
         # Move shouldn't trigger success (no pickup happened)
         WORLD["stones"] = []
-        result = execute_action("rover-mock", "move", {"direction": "east"})
+        result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
         self.assertNotIn("mission", result)
 
 
 class TestMemory(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [10, 10]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["visited"] = [[10, 10]]
-        WORLD["agents"]["rover-mock"]["memory"] = []
+        WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["visited"] = [[10, 10]]
+        WORLD["agents"]["rover-mistral"]["memory"] = []
         self._original_stones = WORLD.get("stones", [])
 
     def tearDown(self):
         WORLD["stones"] = self._original_stones
-        WORLD["agents"]["rover-mock"]["memory"] = []
+        WORLD["agents"]["rover-mistral"]["memory"] = []
 
     def test_move_records_memory(self):
         WORLD["stones"] = []
-        execute_action("rover-mock", "move", {"direction": "east"})
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        execute_action("rover-mistral", "move", {"direction": "east"})
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
         self.assertIn("Moved east", mem[0])
         self.assertIn("(11,10)", mem[0])
@@ -1102,8 +1089,8 @@ class TestMemory(unittest.TestCase):
                 "analyzed": False,
             }
         ]
-        execute_action("rover-mock", "move", {"direction": "east"})
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        execute_action("rover-mistral", "move", {"direction": "east"})
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertIn("unknown", mem[0])
 
     def test_dig_records_memory(self):
@@ -1116,8 +1103,8 @@ class TestMemory(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        execute_action("rover-mock", "dig", {})
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        execute_action("rover-mistral", "dig", {})
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
         self.assertIn("Dug out basalt", mem[0])
 
@@ -1131,40 +1118,40 @@ class TestMemory(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        execute_action("rover-mock", "pickup", {})
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        execute_action("rover-mistral", "pickup", {})
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
         self.assertIn("Picked up core", mem[0])
         self.assertIn("inventory=1", mem[0])
 
     def test_charge_records_memory(self):
-        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
-        WORLD["agents"]["rover-mock"]["battery"] = 0.5
-        charge_rover("rover-mock")
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.5
+        charge_rover("rover-mistral")
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
         self.assertIn("Station charged", mem[0])
 
     def test_failed_action_records_memory(self):
         WORLD["stones"] = []
-        execute_action("rover-mock", "dig", {})
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+        execute_action("rover-mistral", "dig", {})
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
         self.assertIn("Failed dig", mem[0])
 
     def test_memory_capped_at_max(self):
         for i in range(MEMORY_MAX + 5):
-            record_memory("rover-mock", f"entry {i}")
-        mem = WORLD["agents"]["rover-mock"]["memory"]
+            record_memory("rover-mistral", f"entry {i}")
+        mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), MEMORY_MAX)
         self.assertEqual(mem[0], f"entry {5}")
         self.assertEqual(mem[-1], f"entry {MEMORY_MAX + 4}")
 
     def test_memory_in_snapshot(self):
-        record_memory("rover-mock", "test entry")
+        record_memory("rover-mistral", "test entry")
         snap = get_snapshot()
-        self.assertIn("memory", snap["agents"]["rover-mock"])
-        self.assertEqual(snap["agents"]["rover-mock"]["memory"], ["test entry"])
+        self.assertIn("memory", snap["agents"]["rover-mistral"])
+        self.assertEqual(snap["agents"]["rover-mistral"]["memory"], ["test entry"])
 
     def test_record_memory_unknown_agent(self):
         # Should not raise
@@ -1195,24 +1182,28 @@ class TestDirectionHint(unittest.TestCase):
 
 class TestUpdateTasks(unittest.TestCase):
     def setUp(self):
-        self._orig_pos = WORLD["agents"]["rover-mock"]["position"][:]
-        self._orig_inv = WORLD["agents"]["rover-mock"].get("inventory", [])[:]
+        self._orig_pos = WORLD["agents"]["rover-mistral"]["position"][:]
+        self._orig_inv = WORLD["agents"]["rover-mistral"].get("inventory", [])[:]
         self._orig_stones = WORLD.get("stones", [])[:]
-        self._orig_tasks = WORLD["agents"]["rover-mock"].get("tasks", [])[:]
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["tasks"] = []
+        self._orig_tasks = WORLD["agents"]["rover-mistral"].get("tasks", [])[:]
+        self._orig_mission = WORLD["mission"].copy()
+        WORLD["agents"]["rover-mistral"]["position"] = [5, 5]
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["tasks"] = []
+        WORLD["mission"]["status"] = "running"
+        WORLD["mission"]["collected_count"] = 0
 
     def tearDown(self):
-        WORLD["agents"]["rover-mock"]["position"] = self._orig_pos
-        WORLD["agents"]["rover-mock"]["inventory"] = self._orig_inv
+        WORLD["agents"]["rover-mistral"]["position"] = self._orig_pos
+        WORLD["agents"]["rover-mistral"]["inventory"] = self._orig_inv
         WORLD["stones"] = self._orig_stones
-        WORLD["agents"]["rover-mock"]["tasks"] = self._orig_tasks
+        WORLD["agents"]["rover-mistral"]["tasks"] = self._orig_tasks
+        WORLD["mission"] = self._orig_mission
 
     def test_explore_when_no_stones(self):
         WORLD["stones"] = []
-        update_tasks("rover-mock")
-        tasks = WORLD["agents"]["rover-mock"]["tasks"]
+        update_tasks("rover-mistral")
+        tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertEqual(len(tasks), 1)
         self.assertIn("Explore", tasks[0])
 
@@ -1226,8 +1217,8 @@ class TestUpdateTasks(unittest.TestCase):
                 "analyzed": False,
             }
         ]
-        update_tasks("rover-mock")
-        tasks = WORLD["agents"]["rover-mock"]["tasks"]
+        update_tasks("rover-mistral")
+        tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertEqual(len(tasks), 1)
         self.assertIn("Analyze", tasks[0])
 
@@ -1241,8 +1232,8 @@ class TestUpdateTasks(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        update_tasks("rover-mock")
-        tasks = WORLD["agents"]["rover-mock"]["tasks"]
+        update_tasks("rover-mistral")
+        tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertEqual(len(tasks), 1)
         self.assertIn("Dig", tasks[0])
 
@@ -1256,8 +1247,8 @@ class TestUpdateTasks(unittest.TestCase):
                 "analyzed": True,
             }
         ]
-        update_tasks("rover-mock")
-        tasks = WORLD["agents"]["rover-mock"]["tasks"]
+        update_tasks("rover-mistral")
+        tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertEqual(len(tasks), 1)
         self.assertIn("Pick up", tasks[0])
 
@@ -1272,41 +1263,41 @@ class TestUpdateTasks(unittest.TestCase):
             }
         ]
         # Make sure the stone tile is revealed
-        agent = WORLD["agents"]["rover-mock"]
+        agent = WORLD["agents"]["rover-mistral"]
         if [8, 5] not in agent.get("revealed", []):
             agent.setdefault("revealed", []).append([8, 5])
-        update_tasks("rover-mock")
-        tasks = WORLD["agents"]["rover-mock"]["tasks"]
+        update_tasks("rover-mistral")
+        tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertEqual(len(tasks), 1)
         self.assertIn("Navigate", tasks[0])
         self.assertIn("east", tasks[0])
 
     def test_return_to_station_when_has_target(self):
-        WORLD["agents"]["rover-mock"]["inventory"] = [{"type": "core"}]
-        update_tasks("rover-mock")
-        tasks = WORLD["agents"]["rover-mock"]["tasks"]
+        WORLD["agents"]["rover-mistral"]["inventory"] = [{"type": "core"}]
+        update_tasks("rover-mistral")
+        tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertEqual(len(tasks), 1)
-        self.assertIn("Return to station", tasks[0])
+        self.assertIn("station", tasks[0].lower())
 
 
 class TestObserveRover(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [5, 5]
-        WORLD["agents"]["rover-mock"]["battery"] = 0.75
-        WORLD["agents"]["rover-mock"]["mission"] = {"objective": "Explore", "plan": []}
-        WORLD["agents"]["rover-mock"]["visited"] = [[0, 0], [5, 5]]
-        WORLD["agents"]["rover-mock"]["inventory"] = []
-        WORLD["agents"]["rover-mock"]["memory"] = ["moved east"]
-        WORLD["agents"]["rover-mock"]["tasks"] = []
-        WORLD["agents"]["rover-mock"]["ground_readings"] = {"3,3": 0.5}
+        WORLD["agents"]["rover-mistral"]["position"] = [5, 5]
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.75
+        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore", "plan": []}
+        WORLD["agents"]["rover-mistral"]["visited"] = [[0, 0], [5, 5]]
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["memory"] = ["moved east"]
+        WORLD["agents"]["rover-mistral"]["tasks"] = []
+        WORLD["agents"]["rover-mistral"]["ground_readings"] = {"3,3": 0.5}
         WORLD["stones"] = []
 
     def test_returns_rover_context_type(self):
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         self.assertIsInstance(ctx, RoverContext)
 
     def test_agent_state_fields(self):
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         self.assertEqual(ctx.agent.position, [5, 5])
         self.assertAlmostEqual(ctx.agent.battery, 0.75)
         self.assertEqual(ctx.agent.mission.objective, "Explore")
@@ -1315,24 +1306,24 @@ class TestObserveRover(unittest.TestCase):
         self.assertEqual(ctx.agent.ground_readings, {"3,3": 0.5})
 
     def test_world_view_fields(self):
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         self.assertEqual(ctx.world.grid_w, GRID_W)
         self.assertEqual(ctx.world.grid_h, GRID_H)
         self.assertEqual(ctx.world.station_position, [0, 0])
 
     def test_unvisited_dirs(self):
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         # (5,5) with visited={(0,0),(5,5)} — all 4 neighbors are unvisited
         for d in ["north", "south", "east", "west"]:
             self.assertIn(d, ctx.computed.unvisited_dirs)
 
     def test_unvisited_dirs_excludes_visited(self):
-        WORLD["agents"]["rover-mock"]["visited"].append([5, 6])
-        ctx = observe_rover("rover-mock")
+        WORLD["agents"]["rover-mistral"]["visited"].append([5, 6])
+        ctx = observe_rover("rover-mistral")
         self.assertNotIn("north", ctx.computed.unvisited_dirs)
 
     def test_stone_line_none(self):
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         self.assertEqual(ctx.computed.stone_line, "none")
         self.assertIsNone(ctx.computed.stone_here)
 
@@ -1340,7 +1331,7 @@ class TestObserveRover(unittest.TestCase):
         WORLD["stones"] = [
             {"position": [5, 5], "type": "unknown", "_true_type": "core", "extracted": False, "analyzed": False}
         ]
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         self.assertIn("unknown", ctx.computed.stone_line)
         self.assertIsNotNone(ctx.computed.stone_here)
         self.assertIsInstance(ctx.computed.stone_here, StoneInfo)
@@ -1349,14 +1340,14 @@ class TestObserveRover(unittest.TestCase):
         WORLD["stones"] = [
             {"position": [5, 5], "type": "core", "_true_type": "core", "extracted": False, "analyzed": True}
         ]
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         self.assertIn("needs dig", ctx.computed.stone_line)
 
     def test_stone_line_extracted(self):
         WORLD["stones"] = [
             {"position": [5, 5], "type": "core", "_true_type": "core", "extracted": True, "analyzed": True}
         ]
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         self.assertIn("pickup", ctx.computed.stone_line)
 
     def test_visible_stones_excludes_current_tile(self):
@@ -1365,34 +1356,30 @@ class TestObserveRover(unittest.TestCase):
             {"position": [6, 5], "type": "basalt", "_true_type": "basalt", "extracted": False, "analyzed": True},
         ]
         # Ensure (6,5) is in revealed
-        WORLD["agents"]["rover-mock"]["revealed"] = [[5, 5], [6, 5]]
-        ctx = observe_rover("rover-mock")
+        WORLD["agents"]["rover-mistral"]["revealed"] = [[5, 5], [6, 5]]
+        ctx = observe_rover("rover-mistral")
         # Current tile stone not in visible_stones list
         self.assertEqual(len(ctx.computed.visible_stones), 1)
         self.assertIn("basalt", ctx.computed.visible_stones[0])
 
     def test_inventory_in_context(self):
-        WORLD["agents"]["rover-mock"]["inventory"] = [{"type": "core"}]
-        ctx = observe_rover("rover-mock")
+        WORLD["agents"]["rover-mistral"]["inventory"] = [{"type": "core"}]
+        ctx = observe_rover("rover-mistral")
         self.assertEqual(len(ctx.agent.inventory), 1)
         self.assertEqual(ctx.agent.inventory[0].type, "core")
 
     def test_mission_info(self):
-        ctx = observe_rover("rover-mock")
+        ctx = observe_rover("rover-mistral")
         self.assertEqual(ctx.world.target_type, WORLD["mission"]["target_type"])
         self.assertEqual(ctx.world.target_count, WORLD["mission"]["target_count"])
 
 
 class TestObserveStation(unittest.TestCase):
     def setUp(self):
-        WORLD["agents"]["rover-mock"]["position"] = [3, 4]
-        WORLD["agents"]["rover-mock"]["battery"] = 0.5
-        WORLD["agents"]["rover-mock"]["mission"] = {"objective": "Scout", "plan": []}
-        WORLD["agents"]["rover-mock"]["visited"] = [[0, 0], [3, 4]]
-        WORLD["agents"]["rover-mistral"]["position"] = [7, 8]
-        WORLD["agents"]["rover-mistral"]["battery"] = 0.9
-        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Dig", "plan": []}
-        WORLD["agents"]["rover-mistral"]["visited"] = [[0, 0], [7, 8]]
+        WORLD["agents"]["rover-mistral"]["position"] = [3, 4]
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.5
+        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Scout", "plan": []}
+        WORLD["agents"]["rover-mistral"]["visited"] = [[0, 0], [3, 4]]
         WORLD["stones"] = [
             {"position": [1, 1], "type": "unknown", "_true_type": "core", "extracted": False, "analyzed": False},
         ]
@@ -1410,16 +1397,15 @@ class TestObserveStation(unittest.TestCase):
         ctx = observe_station()
         rover_ids = [r.id for r in ctx.rovers]
         self.assertNotIn("station", rover_ids)
-        self.assertIn("rover-mock", rover_ids)
         self.assertIn("rover-mistral", rover_ids)
 
     def test_rover_summary_fields(self):
         ctx = observe_station()
-        mock = next(r for r in ctx.rovers if r.id == "rover-mock")
-        self.assertEqual(mock.position, [3, 4])
-        self.assertAlmostEqual(mock.battery, 0.5)
-        self.assertEqual(mock.mission.objective, "Scout")
-        self.assertEqual(mock.visited_count, 2)
+        rover = next(r for r in ctx.rovers if r.id == "rover-mistral")
+        self.assertEqual(rover.position, [3, 4])
+        self.assertAlmostEqual(rover.battery, 0.5)
+        self.assertEqual(rover.mission.objective, "Scout")
+        self.assertEqual(rover.visited_count, 2)
 
     def test_stones_list(self):
         ctx = observe_station()
@@ -1510,12 +1496,12 @@ class TestDrone(unittest.TestCase):
     def test_rover_tasks_use_drone_scans(self):
         """Rover should suggest navigating to drone-scanned hotspot."""
         WORLD["stones"] = []
-        WORLD["agents"]["rover-mock"]["position"] = [0, 0]
-        WORLD["agents"]["rover-mock"]["visited"] = [[0, 0]]
-        WORLD["agents"]["rover-mock"]["revealed"] = [
+        WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
+        WORLD["agents"]["rover-mistral"]["visited"] = [[0, 0]]
+        WORLD["agents"]["rover-mistral"]["revealed"] = [
             [x, y] for x, y in sorted(_cells_in_radius(0, 0, ROVER_REVEAL_RADIUS))
         ]
-        WORLD["agents"]["rover-mock"]["inventory"] = []
+        WORLD["agents"]["rover-mistral"]["inventory"] = []
         # Add a high-concentration drone scan far from rover
         WORLD["drone_scans"] = [
             {
@@ -1525,8 +1511,8 @@ class TestDrone(unittest.TestCase):
                 "scanner": "drone-mistral",
             }
         ]
-        update_tasks("rover-mock")
-        tasks = WORLD["agents"]["rover-mock"]["tasks"]
+        update_tasks("rover-mistral")
+        tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertTrue(any("hotspot" in t for t in tasks))
 
 
@@ -1535,9 +1521,9 @@ class TestChunkSystem(unittest.TestCase):
 
     def test_chunk_generated_on_move(self):
         """Moving to a far tile generates the chunk."""
-        WORLD["agents"]["rover-mock"]["position"] = [30, 30]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        result = move_agent("rover-mock", 31, 30)
+        WORLD["agents"]["rover-mistral"]["position"] = [30, 30]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        result = move_agent("rover-mistral", 31, 30)
         self.assertTrue(result["ok"])
         # Chunk containing (31, 30) should exist
         from app.world import _chunk_key
@@ -1558,17 +1544,17 @@ class TestChunkSystem(unittest.TestCase):
 
     def test_negative_coords_work(self):
         """Agents can move to and exist at negative coordinates."""
-        WORLD["agents"]["rover-mock"]["position"] = [-5, -5]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        result = move_agent("rover-mock", -6, -5)
+        WORLD["agents"]["rover-mistral"]["position"] = [-5, -5]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        result = move_agent("rover-mistral", -6, -5)
         self.assertTrue(result["ok"])
-        self.assertEqual(WORLD["agents"]["rover-mock"]["position"], [-6, -5])
+        self.assertEqual(WORLD["agents"]["rover-mistral"]["position"], [-6, -5])
 
     def test_bounds_tracking(self):
         """World bounds update when agents move."""
-        WORLD["agents"]["rover-mock"]["position"] = [50, 50]
-        WORLD["agents"]["rover-mock"]["battery"] = 1.0
-        move_agent("rover-mock", 51, 50)
+        WORLD["agents"]["rover-mistral"]["position"] = [50, 50]
+        WORLD["agents"]["rover-mistral"]["battery"] = 1.0
+        move_agent("rover-mistral", 51, 50)
         bounds = WORLD["bounds"]
         self.assertGreaterEqual(bounds["max_x"], 51)
 
@@ -1594,3 +1580,49 @@ class TestChunkSystem(unittest.TestCase):
         self.assertIn("bounds", snap)
         self.assertIn("min_x", snap["bounds"])
         self.assertIn("max_x", snap["bounds"])
+
+
+class TestChargeAgent(unittest.TestCase):
+    """Test charge_agent for non-rover agents (drone)."""
+
+    def setUp(self):
+        self.drone = WORLD["agents"].get("drone-mistral")
+        if self.drone:
+            self.drone["position"] = [0, 0]
+            self.drone["battery"] = 0.5
+            self.drone["memory"] = []
+        WORLD["agents"]["station"]["position"] = [0, 0]
+
+    def test_charge_drone(self):
+        result = charge_agent("drone-mistral")
+        self.assertTrue(result["ok"])
+        self.assertAlmostEqual(result["battery_before"], 0.5)
+        self.assertAlmostEqual(result["battery_after"], 0.5 + CHARGE_RATE)
+
+
+class TestStoneProximityConcentration(unittest.TestCase):
+    """Test proximity-based concentration replaces noise-based."""
+
+    def setUp(self):
+        self._original_stones = WORLD.get("stones", [])
+
+    def tearDown(self):
+        WORLD["stones"] = self._original_stones
+
+    def test_concentration_at_stone(self):
+        from app.world import _stone_proximity_concentration
+        WORLD["stones"] = [{"position": [5, 5], "type": "core", "_true_type": "core", "extracted": False, "analyzed": False}]
+        self.assertEqual(_stone_proximity_concentration(5, 5), 1.0)
+
+    def test_concentration_falls_off(self):
+        from app.world import _stone_proximity_concentration
+        WORLD["stones"] = [{"position": [5, 5], "type": "core", "_true_type": "core", "extracted": False, "analyzed": False}]
+        val_near = _stone_proximity_concentration(6, 5)
+        val_far = _stone_proximity_concentration(10, 5)
+        self.assertGreater(val_near, val_far)
+
+    def test_concentration_zero_far_away(self):
+        from app.world import _stone_proximity_concentration
+        WORLD["stones"] = [{"position": [5, 5], "type": "core", "_true_type": "core", "extracted": False, "analyzed": False}]
+        val = _stone_proximity_concentration(50, 50)
+        self.assertEqual(val, 0.0)

--- a/ui/src/components/AgentPane.vue
+++ b/ui/src/components/AgentPane.vue
@@ -77,14 +77,36 @@ const emit = defineEmits(['select-agent'])
       >
         {{ m }}
       </div>
-      <!-- Thinking events -->
+      <!-- All events chronologically -->
       <div
-        v-for="(e, i) in (events || []).filter(e => e.name === 'thinking')"
+        v-for="(e, i) in (events || [])"
         :key="'e-'+i"
         class="agent-event"
       >
-        <span class="ae-type">think</span>
-        <span class="ae-text">{{ e.payload.text }}</span>
+        <span
+          v-if="e.name === 'thinking'"
+          class="ae-type think"
+        >think</span>
+        <span
+          v-else
+          class="ae-type action"
+        >{{ e.name }}</span>
+        <span
+          v-if="e.name === 'thinking'"
+          class="ae-text"
+        >{{ e.payload.text }}</span>
+        <span
+          v-else-if="e.name === 'move' && e.payload && e.payload.from"
+          class="ae-text action-text"
+        >
+          ({{ e.payload.from[0] }},{{ e.payload.from[1] }}) → ({{ e.payload.to[0] }},{{ e.payload.to[1] }})
+        </span>
+        <span
+          v-else
+          class="ae-text action-text"
+        >
+          {{ e.payload && e.payload.result ? e.payload.result : '' }}
+        </span>
       </div>
     </div>
   </div>
@@ -163,6 +185,10 @@ const emit = defineEmits(['select-agent'])
   flex-shrink: 0;
 }
 
+.ae-type.think {
+  color: #668;
+}
+
 .ae-type.action {
   color: #c86040;
 }
@@ -177,5 +203,9 @@ const emit = defineEmits(['select-agent'])
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.ae-text.action-text {
+  color: #7a9a7a;
 }
 </style>

--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
-import { TILE_SIZE, MAP_W, MAP_H, VIEWPORT_W, VIEWPORT_H, STONE_COLORS, agentColor, revealRadius } from '../constants.js'
+import { TILE_SIZE, MAP_W, MAP_H, VIEWPORT_W, VIEWPORT_H, STONE_COLORS, SOLAR_PANEL_COLOR, SOLAR_PANEL_DEPLETED_COLOR, agentColor, revealRadius } from '../constants.js'
 
 const props = defineProps({
   worldState: {
@@ -134,6 +134,20 @@ function stoneRotateCenter(s) {
   return `rotate(45, ${cx}, ${cy})`
 }
 
+function isPanelVisible(p) {
+  const [wx, wy] = p.position
+  return wx >= camX.value && wx < camX.value + VIEWPORT_W &&
+         wy >= camY.value && wy < camY.value + VIEWPORT_H
+}
+
+function panelScreenX(p) {
+  return (p.position[0] - camX.value) * TILE_SIZE + 2
+}
+
+function panelScreenY(p) {
+  return (VIEWPORT_H - 1 - (p.position[1] - camY.value)) * TILE_SIZE + 2
+}
+
 // Drag-to-pan
 function onMouseDown(e) {
   dragging.value = true
@@ -209,6 +223,37 @@ defineExpose({ camX, camY })
           opacity="0.85"
           :transform="stoneRotateCenter(s)"
         />
+      </template>
+
+      <!-- solar panels -->
+      <template v-for="(p, i) in (worldState.solar_panels || [])" :key="'panel-'+i">
+        <g v-if="isPanelVisible(p)">
+          <rect
+            :x="panelScreenX(p)"
+            :y="panelScreenY(p)"
+            :width="TILE_SIZE - 4"
+            :height="TILE_SIZE - 4"
+            :fill="p.depleted ? SOLAR_PANEL_DEPLETED_COLOR : SOLAR_PANEL_COLOR"
+            opacity="0.7"
+            rx="1"
+          />
+          <line
+            :x1="panelScreenX(p) + (TILE_SIZE - 4) / 2"
+            :y1="panelScreenY(p)"
+            :x2="panelScreenX(p) + (TILE_SIZE - 4) / 2"
+            :y2="panelScreenY(p) + TILE_SIZE - 4"
+            :stroke="p.depleted ? '#333' : '#aa8020'"
+            stroke-width="0.5"
+          />
+          <line
+            :x1="panelScreenX(p)"
+            :y1="panelScreenY(p) + (TILE_SIZE - 4) / 2"
+            :x2="panelScreenX(p) + TILE_SIZE - 4"
+            :y2="panelScreenY(p) + (TILE_SIZE - 4) / 2"
+            :stroke="p.depleted ? '#333' : '#aa8020'"
+            stroke-width="0.5"
+          />
+        </g>
       </template>
 
       <!-- station markers (square) -->

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -17,10 +17,12 @@ export const STONE_COLORS = {
 
 export const AGENT_COLORS = {
   'station': '#44cc88',
-  'rover-mock': '#6688cc',
   'rover-mistral': '#e06030',
   'drone-mistral': '#cc44cc',
 }
+
+export const SOLAR_PANEL_COLOR = '#f0c040'
+export const SOLAR_PANEL_DEPLETED_COLOR = '#555555'
 
 export function agentColor(id) {
   return AGENT_COLORS[id] || '#6c6'


### PR DESCRIPTION
## Changes

### Removed
- **MockRoverAgent** class and `rover-mock` from active agents, config, and agent factory. Only LLM-powered `rover-mistral` remains.

### Changed
- **Mission Fulfillment**: Rovers immediately return to station when target stone count is met. No more gathering extra stones.
- **Chronological Logs**: Agent pane shows thinking + actions interleaved in order (not grouped by type). Actions are orange, thinking in muted blue.

### Tests
- All 162 tests pass (updated from `rover-mock` to `rover-mistral`)