### PR TITLE
feat(ui): add keyboard shortcuts for simulation control

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useWebSocket } from './composables/useWebSocket.js'
+import { useKeyboard } from './composables/useKeyboard.js'
 import { agentColor } from './constants.js'
 import AppHeader from './components/AppHeader.vue'
 import WorldMap from './components/WorldMap.vue'
@@ -98,6 +99,24 @@ function setFollowAgent(id) {
 function onUnfollow() {
   followAgent.value = null
 }
+
+// Keyboard shortcuts
+useKeyboard({
+  onTogglePause: () => togglePause(),
+  onPanCamera: (dx, dy) => {
+    if (worldMapRef.value) {
+      worldMapRef.value.panCamera(dx, dy)
+      followAgent.value = null
+    }
+  },
+  onFollowAgent: (idx) => {
+    if (mobileAgents.value[idx]) {
+      setFollowAgent(mobileAgents.value[idx])
+    }
+  },
+  onFreeCamera: () => { followAgent.value = null },
+  onCloseModal: () => { selectedAgent.value = null },
+})
 </script>
 
 <template>

--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -250,8 +250,13 @@ function onMouseUp() {
   dragging.value = false
 }
 
-// Expose camera for minimap
-defineExpose({ camX, camY })
+function panCamera(dx, dy) {
+  targetCamX.value += dx
+  targetCamY.value += dy
+}
+
+// Expose camera for minimap & keyboard shortcuts
+defineExpose({ camX, camY, panCamera })
 </script>
 
 <template>

--- a/ui/src/composables/useKeyboard.js
+++ b/ui/src/composables/useKeyboard.js
@@ -1,0 +1,72 @@
+import { onMounted, onUnmounted } from 'vue'
+
+/**
+ * Global keyboard shortcuts for the simulation UI.
+ *
+ * @param {Object} opts
+ * @param {Function} opts.onTogglePause    — Space key
+ * @param {Function} opts.onPanCamera      — Arrow / WASD keys → (dx, dy)
+ * @param {Function} opts.onFollowAgent    — 1-9 digit keys → index (0-based)
+ * @param {Function} opts.onFreeCamera     — 0 key
+ * @param {Function} opts.onCloseModal     — Escape key
+ */
+export function useKeyboard({ onTogglePause, onPanCamera, onFollowAgent, onFreeCamera, onCloseModal } = {}) {
+  function handler(e) {
+    // Skip if user is typing in an input / textarea / contenteditable
+    const tag = e.target.tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return
+
+    switch (e.code) {
+      case 'Space':
+        e.preventDefault()
+        onTogglePause?.()
+        break
+      case 'Escape':
+        onCloseModal?.()
+        break
+
+      // Camera panning — Arrow keys & WASD
+      case 'ArrowLeft':
+      case 'KeyA':
+        e.preventDefault()
+        onPanCamera?.(-1, 0)
+        break
+      case 'ArrowRight':
+      case 'KeyD':
+        e.preventDefault()
+        onPanCamera?.(1, 0)
+        break
+      case 'ArrowUp':
+      case 'KeyW':
+        e.preventDefault()
+        onPanCamera?.(0, 1)
+        break
+      case 'ArrowDown':
+      case 'KeyS':
+        e.preventDefault()
+        onPanCamera?.(0, -1)
+        break
+
+      // Agent follow — digit keys 1-9, 0 = free
+      case 'Digit0':
+        onFreeCamera?.()
+        break
+      case 'Digit1':
+      case 'Digit2':
+      case 'Digit3':
+      case 'Digit4':
+      case 'Digit5':
+      case 'Digit6':
+      case 'Digit7':
+      case 'Digit8':
+      case 'Digit9':
+        onFollowAgent?.(parseInt(e.code.slice(-1), 10) - 1)
+        break
+      default:
+        break
+    }
+  }
+
+  onMounted(() => window.addEventListener('keydown', handler))
+  onUnmounted(() => window.removeEventListener('keydown', handler))
+}


### PR DESCRIPTION
## Summary
Add global keyboard shortcuts via a new `useKeyboard` composable.

### Shortcuts
- **Space** — Toggle pause/resume
- **Arrow keys / WASD** — Pan camera (smooth interpolation)
- **1–9** — Follow mobile agent by index
- **0** — Free camera
- **Escape** — Close agent detail modal

### Files changed
- `ui/src/composables/useKeyboard.js` — New composable with keydown handler + input field skip
- `ui/src/App.vue` — Wire useKeyboard with all callbacks
- `ui/src/components/WorldMap.vue` — Expose `panCamera(dx, dy)` method

Co-Authored-By: Oz <oz-agent@warp.dev>