### PR TITLE
style: apply ruff format to pass CI

### DIFF
--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -104,7 +104,15 @@ USE_SOLAR_BATTERY_TOOL = {
     },
 }
 
-ROVER_TOOLS = [MOVE_TOOL, ANALYZE_TOOL, DIG_TOOL, PICKUP_TOOL, ANALYZE_GROUND_TOOL, DEPLOY_SOLAR_PANEL_TOOL, USE_SOLAR_BATTERY_TOOL]
+ROVER_TOOLS = [
+    MOVE_TOOL,
+    ANALYZE_TOOL,
+    DIG_TOOL,
+    PICKUP_TOOL,
+    ANALYZE_GROUND_TOOL,
+    DEPLOY_SOLAR_PANEL_TOOL,
+    USE_SOLAR_BATTERY_TOOL,
+]
 
 
 # ── Rover Reasoners (sync decision engines, read from WORLD) ──
@@ -203,7 +211,11 @@ class MistralRoverReasoner:
             f"\n== Mission ==\n"
             f"Objective: {mission['objective']}\n"
             f"Target: collect {target_quantity} units of basalt from veins ({collected_qty}/{target_quantity} delivered)"
-            + ("\n🏁 MISSION TARGET MET — RETURN TO STATION NOW!" if collected_qty >= target_quantity else "")
+            + (
+                "\n🏁 MISSION TARGET MET — RETURN TO STATION NOW!"
+                if collected_qty >= target_quantity
+                else ""
+            )
         )
 
         tasks = agent.get("tasks", [])
@@ -221,7 +233,13 @@ class MistralRoverReasoner:
             f"Distance to station: {dist_to_station} tiles\n"
             f"Safety margin: {'OK' if battery > RETURN_TO_BASE_THRESHOLD else 'LOW — return to station immediately'}\n"
             f"Inventory: {len(inventory)} veins"
-            + (" (" + ", ".join(f"{s.get('grade','?')} qty={s.get('quantity',0)}" for s in inventory) + ")" if inventory else "")
+            + (
+                " ("
+                + ", ".join(f"{s.get('grade', '?')} qty={s.get('quantity', 0)}" for s in inventory)
+                + ")"
+                if inventory
+                else ""
+            )
             + f"\nSolar panels remaining: {agent.get('solar_panels_remaining', 0)}"
         )
 
@@ -248,7 +266,11 @@ class MistralRoverReasoner:
                 hint = _direction_hint(sp[0] - x, sp[1] - y)
                 grade_info = stone.get("grade", "unknown")
                 qty_info = stone.get("quantity", 0)
-                label = f"{stone['type']} {grade_info}" if stone["type"] != "unknown" else "unknown vein"
+                label = (
+                    f"{stone['type']} {grade_info}"
+                    if stone["type"] != "unknown"
+                    else "unknown vein"
+                )
                 if qty_info > 0:
                     label += f" qty={qty_info}"
                 visible_stones.append(
@@ -329,7 +351,15 @@ class MistralRoverReasoner:
                     if isinstance(tc.function.arguments, str)
                     else tc.function.arguments
                 )
-                if name in ("move", "dig", "pickup", "analyze", "analyze_ground", "deploy_solar_panel", "use_solar_battery"):
+                if name in (
+                    "move",
+                    "dig",
+                    "pickup",
+                    "analyze",
+                    "analyze_ground",
+                    "deploy_solar_panel",
+                    "use_solar_battery",
+                ):
                     action = {"name": name, "params": args}
                 else:
                     logger.warning("%s called unknown tool %r, ignoring", self.agent_id, name)
@@ -362,7 +392,10 @@ class MistralRoverReasoner:
         candidates = unvisited if unvisited else valid
         direction, tx, ty = random.choice(candidates)
         thinking = f"LLM fallback: {reason}. Moving {direction} to ({tx},{ty})."
-        return {"thinking": thinking, "action": {"name": "move", "params": {"direction": direction}}}
+        return {
+            "thinking": thinking,
+            "action": {"name": "move", "params": {"direction": direction}},
+        }
 
 
 # Backward-compat aliases
@@ -614,7 +647,10 @@ class MockDroneAgent:
                 dx, dy = sp[0] - x, sp[1] - y
                 if dx == 0 and dy == 0:
                     thinking = f"Recall received but already at station ({x}, {y})."
-                    return {"thinking": thinking, "action": {"name": "move", "params": {"direction": "north", "distance": 1}}}
+                    return {
+                        "thinking": thinking,
+                        "action": {"name": "move", "params": {"direction": "north", "distance": 1}},
+                    }
                 if abs(dx) >= abs(dy):
                     direction = "east" if dx > 0 else "west"
                     distance = min(abs(dx), MAX_MOVE_DISTANCE_DRONE)
@@ -625,7 +661,10 @@ class MockDroneAgent:
                 thinking = f"RECALL received: {reason}. Heading to station at ({sp[0]},{sp[1]})."
                 return {
                     "thinking": thinking,
-                    "action": {"name": "move", "params": {"direction": direction, "distance": distance}},
+                    "action": {
+                        "name": "move",
+                        "params": {"direction": direction, "distance": distance},
+                    },
                 }
 
         # Battery safety — return to base if battery is low
