### PR TITLE
fix: resolve 10 ruff lint errors failing CI

### DIFF
--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -20,8 +20,8 @@ from .world import FUEL_CAPACITY_ROVER, FUEL_CAPACITY_DRONE, DRONE_REVEAL_RADIUS
 from .world import BATTERY_COST_MOVE, BATTERY_COST_MOVE_DRONE, BATTERY_COST_DIG
 from .world import BATTERY_COST_PICKUP, BATTERY_COST_ANALYZE, BATTERY_COST_ANALYZE_GROUND
 from .world import BATTERY_COST_SCAN, RETURN_TO_BASE_THRESHOLD
-from .world import check_ground, _direction_hint, _find_stone_at, must_return_to_base
-from .world import execute_action, get_snapshot, charge_agent, next_tick, all_agents_at_station
+from .world import check_ground, _direction_hint, must_return_to_base
+from .world import execute_action, get_snapshot, charge_agent, next_tick
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +162,6 @@ class MistralRoverReasoner:
 
         # Mission target
         world_mission = WORLD.get("mission", {})
-        target_type = world_mission.get("target_type", "basalt_vein")
         target_quantity = world_mission.get("target_quantity", 100)
         collected_qty = world_mission.get("collected_quantity", 0)
 
@@ -204,7 +203,7 @@ class MistralRoverReasoner:
             f"\n== Mission ==\n"
             f"Objective: {mission['objective']}\n"
             f"Target: collect {target_quantity} units of basalt from veins ({collected_qty}/{target_quantity} delivered)"
-            + (f"\n🏁 MISSION TARGET MET — RETURN TO STATION NOW!" if collected_qty >= target_quantity else "")
+            + ("\n🏁 MISSION TARGET MET — RETURN TO STATION NOW!" if collected_qty >= target_quantity else "")
         )
 
         tasks = agent.get("tasks", [])
@@ -739,7 +738,7 @@ class RoverLoop(BaseAgent):
             return
 
         turn = await asyncio.to_thread(self._reasoner.run_turn)
-        tick = next_tick()
+        next_tick()
         messages = []
 
         if turn["thinking"]:
@@ -844,7 +843,7 @@ class DroneLoop(BaseAgent):
             ]
 
         turn = await asyncio.to_thread(self._reasoner.run_turn)
-        tick = next_tick()
+        next_tick()
         messages = []
 
         if turn["thinking"]:

--- a/server/app/host.py
+++ b/server/app/host.py
@@ -10,12 +10,11 @@ import logging
 
 from .base_agent import BaseAgent
 from .broadcast import broadcaster
-from .config import settings
 from .narrator import Narrator
 from .protocol import make_message
 from .station import StationAgent, execute_action as station_execute_action
 from .world import abort_mission as world_abort_mission
-from .world import get_snapshot, WORLD
+from .world import get_snapshot
 from .world import observe_station
 
 logger = logging.getLogger(__name__)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -13,6 +13,7 @@ from .config import settings
 from .db import init_db, close_db
 from .host import Host
 from .narrator import Narrator
+from .views import router as views_router
 from .world import reset_world
 
 logging.basicConfig(
@@ -67,8 +68,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-from .views import router as views_router
 
 app.include_router(views_router)
 

--- a/server/tests/test_base_agent.py
+++ b/server/tests/test_base_agent.py
@@ -1,6 +1,6 @@
 import asyncio
 import unittest
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock
 
 from app.base_agent import BaseAgent
 from app.world import WORLD


### PR DESCRIPTION
## Summary

Fix all 10 ruff lint errors that caused CI failure on main after the basalt vein system merge.

## Change Type

- [x] `fix` — Bug fix
- [x] `style` — Formatting, linting (no logic change)

## Semantic Diff

### Changed
- `server/app/agent.py` — Remove unused imports (`_find_stone_at`, `all_agents_at_station`), unused `target_type` variable, extraneous f-prefix, unused `tick` assignments
- `server/app/host.py` — Remove unused imports (`settings`, `WORLD`)
- `server/app/main.py` — Move `views` import to top of file (E402)
- `server/tests/test_base_agent.py` — Remove unused `AsyncMock` import

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 4 |
| Files deleted | 0 |
| Lines added | +8 |
| Lines removed | -11 |

### Core Files Modified
- `server/app/agent.py`
- `server/app/host.py`
- `server/app/main.py`

### Tests
- `server/tests/test_base_agent.py`

## How to Test

1. `cd server && uv run ruff check app/ tests/` — 0 errors
2. `cd server && uv run python -m pytest tests/ -q` — 291 pass

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>