### PR TITLE
feat(ui): Phase 5 — Responsive layout

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -325,4 +325,39 @@ h2 {
 .follow-btn.active {
   font-weight: bold;
 }
+
+/* ── Responsive: Tablet (≤768px) ── */
+@media (max-width: 768px) {
+  .app {
+    padding: 0.5rem;
+  }
+
+  .top-row {
+    flex-direction: column;
+  }
+
+  .left-col {
+    flex: none;
+  }
+}
+
+/* ── Responsive: Mobile (≤480px) ── */
+@media (max-width: 480px) {
+  .app {
+    padding: 0.25rem;
+  }
+
+  h2 {
+    font-size: 0.75rem;
+  }
+
+  .follow-bar {
+    gap: 0.2rem;
+  }
+
+  .follow-btn {
+    font-size: 0.55rem;
+    padding: 0.1rem 0.3rem;
+  }
+}
 </style>

--- a/ui/src/components/AgentPane.vue
+++ b/ui/src/components/AgentPane.vue
@@ -215,4 +215,24 @@ const emit = defineEmits(['select-agent'])
 .ae-text.action-text {
   color: #7a9a7a;
 }
+
+@media (max-width: 768px) {
+  .agent-pane {
+    height: 160px;
+  }
+}
+
+@media (max-width: 480px) {
+  .agent-pane {
+    height: 140px;
+  }
+
+  .agent-name {
+    font-size: 0.7rem;
+  }
+
+  .agent-stats {
+    font-size: 0.6rem;
+  }
+}
 </style>

--- a/ui/src/components/AppHeader.vue
+++ b/ui/src/components/AppHeader.vue
@@ -105,4 +105,37 @@ h1 {
   background: var(--bg-status-ok);
   color: var(--accent-green);
 }
+
+@media (max-width: 768px) {
+  header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  h1 {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  h1 {
+    font-size: 0.85rem;
+    width: 100%;
+  }
+
+  .header-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .reset-btn,
+  .pause-btn {
+    font-size: 0.65rem;
+    padding: 0.2rem 0.4rem;
+  }
+
+  .status {
+    font-size: 0.65rem;
+  }
+}
 </style>

--- a/ui/src/components/MiniMap.vue
+++ b/ui/src/components/MiniMap.vue
@@ -172,4 +172,10 @@ function onClick(e) {
   display: block;
   cursor: crosshair;
 }
+
+@media (max-width: 480px) {
+  .minimap {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary
Add responsive breakpoints at 768px (tablet) and 480px (mobile) across 4 components.

## Changes
- **App.vue**: Stack main layout vertically at tablet, reduce padding on mobile
- **AppHeader.vue**: Wrap header controls at tablet, full-width on mobile
- **AgentPane.vue**: Reduce pane height and text sizes at both breakpoints
- **MiniMap.vue**: Hide entirely on mobile to save vertical space

## Part of
UI Polish spec: `specs/002-ui-polish/spec.md` (Phase 5 of 8)

Co-Authored-By: Oz <oz-agent@warp.dev>