@@ -642,7 +681,9 @@ class MockDroneAgent:
             else:
                 direction = "north"
                 distance = 1
-            thinking = f"I'm at ({x}, {y}). LOW BATTERY ({agent['battery']:.0%}) — must return to station!"
+            thinking = (
+                f"I'm at ({x}, {y}). LOW BATTERY ({agent['battery']:.0%}) — must return to station!"
+            )
             return {
                 "thinking": thinking,
                 "action": {
@@ -724,7 +765,9 @@ class RoverLoop(BaseAgent):
         pending = host.drain_inbox(self.agent_id)
         # During abort, force recall so rover heads to station
         if mission_status == "aborted":
-            pending = [{"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}]
+            pending = [
+                {"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}
+            ]
         if pending:
             WORLD["agents"][self.agent_id]["pending_commands"] = pending
         else:
@@ -733,7 +776,12 @@ class RoverLoop(BaseAgent):
         # If aborted and already at station, stop this agent's loop
         rover = WORLD["agents"].get(self.agent_id)
         station_agent = WORLD["agents"].get("station")
-        if mission_status == "aborted" and rover and station_agent and rover["position"] == station_agent["position"]:
+        if (
+            mission_status == "aborted"
+            and rover
+            and station_agent
+            and rover["position"] == station_agent["position"]
+        ):
             logger.info("Agent %s at station — abort complete", self.agent_id)
             return
 
@@ -790,9 +838,7 @@ class RoverLoop(BaseAgent):
         for msg in messages:
             await host.broadcast(msg.to_dict())
 
-        await broadcaster.send(
-            make_message("world", "event", "state", get_snapshot()).to_dict()
-        )
+        await broadcaster.send(make_message("world", "event", "state", get_snapshot()).to_dict())
 
         # Auto-charge rover when it arrives at station
         rover = WORLD["agents"].get(self.agent_id)
@@ -832,7 +878,12 @@ class DroneLoop(BaseAgent):
         station_agent = WORLD["agents"].get("station")
 
         # If aborted and at station, stop this agent
-        if mission_status == "aborted" and drone and station_agent and drone["position"] == station_agent["position"]:
+        if (
+            mission_status == "aborted"
+            and drone
+            and station_agent
+            and drone["position"] == station_agent["position"]
+        ):
             logger.info("Agent %s at station — abort complete", self.agent_id)
             return
 
@@ -873,9 +924,7 @@ class DroneLoop(BaseAgent):
         for msg in messages:
             await host.broadcast(msg.to_dict())
 
-        await broadcaster.send(
-            make_message("world", "event", "state", get_snapshot()).to_dict()
-        )
+        await broadcaster.send(make_message("world", "event", "state", get_snapshot()).to_dict())
 
         # Auto-charge drone when at station
         if (

--- a/server/app/host.py
+++ b/server/app/host.py
@@ -125,13 +125,16 @@ class Host:
             # Route assign_mission to target rover inbox
             if action["name"] == "assign_mission" and action_result.get("ok"):
                 target_id = action["params"]["agent_id"]
-                self.send_command(target_id, {
-                    "name": "assign_mission",
-                    "payload": {
-                        "objective": action["params"]["objective"],
+                self.send_command(
+                    target_id,
+                    {
+                        "name": "assign_mission",
+                        "payload": {
+                            "objective": action["params"]["objective"],
+                        },
+                        "id": correlation_id or "",
                     },
-                    "id": correlation_id or "",
-                })
+                )
 
             # Broadcast to UI
             if action["name"] == "broadcast_alert":
@@ -161,10 +164,13 @@ class Host:
         """Send a recall command to a rover's inbox."""
         if rover_id not in self._inboxes:
             return {"ok": False, "error": f"Unknown rover: {rover_id}"}
-        self.send_command(rover_id, {
-            "name": "recall",
-            "payload": {"reason": "Emergency recall from mission control"},
-        })
+        self.send_command(
+            rover_id,
+            {
+                "name": "recall",
+                "payload": {"reason": "Emergency recall from mission control"},
+            },
+        )
         msg = make_message(
             source="host",
             type="command",

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -28,6 +28,7 @@ class StoneInfo(BaseModel):
 
 class RoverAgentState(BaseModel):
     """Rover's own internal state."""
+
     position: list[int]
     battery: float
     mission: AgentMission
@@ -41,6 +42,7 @@ class RoverAgentState(BaseModel):
 
 class RoverWorldView(BaseModel):
     """World info visible to the rover (not agent state)."""
+
     grid_w: int
     grid_h: int
     station_position: list[int]
@@ -51,6 +53,7 @@ class RoverWorldView(BaseModel):
 
 class PendingCommand(BaseModel):
     """A command queued for an agent by the Host (e.g. recall, assign_mission)."""
+
     name: str
     payload: dict = {}
     id: str = ""
@@ -58,6 +61,7 @@ class PendingCommand(BaseModel):
 
 class RoverComputed(BaseModel):
     """Derived fields for decision-making."""
+
     unvisited_dirs: list[str] = []
     stone_line: str = "none"
     stone_here: StoneInfo | None = None

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -418,12 +418,14 @@ def check_ground(agent_id):
     x, y = agent["position"]
     for stone in WORLD.get("stones", []):
         if stone["position"] == [x, y]:
-            return {"stone": {
-                "type": stone["type"],
-                "grade": stone.get("grade", "unknown"),
-                "quantity": stone.get("quantity", 0),
-                "extracted": stone.get("extracted", False),
-            }}
+            return {
+                "stone": {
+                    "type": stone["type"],
+                    "grade": stone.get("grade", "unknown"),
+                    "quantity": stone.get("quantity", 0),
+                    "extracted": stone.get("extracted", False),
+                }
+            }
     return {"stone": None}
 
 
@@ -595,7 +597,12 @@ def _execute_analyze(agent_id, agent):
     stone["quantity"] = stone["_true_quantity"]
     logger.info(
         "Agent %s analyzed vein at (%d,%d), type=%s grade=%s qty=%d",
-        agent_id, x, y, stone["type"], stone["grade"], stone["quantity"],
+        agent_id,
+        x,
+        y,
+        stone["type"],
+        stone["grade"],
+        stone["quantity"],
     )
     return {
         "ok": True,
@@ -669,7 +676,12 @@ def _execute_dig(agent_id, agent):
     stone["extracted"] = True
     logger.info(
         "Agent %s dug at (%d,%d), extracted %s grade=%s qty=%d",
-        agent_id, x, y, stone["type"], stone["grade"], stone["quantity"],
+        agent_id,
+        x,
+        y,
+        stone["type"],
+        stone["grade"],
+        stone["quantity"],
     )
     return {
         "ok": True,
@@ -697,15 +709,22 @@ def _execute_pickup(agent_id, agent):
         return {"ok": False, "error": f"Vein at ({x}, {y}) not yet extracted (dig first)"}
 
     agent["battery"] = max(0.0, agent["battery"] - BATTERY_COST_PICKUP)
-    agent.setdefault("inventory", []).append({
-        "type": stone["type"],
-        "grade": stone["grade"],
-        "quantity": stone["quantity"],
-    })
+    agent.setdefault("inventory", []).append(
+        {
+            "type": stone["type"],
+            "grade": stone["grade"],
+            "quantity": stone["quantity"],
+        }
+    )
     WORLD["stones"].remove(stone)
     logger.info(
         "Agent %s picked up %s grade=%s qty=%d at (%d,%d)",
-        agent_id, stone["type"], stone["grade"], stone["quantity"], x, y,
+        agent_id,
+        stone["type"],
+        stone["grade"],
+        stone["quantity"],
+        x,
+        y,
     )
     return {
         "ok": True,
@@ -770,11 +789,18 @@ def _execute_deploy_solar_panel(agent_id):
     for p in WORLD.get("solar_panels", []):
         if p["position"] == [x, y]:
             return {"ok": False, "error": "Solar panel already deployed here"}
-    panel = {"position": [x, y], "battery": SOLAR_BATTERY_CAPACITY, "deployed_by": agent_id, "depleted": False}
+    panel = {
+        "position": [x, y],
+        "battery": SOLAR_BATTERY_CAPACITY,
+        "deployed_by": agent_id,
+        "depleted": False,
+    }
     WORLD.setdefault("solar_panels", []).append(panel)
     agent["solar_panels_remaining"] = remaining - 1
     agent["battery"] = max(0.0, agent["battery"] - BATTERY_COST_MOVE)  # deploy costs 1 fuel
-    record_memory(agent_id, f"Deployed solar panel at ({x},{y}) — {SOLAR_BATTERY_CAPACITY:.0%} battery")
+    record_memory(
+        agent_id, f"Deployed solar panel at ({x},{y}) — {SOLAR_BATTERY_CAPACITY:.0%} battery"
+    )
     return {"ok": True, "result": f"Solar panel deployed at ({x},{y})", "panel": panel}
 
 
@@ -790,7 +816,11 @@ def _execute_use_solar_battery(agent_id):
             panel["battery"] = 0.0
             panel["depleted"] = True
             record_memory(agent_id, f"Used solar battery at ({x},{y}), gained {charge:.0%}")
-            return {"ok": True, "result": f"Recharged {charge:.0%} from solar panel", "new_battery": agent["battery"]}
+            return {
+                "ok": True,
+                "result": f"Recharged {charge:.0%} from solar panel",
+                "new_battery": agent["battery"],
+            }
     return {"ok": False, "error": "No active solar panel at current position"}
 
 
@@ -841,7 +871,11 @@ def check_mission_status():
             delivered_qty,
             mission["target_quantity"],
         )
-        return {"status": "success", "collected_quantity": collected_qty, "delivered_quantity": delivered_qty}
+        return {
+            "status": "success",
+            "collected_quantity": collected_qty,
+            "delivered_quantity": delivered_qty,
+        }
 
     # Failure: all rovers have zero battery and none are at the station
     all_dead = True
@@ -933,7 +967,9 @@ def update_tasks(agent_id):
         else:
             dist = abs(sp[0] - x) + abs(sp[1] - y)
             hint = _direction_hint(sp[0] - x, sp[1] - y)
-            agent["tasks"] = [f"MISSION ABORTED — return to station at ({sp[0]},{sp[1]}) — {hint}, {dist} tiles"]
+            agent["tasks"] = [
+                f"MISSION ABORTED — return to station at ({sp[0]},{sp[1]}) — {hint}, {dist} tiles"
+            ]
         return
     if agent.get("type") == "drone":
         _update_drone_tasks(agent_id, agent)
@@ -1038,14 +1074,20 @@ def _update_rover_tasks(agent_id, agent):
         sp = station["position"] if station else [0, 0]
         if [x, y] == sp:
             if inv_qty > 0:
-                tasks.append(f"🏁 Deliver basalt at station ({inv_qty} units, mission needs {target_qty})")
+                tasks.append(
+                    f"🏁 Deliver basalt at station ({inv_qty} units, mission needs {target_qty})"
+                )
             else:
                 tasks.append("🏁 Mission target reached! Standby at station.")
         else:
             if mission_met:
-                tasks.append(f"🏁 Mission fulfilled! Return to station at ({sp[0]},{sp[1]}) to deliver {inv_qty} units of basalt IMMEDIATELY")
+                tasks.append(
+                    f"🏁 Mission fulfilled! Return to station at ({sp[0]},{sp[1]}) to deliver {inv_qty} units of basalt IMMEDIATELY"
+                )
             else:
-                tasks.append(f"Return to station at ({sp[0]},{sp[1]}) to deliver {inv_qty} units of basalt")
+                tasks.append(
+                    f"Return to station at ({sp[0]},{sp[1]}) to deliver {inv_qty} units of basalt"
+                )
         agent["tasks"] = tasks
         return
 
@@ -1055,9 +1097,13 @@ def _update_rover_tasks(agent_id, agent):
         if not stone_here.get("analyzed"):
             tasks.append(f"Analyze unknown vein at current tile ({x},{y})")
         elif not stone_here.get("extracted"):
-            tasks.append(f"Dig {stone_here['grade']} vein (qty={stone_here['quantity']}) at current tile ({x},{y})")
+            tasks.append(
+                f"Dig {stone_here['grade']} vein (qty={stone_here['quantity']}) at current tile ({x},{y})"
+            )
         else:
-            tasks.append(f"Pick up {stone_here['grade']} vein (qty={stone_here['quantity']}) at current tile ({x},{y})")
+            tasks.append(
+                f"Pick up {stone_here['grade']} vein (qty={stone_here['quantity']}) at current tile ({x},{y})"
+            )
         agent["tasks"] = tasks
         return
 
@@ -1187,12 +1233,12 @@ def observe_rover(agent_id):
             hint = _direction_hint(sp[0] - x, sp[1] - y)
             grade_info = stone.get("grade", "unknown")
             qty_info = stone.get("quantity", 0)
-            label = f"{stone['type']} {grade_info}" if stone["type"] != "unknown" else "unknown vein"
+            label = (
+                f"{stone['type']} {grade_info}" if stone["type"] != "unknown" else "unknown vein"
+            )
             if qty_info > 0:
                 label += f" qty={qty_info}"
-            visible_stones.append(
-                f"{label} ({status}) at ({sp[0]},{sp[1]}) — {hint}, {dist} tiles"
-            )
+            visible_stones.append(f"{label} ({status}) at ({sp[0]},{sp[1]}) — {hint}, {dist} tiles")
 
     # Mission info
     world_mission = WORLD.get("mission", {})
@@ -1232,22 +1278,26 @@ def observe_station():
     for aid, agent in WORLD["agents"].items():
         if agent["type"] == "station":
             continue
-        rovers.append(RoverSummary(
-            id=aid,
-            position=list(agent["position"]),
-            battery=agent["battery"],
-            mission=AgentMission(**agent["mission"]),
-            visited_count=len(agent.get("visited", [])),
-        ))
+        rovers.append(
+            RoverSummary(
+                id=aid,
+                position=list(agent["position"]),
+                battery=agent["battery"],
+                mission=AgentMission(**agent["mission"]),
+                visited_count=len(agent.get("visited", [])),
+            )
+        )
 
     stones = []
     for s in WORLD.get("stones", []):
-        stones.append(StoneInfo(
-            type=s["type"],
-            position=list(s["position"]),
-            grade=s.get("grade", "unknown"),
-            quantity=s.get("quantity", 0),
-        ))
+        stones.append(
+            StoneInfo(
+                type=s["type"],
+                position=list(s["position"]),
+                grade=s.get("grade", "unknown"),
+                quantity=s.get("quantity", 0),
+            )
+        )
 
     return StationContext(
         grid_w=GRID_W,

--- a/server/tests/test_agent.py
+++ b/server/tests/test_agent.py
@@ -8,7 +8,10 @@ class TestRoverFallback(unittest.TestCase):
     def setUp(self):
         WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
         WORLD["agents"]["rover-mistral"]["battery"] = 1.0
-        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["mission"] = {
+            "objective": "Explore the terrain",
+            "plan": [],
+        }
         WORLD["agents"]["rover-mistral"]["visited"] = [[10, 10]]
 
     def test_fallback_returns_dict(self):

--- a/server/tests/test_host.py
+++ b/server/tests/test_host.py
@@ -90,7 +90,10 @@ class TestHostStationRouting(unittest.TestCase):
         result = {
             "thinking": "Assigning mission.",
             "actions": [
-                {"name": "assign_mission", "params": {"agent_id": "rover-mock", "objective": "Go north"}},
+                {
+                    "name": "assign_mission",
+                    "params": {"agent_id": "rover-mock", "objective": "Go north"},
+                },
             ],
         }
 
@@ -98,9 +101,7 @@ class TestHostStationRouting(unittest.TestCase):
             mock_exec.return_value = {"ok": True, "agent_id": "rover-mock", "objective": "Go north"}
             with patch("app.host.broadcaster") as mock_bc:
                 mock_bc.send = AsyncMock()
-                asyncio.run(
-                    host.route_station_actions(result)
-                )
+                asyncio.run(host.route_station_actions(result))
 
         # Command should be in rover inbox
         commands = host.drain_inbox("rover-mock")
@@ -122,9 +123,7 @@ class TestHostStationRouting(unittest.TestCase):
             mock_exec.return_value = {"ok": True, "message": "Storm!"}
             with patch("app.host.broadcaster") as mock_bc:
                 mock_bc.send = AsyncMock()
-                asyncio.run(
-                    host.route_station_actions(result)
-                )
+                asyncio.run(host.route_station_actions(result))
                 # Verify broadcast was called
                 mock_bc.send.assert_called()
 
@@ -132,14 +131,17 @@ class TestHostStationRouting(unittest.TestCase):
 class TestHostAbortMission(unittest.TestCase):
     def setUp(self):
         from app.world import WORLD
+
         self._original_status = WORLD["mission"]["status"]
 
     def tearDown(self):
         from app.world import WORLD
+
         WORLD["mission"]["status"] = self._original_status
 
     def test_abort_broadcasts_event(self):
         from app.world import WORLD
+
         WORLD["mission"]["status"] = "running"
         host = _make_host()
 
@@ -154,6 +156,7 @@ class TestHostAbortMission(unittest.TestCase):
 
     def test_abort_already_ended(self):
         from app.world import WORLD
+
         WORLD["mission"]["status"] = "success"
         host = _make_host()
 
@@ -169,9 +172,7 @@ class TestHostRecall(unittest.TestCase):
 
         with patch("app.host.broadcaster") as mock_bc:
             mock_bc.send = AsyncMock()
-            result = asyncio.run(
-                host.recall_rover("rover-mock")
-            )
+            result = asyncio.run(host.recall_rover("rover-mock"))
 
         self.assertTrue(result["ok"])
         self.assertEqual(result["rover_id"], "rover-mock")
@@ -183,9 +184,7 @@ class TestHostRecall(unittest.TestCase):
     def test_recall_unknown_rover(self):
         host = _make_host()
 
-        result = asyncio.run(
-            host.recall_rover("nonexistent")
-        )
+        result = asyncio.run(host.recall_rover("nonexistent"))
 
         self.assertFalse(result["ok"])
         self.assertIn("Unknown rover", result["error"])

--- a/server/tests/test_protocol.py
+++ b/server/tests/test_protocol.py
@@ -68,7 +68,9 @@ class TestMakeMessage(unittest.TestCase):
     def test_make_message_with_correlation(self):
         trigger = make_message("rover-mock", "event", "check", {"stone": "core"})
         response = make_message(
-            "station", "command", "assign_mission",
+            "station",
+            "command",
+            "assign_mission",
             {"agent_id": "rover-mock"},
             correlation_id=trigger.id,
         )
@@ -82,6 +84,7 @@ class TestMakeMessage(unittest.TestCase):
     def test_to_dict_serializable(self):
         """Ensure to_dict produces JSON-serializable output."""
         import json
+
         msg = make_message("rover-mock", "action", "dig", {"x": 1, "y": 2})
         d = msg.to_dict()
         serialized = json.dumps(d)

--- a/server/tests/test_station.py
+++ b/server/tests/test_station.py
@@ -140,7 +140,9 @@ class TestStationHandleEvent(unittest.TestCase):
 class TestParseToolCalls(unittest.TestCase):
     def test_assign_mission_parsed(self):
         tool_calls = [
-            _mock_tool_call("assign_mission", {"agent_id": "rover-mistral", "objective": "Go north"})
+            _mock_tool_call(
+                "assign_mission", {"agent_id": "rover-mistral", "objective": "Go north"}
+            )
         ]
         actions = _parse_tool_calls(tool_calls)
 
@@ -175,36 +177,45 @@ class TestParseToolCalls(unittest.TestCase):
 
 class TestExecuteAction(unittest.TestCase):
     def test_assign_mission(self):
-        result = execute_action({
-            "name": "assign_mission",
-            "params": {"agent_id": "rover-mistral", "objective": "Go north"},
-        })
+        result = execute_action(
+            {
+                "name": "assign_mission",
+                "params": {"agent_id": "rover-mistral", "objective": "Go north"},
+            }
+        )
         self.assertTrue(result["ok"])
         self.assertEqual(result["agent_id"], "rover-mistral")
 
     def test_broadcast_alert(self):
-        result = execute_action({
-            "name": "broadcast_alert",
-            "params": {"message": "Storm incoming!"},
-        })
+        result = execute_action(
+            {
+                "name": "broadcast_alert",
+                "params": {"message": "Storm incoming!"},
+            }
+        )
         self.assertTrue(result["ok"])
         self.assertEqual(result["message"], "Storm incoming!")
 
     def test_charge_rover_at_station(self):
         from app.world import WORLD
+
         WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
         WORLD["agents"]["rover-mistral"]["battery"] = 0.5
-        result = execute_action({
-            "name": "charge_rover",
-            "params": {"rover_id": "rover-mistral"},
-        })
+        result = execute_action(
+            {
+                "name": "charge_rover",
+                "params": {"rover_id": "rover-mistral"},
+            }
+        )
         self.assertTrue(result["ok"])
 
     def test_unknown_action(self):
-        result = execute_action({
-            "name": "self_destruct",
-            "params": {},
-        })
+        result = execute_action(
+            {
+                "name": "self_destruct",
+                "params": {},
+            }
+        )
         self.assertFalse(result["ok"])
         self.assertIn("Unknown station action", result["error"])
 

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -35,7 +35,10 @@ class TestMoveAgent(unittest.TestCase):
     def setUp(self):
         WORLD["agents"]["rover-mistral"]["position"] = [2, 10]
         WORLD["agents"]["rover-mistral"]["battery"] = 1.0
-        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["mission"] = {
+            "objective": "Explore the terrain",
+            "plan": [],
+        }
         WORLD["agents"]["rover-mistral"]["visited"] = [[2, 10]]
 
     def test_move_success(self):
@@ -119,7 +122,10 @@ class TestExecuteAction(unittest.TestCase):
     def setUp(self):
         WORLD["agents"]["rover-mistral"]["position"] = [2, 10]
         WORLD["agents"]["rover-mistral"]["battery"] = 1.0
-        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["mission"] = {
+            "objective": "Explore the terrain",
+            "plan": [],
+        }
         WORLD["agents"]["rover-mistral"]["visited"] = [[2, 10]]
 
     def test_execute_move_east(self):
@@ -294,7 +300,10 @@ class TestVisited(unittest.TestCase):
     def setUp(self):
         WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
         WORLD["agents"]["rover-mistral"]["battery"] = 1.0
-        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["mission"] = {
+            "objective": "Explore the terrain",
+            "plan": [],
+        }
         WORLD["agents"]["rover-mistral"]["visited"] = [[10, 10]]
 
     def test_visited_initial(self):
@@ -316,7 +325,10 @@ class TestCheckGround(unittest.TestCase):
     def setUp(self):
         WORLD["agents"]["rover-mistral"]["position"] = [10, 10]
         WORLD["agents"]["rover-mistral"]["battery"] = 1.0
-        WORLD["agents"]["rover-mistral"]["mission"] = {"objective": "Explore the terrain", "plan": []}
+        WORLD["agents"]["rover-mistral"]["mission"] = {
+            "objective": "Explore the terrain",
+            "plan": [],
+        }
         WORLD["agents"]["rover-mistral"]["visited"] = [[10, 10]]
         self._original_stones = WORLD.get("stones", [])
 
@@ -331,7 +343,9 @@ class TestCheckGround(unittest.TestCase):
         self.assertFalse(result["stone"]["extracted"])
 
     def test_check_ground_extracted_stone(self):
-        WORLD["stones"] = [_make_vein([10, 10], grade="rich", quantity=500, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([10, 10], grade="rich", quantity=500, analyzed=True, extracted=True)
+        ]
         result = check_ground("rover-mistral")
         self.assertEqual(result["stone"]["type"], "basalt_vein")
         self.assertEqual(result["stone"]["grade"], "rich")
@@ -363,7 +377,9 @@ class TestAssignMission(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["agent_id"], "rover-mistral")
         self.assertEqual(result["objective"], "Go to north edge")
-        self.assertEqual(WORLD["agents"]["rover-mistral"]["mission"]["objective"], "Go to north edge")
+        self.assertEqual(
+            WORLD["agents"]["rover-mistral"]["mission"]["objective"], "Go to north edge"
+        )
 
     def test_assign_mission_unknown_agent(self):
         result = assign_mission("rover-99", "Go anywhere")
@@ -419,7 +435,9 @@ class TestAnalyze(unittest.TestCase):
 
     def test_analyze_drains_battery(self):
         execute_action("rover-mistral", "analyze", {})
-        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_ANALYZE)
+        self.assertAlmostEqual(
+            WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_ANALYZE
+        )
 
     def test_analyze_no_stone(self):
         WORLD["stones"] = []
@@ -483,7 +501,9 @@ class TestAnalyzeGround(unittest.TestCase):
         self.assertIn("5,5", readings)
 
     def test_analyze_ground_not_enough_battery(self):
-        WORLD["agents"]["rover-mistral"]["battery"] = BATTERY_COST_ANALYZE_GROUND * 0.5  # below cost
+        WORLD["agents"]["rover-mistral"]["battery"] = (
+            BATTERY_COST_ANALYZE_GROUND * 0.5
+        )  # below cost
         result = execute_action("rover-mistral", "analyze_ground", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
@@ -526,7 +546,9 @@ class TestDig(unittest.TestCase):
         self.assertIn("No vein", result["error"])
 
     def test_dig_already_extracted(self):
-        WORLD["stones"] = [_make_vein([5, 5], grade="high", quantity=200, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([5, 5], grade="high", quantity=200, analyzed=True, extracted=True)
+        ]
         result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("already extracted", result["error"])
@@ -559,7 +581,9 @@ class TestPickup(unittest.TestCase):
         WORLD["agents"]["rover-mistral"]["inventory"] = []
         WORLD["agents"]["rover-mistral"]["visited"] = [[5, 5]]
         self._original_stones = WORLD.get("stones", [])
-        WORLD["stones"] = [_make_vein([5, 5], grade="rich", quantity=400, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([5, 5], grade="rich", quantity=400, analyzed=True, extracted=True)
+        ]
 
     def tearDown(self):
         WORLD["stones"] = self._original_stones
@@ -586,7 +610,9 @@ class TestPickup(unittest.TestCase):
 
     def test_pickup_drains_battery(self):
         execute_action("rover-mistral", "pickup", {})
-        self.assertAlmostEqual(WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_PICKUP)
+        self.assertAlmostEqual(
+            WORLD["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_PICKUP
+        )
 
     def test_pickup_not_extracted(self):
         WORLD["stones"] = [_make_vein([5, 5], grade="low", quantity=30, analyzed=True)]
@@ -832,14 +858,18 @@ class TestMissionCompletion(unittest.TestCase):
         self.assertEqual(snap["mission"]["status"], "running")
 
     def test_collected_quantity_updates_on_pickup(self):
-        WORLD["stones"] = [_make_vein([5, 5], grade="high", quantity=200, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([5, 5], grade="high", quantity=200, analyzed=True, extracted=True)
+        ]
         execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["collected_quantity"], 200)
 
     def test_pickup_away_from_station_no_success(self):
         """Picking up a vein away from station should NOT trigger success."""
         WORLD["mission"]["target_quantity"] = 100
-        WORLD["stones"] = [_make_vein([5, 5], grade="pristine", quantity=900, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([5, 5], grade="pristine", quantity=900, analyzed=True, extracted=True)
+        ]
         result = execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "running")
         self.assertNotIn("mission", result)
@@ -850,7 +880,9 @@ class TestMissionCompletion(unittest.TestCase):
         WORLD["mission"]["target_quantity"] = 100
         WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
         WORLD["agents"]["station"]["position"] = [0, 0]
-        WORLD["stones"] = [_make_vein([0, 0], grade="high", quantity=200, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([0, 0], grade="high", quantity=200, analyzed=True, extracted=True)
+        ]
         result = execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "success")
         self.assertIn("mission", result)
@@ -860,7 +892,9 @@ class TestMissionCompletion(unittest.TestCase):
         """Moving to station while carrying enough basalt triggers success."""
         WORLD["mission"]["target_quantity"] = 100
         WORLD["agents"]["rover-mistral"]["position"] = [1, 0]
-        WORLD["agents"]["rover-mistral"]["inventory"] = [{"type": "basalt_vein", "grade": "rich", "quantity": 150}]
+        WORLD["agents"]["rover-mistral"]["inventory"] = [
+            {"type": "basalt_vein", "grade": "rich", "quantity": 150}
+        ]
         WORLD["agents"]["station"]["position"] = [0, 0]
         WORLD["stones"] = []
         result = execute_action("rover-mistral", "move", {"direction": "west"})
@@ -873,12 +907,16 @@ class TestMissionCompletion(unittest.TestCase):
         WORLD["agents"]["station"]["position"] = [0, 0]
         # First pickup: 200 units at station
         WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
-        WORLD["stones"] = [_make_vein([0, 0], grade="high", quantity=200, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([0, 0], grade="high", quantity=200, analyzed=True, extracted=True)
+        ]
         execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "running")
         # Rover-mistral picks up another 200 at station — total 400 >= 300
         WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
-        WORLD["stones"] = [_make_vein([0, 0], grade="high", quantity=200, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([0, 0], grade="high", quantity=200, analyzed=True, extracted=True)
+        ]
         result = execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "success")
         self.assertEqual(WORLD["mission"]["collected_quantity"], 400)
@@ -922,7 +960,9 @@ class TestMissionCompletion(unittest.TestCase):
         WORLD["mission"]["target_quantity"] = 500
         WORLD["agents"]["rover-mistral"]["position"] = [0, 0]
         WORLD["agents"]["station"]["position"] = [0, 0]
-        WORLD["stones"] = [_make_vein([0, 0], grade="medium", quantity=100, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([0, 0], grade="medium", quantity=100, analyzed=True, extracted=True)
+        ]
         execute_action("rover-mistral", "pickup", {})
         self.assertEqual(WORLD["mission"]["status"], "running")
         self.assertEqual(WORLD["mission"]["collected_quantity"], 100)
@@ -964,7 +1004,9 @@ class TestMemory(unittest.TestCase):
         self.assertIn("qty=80", mem[0])
 
     def test_pickup_records_memory(self):
-        WORLD["stones"] = [_make_vein([10, 10], grade="rich", quantity=400, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([10, 10], grade="rich", quantity=400, analyzed=True, extracted=True)
+        ]
         execute_action("rover-mistral", "pickup", {})
         mem = WORLD["agents"]["rover-mistral"]["memory"]
         self.assertEqual(len(mem), 1)
@@ -1069,7 +1111,9 @@ class TestUpdateTasks(unittest.TestCase):
         self.assertIn("Dig", tasks[0])
 
     def test_pickup_when_stone_extracted(self):
-        WORLD["stones"] = [_make_vein([5, 5], grade="rich", quantity=400, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([5, 5], grade="rich", quantity=400, analyzed=True, extracted=True)
+        ]
         update_tasks("rover-mistral")
         tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertEqual(len(tasks), 1)
@@ -1087,7 +1131,9 @@ class TestUpdateTasks(unittest.TestCase):
         self.assertIn("east", tasks[0])
 
     def test_return_to_station_when_has_target(self):
-        WORLD["agents"]["rover-mistral"]["inventory"] = [{"type": "basalt_vein", "grade": "high", "quantity": 200}]
+        WORLD["agents"]["rover-mistral"]["inventory"] = [
+            {"type": "basalt_vein", "grade": "high", "quantity": 200}
+        ]
         update_tasks("rover-mistral")
         tasks = WORLD["agents"]["rover-mistral"]["tasks"]
         self.assertEqual(len(tasks), 1)
@@ -1155,7 +1201,9 @@ class TestObserveRover(unittest.TestCase):
         self.assertIn("high", ctx.computed.stone_line)
 
     def test_stone_line_extracted(self):
-        WORLD["stones"] = [_make_vein([5, 5], grade="rich", quantity=400, analyzed=True, extracted=True)]
+        WORLD["stones"] = [
+            _make_vein([5, 5], grade="rich", quantity=400, analyzed=True, extracted=True)
+        ]
         ctx = observe_rover("rover-mistral")
         self.assertIn("pickup", ctx.computed.stone_line)
         self.assertIn("rich", ctx.computed.stone_line)
@@ -1171,7 +1219,9 @@ class TestObserveRover(unittest.TestCase):
         self.assertIn("basalt_vein", ctx.computed.visible_stones[0])
 
     def test_inventory_in_context(self):
-        WORLD["agents"]["rover-mistral"]["inventory"] = [{"type": "basalt_vein", "grade": "high", "quantity": 200}]
+        WORLD["agents"]["rover-mistral"]["inventory"] = [
+            {"type": "basalt_vein", "grade": "high", "quantity": 200}
+        ]
         ctx = observe_rover("rover-mistral")
         self.assertEqual(len(ctx.agent.inventory), 1)
         self.assertEqual(ctx.agent.inventory[0].type, "basalt_vein")
@@ -1398,8 +1448,12 @@ class TestVeinGradeDistribution(unittest.TestCase):
             expected_pct = VEIN_WEIGHTS[i] / total_weight
             actual_pct = counts[grade] / n
             # Allow generous tolerance (5% absolute) for statistical sampling
-            self.assertAlmostEqual(actual_pct, expected_pct, delta=0.05,
-                msg=f"Grade '{grade}': expected ~{expected_pct:.1%}, got {actual_pct:.1%}")
+            self.assertAlmostEqual(
+                actual_pct,
+                expected_pct,
+                delta=0.05,
+                msg=f"Grade '{grade}': expected ~{expected_pct:.1%}, got {actual_pct:.1%}",
+            )
 
     def test_quantity_ranges_per_grade(self):
         """Verify that random quantities stay within defined ranges."""
@@ -1527,11 +1581,13 @@ class TestStoneProximityConcentration(unittest.TestCase):
 
     def test_concentration_at_stone(self):
         from app.world import _stone_proximity_concentration
+
         WORLD["stones"] = [_make_vein([5, 5])]
         self.assertEqual(_stone_proximity_concentration(5, 5), 1.0)
 
     def test_concentration_falls_off(self):
         from app.world import _stone_proximity_concentration
+
         WORLD["stones"] = [_make_vein([5, 5])]
         val_near = _stone_proximity_concentration(6, 5)
         val_far = _stone_proximity_concentration(10, 5)
@@ -1539,6 +1595,7 @@ class TestStoneProximityConcentration(unittest.TestCase):
 
     def test_concentration_zero_far_away(self):
         from app.world import _stone_proximity_concentration
+
         WORLD["stones"] = [_make_vein([5, 5])]
         val = _stone_proximity_concentration(50, 50)
         self.assertEqual(val, 0.0)


### PR DESCRIPTION
## Summary

Apply ruff format to 9 files that were failing the `ruff format --check` CI step.

## Change Type

- [x] `style` — Formatting, linting (no logic change)

## How to Test

1. `cd server && uv run ruff format --check app/ tests/` — 0 files to reformat
2. `cd server && uv run ruff check app/ tests/` — 0 errors
3. `cd server && uv run python -m pytest tests/ -q` — 291 pass

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>