### PR TITLE
feat(ui): Phase 2 — JetBrains Mono font upgrade

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mars-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "vue": "^3.5.18"
       },
       "devDependencies": {
@@ -19,7 +20,7 @@
         "vite": "^7.0.6"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -665,6 +666,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint . --fix"
   },
   "dependencies": {
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "vue": "^3.5.18"
   },
   "devDependencies": {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -226,7 +226,7 @@ function onUnfollow() {
   --bg-status-narration: #2a1a30;
 
   /* Typography */
-  --font-mono: 'Courier New', monospace;
+  --font-mono: 'JetBrains Mono', monospace;
 
   /* Radii */
   --radius-sm: 3px;

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -1,4 +1,6 @@
 import { createApp } from 'vue'
+import '@fontsource/jetbrains-mono/400.css'
+import '@fontsource/jetbrains-mono/700.css'
 import App from './App.vue'
 
 const app = createApp(App)


### PR DESCRIPTION
## Summary
Replace Courier New with JetBrains Mono for a sharper, purpose-built monospace font across the entire UI.

## Changes
- Install `@fontsource/jetbrains-mono` (OFL-1.1 licensed)
- Import 400 (regular) and 700 (bold) weights in `main.js`
- Update `--font-mono` CSS token: `'Courier New', monospace` → `'JetBrains Mono', monospace`
- All components already reference `var(--font-mono)` from Phase 1

## Part of
UI Polish spec: `specs/002-ui-polish/spec.md` (Phase 2 of 8)

Co-Authored-By: Oz <oz-agent@warp.dev>