### PR TITLE
feat(ui): add Vue transitions to modal, event log, and narration player

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -168,12 +168,14 @@ function onUnfollow() {
       />
     </div>
 
-    <AgentDetailModal
-      v-if="selectedAgent"
-      :agent="agentData(selectedAgent)"
-      :agent-id="selectedAgent"
-      @close="closeAgent"
-    />
+    <Transition name="modal">
+      <AgentDetailModal
+        v-if="selectedAgent"
+        :agent="agentData(selectedAgent)"
+        :agent-id="selectedAgent"
+        @close="closeAgent"
+      />
+    </Transition>
   </div>
 </template>
 
@@ -291,6 +293,32 @@ h2 {
 ::-webkit-scrollbar-thumb {
   background: var(--border-separator);
   border-radius: 2px;
+}
+
+/* ── Modal transition ── */
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-enter-active .modal,
+.modal-leave-active .modal {
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-from .modal {
+  transform: translateY(16px) scale(0.97);
+  opacity: 0;
+}
+
+.modal-leave-to .modal {
+  transform: translateY(8px) scale(0.98);
+  opacity: 0;
 }
 
 .follow-bar {

--- a/ui/src/components/EventLog.vue
+++ b/ui/src/components/EventLog.vue
@@ -64,26 +64,28 @@ function formatPayload(event) {
     >
       Waiting for mission events...
     </div>
-    <div
-      v-for="(event, i) in events"
-      :key="i"
-      class="event"
-    >
-      <span
-        v-if="event.tick != null"
-        class="event-tick"
-      >#{{ event.tick }}</span>
-      <span
-        class="event-source"
-        :style="{ color: agentColor(event.source) }"
-      >{{ event.source }}</span>
-      <span class="event-type">{{ event.type }}</span>
-      <span class="event-name">{{ event.name }}</span>
-      <span
-        v-if="event.payload && formatPayload(event)"
-        class="event-payload"
-      >{{ formatPayload(event) }}</span>
-    </div>
+    <TransitionGroup name="event-item">
+      <div
+        v-for="(event, i) in events"
+        :key="event._uid ?? i"
+        class="event"
+      >
+        <span
+          v-if="event.tick != null"
+          class="event-tick"
+        >#{{ event.tick }}</span>
+        <span
+          class="event-source"
+          :style="{ color: agentColor(event.source) }"
+        >{{ event.source }}</span>
+        <span class="event-type">{{ event.type }}</span>
+        <span class="event-name">{{ event.name }}</span>
+        <span
+          v-if="event.payload && formatPayload(event)"
+          class="event-payload"
+        >{{ formatPayload(event) }}</span>
+      </div>
+    </TransitionGroup>
   </section>
 </template>
 
@@ -136,5 +138,19 @@ function formatPayload(event) {
   text-overflow: ellipsis;
   flex: 1;
   min-width: 0;
+}
+
+/* ── TransitionGroup animations ── */
+.event-item-enter-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.event-item-enter-from {
+  opacity: 0;
+  transform: translateX(-12px);
+}
+
+.event-item-move {
+  transition: transform 0.3s ease;
 }
 </style>

--- a/ui/src/components/NarrationPlayer.vue
+++ b/ui/src/components/NarrationPlayer.vue
@@ -161,35 +161,43 @@ function skipAudio() {
       <span class="narrator-label">MISSION COMMS</span>
     </div>
 
-    <div
-      v-if="dialogueLines.length > 0"
-      class="narration-text dialogue-block"
+    <Transition
+      name="narration-fade"
+      mode="out-in"
     >
       <div
-        v-for="(line, idx) in dialogueLines"
-        :key="idx"
-        class="dialogue-line"
+        v-if="dialogueLines.length > 0"
+        :key="'dialogue-' + dialogueLines.length"
+        class="narration-text dialogue-block"
       >
-        <span
-          class="speaker-label"
-          :style="{ color: line.color }"
-        >{{ line.label }}:</span>
-        <span class="speaker-text">{{ line.text }}</span>
+        <div
+          v-for="(line, idx) in dialogueLines"
+          :key="idx"
+          class="dialogue-line"
+        >
+          <span
+            class="speaker-label"
+            :style="{ color: line.color }"
+          >{{ line.label }}:</span>
+          <span class="speaker-text">{{ line.text }}</span>
+        </div>
       </div>
-    </div>
 
-    <div
-      v-else-if="currentText"
-      class="narration-text"
-    >
-      {{ currentText }}
-    </div>
-    <div
-      v-else
-      class="narration-text idle"
-    >
-      Awaiting mission events...
-    </div>
+      <div
+        v-else-if="currentText"
+        :key="'text'"
+        class="narration-text"
+      >
+        {{ currentText }}
+      </div>
+      <div
+        v-else
+        :key="'idle'"
+        class="narration-text idle"
+      >
+        Awaiting mission events...
+      </div>
+    </Transition>
 
     <div class="narration-controls">
       <button
@@ -351,6 +359,17 @@ function skipAudio() {
 
 .toggle-btn.off {
   opacity: 0.3;
+}
+
+/* ── Narration text fade transition ── */
+.narration-fade-enter-active,
+.narration-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.narration-fade-enter-from,
+.narration-fade-leave-to {
+  opacity: 0;
 }
 
 /* Responsive */

--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -7,6 +7,7 @@ export function useWebSocket({ onConnect } = {}) {
   const narration = ref(null)
   const narrationChunk = ref(null)
   let ws = null
+  let eventUid = 0
 
   const agentEvents = computed(() => {
     const byAgent = {}
@@ -43,6 +44,7 @@ export function useWebSocket({ onConnect } = {}) {
       } else if (event.source === 'narrator' && event.name === 'narration_chunk') {
         narrationChunk.value = event.payload
       } else {
+        event._uid = ++eventUid
         events.value.unshift(event)
         if (events.value.length > 200) {
           events.value.length = 200


### PR DESCRIPTION
## Summary
Add Vue `<Transition>` and `<TransitionGroup>` animations across three key components:

### Changes
- **AgentDetailModal**: `<Transition name="modal">` — fade overlay + slide-up/scale panel (0.25s ease)
- **EventLog**: `<TransitionGroup name="event-item">` — new events slide in from left with opacity fade (0.3s ease)
- **NarrationPlayer**: `<Transition name="narration-fade" mode="out-in">` — smooth crossfade between idle/text/dialogue states (0.3s ease)
- **useWebSocket**: Assigns unique `_uid` to each event for stable TransitionGroup keys

### Files changed
- `ui/src/App.vue` — Wrap modal, add modal transition CSS
- `ui/src/components/EventLog.vue` — TransitionGroup + animation CSS
- `ui/src/components/NarrationPlayer.vue` — Transition wrapper + fade CSS
- `ui/src/composables/useWebSocket.js` — Event UID counter

Co-Authored-By: Oz <oz-agent@warp.dev>