### PR TITLE
feat(ui): Phase 3 — Battery bars & mission progress

### DIFF
--- a/ui/src/components/AgentPane.vue
+++ b/ui/src/components/AgentPane.vue
@@ -1,4 +1,6 @@
 <script setup>
+import BatteryBar from './BatteryBar.vue'
+
 defineProps({
   agentId: {
     type: String,
@@ -11,6 +13,10 @@ defineProps({
   battery: {
     type: String,
     default: '',
+  },
+  batteryLevel: {
+    type: Number,
+    default: 0,
   },
   inventoryCount: {
     type: Number,
@@ -49,7 +55,8 @@ const emit = defineEmits(['select-agent'])
         :style="{ color }"
       >{{ agentId }}</span>
       <span class="agent-stats">
-        {{ position }} &middot; bat {{ battery }}
+        {{ position }} &middot;
+        <BatteryBar :level="batteryLevel" />
         <span
           v-if="inventoryCount > 0"
           class="agent-inv"

--- a/ui/src/components/AgentPanes.vue
+++ b/ui/src/components/AgentPanes.vue
@@ -25,6 +25,12 @@ function batteryPct(id) {
   return a ? Math.round(a.battery * 100) + '%' : '?'
 }
 
+function batteryRaw(id) {
+  if (!props.worldState) return 0
+  const a = props.worldState.agents[id]
+  return a ? a.battery : 0
+}
+
 function agentPosition(id) {
   if (!props.worldState) return '?'
   const a = props.worldState.agents[id]
@@ -62,6 +68,7 @@ function agentMemory(id) {
       :agent-id="id"
       :position="agentPosition(id)"
       :battery="batteryPct(id)"
+      :battery-level="batteryRaw(id)"
       :inventory-count="inventoryCount(id)"
       :mission="missionObjective(id)"
       :memory="agentMemory(id)"

--- a/ui/src/components/BatteryBar.vue
+++ b/ui/src/components/BatteryBar.vue
@@ -1,0 +1,64 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  /** 0-1 fraction */
+  level: {
+    type: Number,
+    default: 0,
+  },
+})
+
+const pct = computed(() => Math.max(0, Math.min(100, Math.round(props.level * 100))))
+
+const barColor = computed(() => {
+  const p = pct.value
+  if (p > 60) return 'var(--accent-green)'
+  if (p > 30) return 'var(--accent-amber)'
+  return 'var(--accent-red)'
+})
+</script>
+
+<template>
+  <span class="battery-bar">
+    <span class="battery-track">
+      <span
+        class="battery-fill"
+        :style="{ width: pct + '%', background: barColor }"
+      />
+    </span>
+    <span class="battery-label">{{ pct }}%</span>
+  </span>
+</template>
+
+<style scoped>
+.battery-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.battery-track {
+  display: inline-block;
+  width: 3rem;
+  height: 0.5rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  overflow: hidden;
+}
+
+.battery-fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-sm);
+  transition: width 0.3s ease, background 0.3s ease;
+}
+
+.battery-label {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  min-width: 2.2em;
+  text-align: right;
+}
+</style>

--- a/ui/src/components/MissionBar.vue
+++ b/ui/src/components/MissionBar.vue
@@ -1,5 +1,7 @@
 <script setup>
-defineProps({
+import { computed } from 'vue'
+
+const props = defineProps({
   mission: {
     type: Object,
     default: null,
@@ -7,6 +9,18 @@ defineProps({
 })
 
 const emit = defineEmits(['abort'])
+
+const collected = computed(() => {
+  if (!props.mission) return 0
+  return props.mission.collected_quantity || props.mission.collected_count || 0
+})
+
+const target = computed(() => {
+  if (!props.mission) return 1
+  return props.mission.target_quantity || props.mission.target_count || 1
+})
+
+const progressPct = computed(() => Math.min(100, Math.round((collected.value / target.value) * 100)))
 </script>
 
 <template>
@@ -15,8 +29,16 @@ const emit = defineEmits(['abort'])
     class="mission-bar"
   >
     <span class="mission-label">Mission</span>
-    <span class="mission-target">collect {{ mission.target_quantity || mission.target_count }} basalt</span>
-    <span class="mission-progress">{{ mission.collected_quantity || mission.collected_count || 0 }} / {{ mission.target_quantity || mission.target_count }}</span>
+    <span class="mission-target">collect {{ target }} basalt</span>
+    <span class="mission-progress-wrap">
+      <span class="progress-track">
+        <span
+          class="progress-fill"
+          :style="{ width: progressPct + '%' }"
+        />
+      </span>
+      <span class="mission-progress">{{ collected }} / {{ target }}</span>
+    </span>
     <span
       class="mission-status"
       :class="mission.status"
@@ -53,6 +75,30 @@ const emit = defineEmits(['abort'])
 
 .mission-target {
   color: var(--accent-amber-dark);
+}
+
+.mission-progress-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.progress-track {
+  display: inline-block;
+  width: 4rem;
+  height: 0.45rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  overflow: hidden;
+}
+
+.progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background: var(--accent-amber);
+  transition: width 0.3s ease;
 }
 
 .mission-progress {


### PR DESCRIPTION
## Summary
Add visual battery bars to agent panes and a progress track to the mission bar.

## Changes
- **BatteryBar.vue**: New component with color-coded fill (green >60%, amber >30%, red ≤30%) and smooth transitions
- **AgentPane.vue**: Replace text-only `bat 75%` with visual BatteryBar component
- **AgentPanes.vue**: Pass raw battery level (0-1 float) as `batteryLevel` prop
- **MissionBar.vue**: Add progress track showing collected/target ratio with amber fill, extract computed props

## Part of
UI Polish spec: `specs/002-ui-polish/spec.md` (Phase 3 of 8)

Co-Authored-By: Oz <oz-agent@warp.dev>