### PR TITLE
feat(ui): add toast notification system for critical simulation events

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue'
 import { useWebSocket } from './composables/useWebSocket.js'
 import { useKeyboard } from './composables/useKeyboard.js'
+import { useToasts } from './composables/useToasts.js'
 import { agentColor } from './constants.js'
 import AppHeader from './components/AppHeader.vue'
 import WorldMap from './components/WorldMap.vue'
@@ -12,6 +13,7 @@ import EventLog from './components/EventLog.vue'
 import AgentDetailModal from './components/AgentDetailModal.vue'
 import NarrationPlayer from './components/NarrationPlayer.vue'
 import StatsBar from './components/StatsBar.vue'
+import ToastOverlay from './components/ToastOverlay.vue'
 
 const selectedAgent = ref(null)
 const paused = ref(false)
@@ -63,7 +65,29 @@ async function resetSimulation() {
   }
 }
 
-const { events, connected, worldState, agentIds, agentEvents, narration, narrationChunk } = useWebSocket({ onConnect: onWsConnect })
+const { toasts, addToast, dismiss: dismissToast } = useToasts()
+
+function onSimEvent(event) {
+  switch (event.name) {
+    case 'mission_success':
+      addToast(`Mission complete — ${event.payload?.collected_quantity ?? '?'} collected`, { type: 'success', duration: 6000 })
+      break
+    case 'mission_aborted':
+      addToast(`Mission aborted — ${event.payload?.reason || 'unknown'}`, { type: 'error', duration: 6000 })
+      break
+    case 'alert':
+      addToast(`${event.source}: ${event.payload?.message || 'Alert'}`, { type: 'warning' })
+      break
+    case 'analyze':
+      if (event.payload?.stone)
+        addToast(`${event.source}: found ${event.payload.stone.grade} vein`, { type: 'info' })
+      break
+    default:
+      break
+  }
+}
+
+const { events, connected, worldState, agentIds, agentEvents, narration, narrationChunk } = useWebSocket({ onConnect: onWsConnect, onEvent: onSimEvent })
 
 async function togglePause() {
   const endpoint = paused.value ? '/api/simulation/resume' : '/api/simulation/pause'
@@ -193,6 +217,11 @@ useKeyboard({
         @select-agent="selectAgent"
       />
     </div>
+
+    <ToastOverlay
+      :toasts="toasts"
+      @dismiss="dismissToast"
+    />
 
     <Transition name="modal">
       <AgentDetailModal

--- a/ui/src/components/ToastOverlay.vue
+++ b/ui/src/components/ToastOverlay.vue
@@ -1,0 +1,117 @@
+<script setup>
+defineProps({
+  toasts: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const emit = defineEmits(['dismiss'])
+
+const ICONS = {
+  success: '✓',
+  warning: '⚠',
+  error: '✗',
+  info: '●',
+}
+</script>
+
+<template>
+  <div class="toast-container">
+    <TransitionGroup name="toast">
+      <div
+        v-for="toast in toasts"
+        :key="toast.id"
+        :class="['toast', 'toast-' + toast.type]"
+        @click="emit('dismiss', toast.id)"
+      >
+        <span class="toast-icon">{{ ICONS[toast.type] || ICONS.info }}</span>
+        <span class="toast-msg">{{ toast.message }}</span>
+      </div>
+    </TransitionGroup>
+  </div>
+</template>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  pointer-events: none;
+  max-width: 320px;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--radius-md);
+  font-size: 0.7rem;
+  font-family: var(--font-mono);
+  pointer-events: auto;
+  cursor: pointer;
+  border: 1px solid var(--border-subtle);
+  backdrop-filter: blur(6px);
+}
+
+.toast-icon {
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+.toast-msg {
+  line-height: 1.3;
+}
+
+.toast-info {
+  background: rgba(26, 26, 48, 0.92);
+  color: var(--accent-blue);
+  border-color: var(--accent-blue);
+}
+
+.toast-success {
+  background: rgba(17, 51, 17, 0.92);
+  color: var(--accent-green);
+  border-color: var(--accent-green);
+}
+
+.toast-warning {
+  background: rgba(42, 26, 10, 0.92);
+  color: var(--accent-amber);
+  border-color: var(--accent-amber);
+}
+
+.toast-error {
+  background: rgba(51, 17, 17, 0.92);
+  color: var(--accent-red);
+  border-color: var(--accent-red);
+}
+
+/* TransitionGroup animations */
+.toast-enter-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.toast-enter-from {
+  opacity: 0;
+  transform: translateX(20px);
+}
+
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(20px);
+}
+
+.toast-move {
+  transition: transform 0.3s ease;
+}
+</style>

--- a/ui/src/composables/useToasts.js
+++ b/ui/src/composables/useToasts.js
@@ -1,0 +1,25 @@
+import { ref } from 'vue'
+
+let toastId = 0
+
+/**
+ * Lightweight toast notification system.
+ * Toasts auto-dismiss after a configurable duration.
+ */
+export function useToasts() {
+  const toasts = ref([])
+
+  function addToast(message, { type = 'info', duration = 4000 } = {}) {
+    const id = ++toastId
+    toasts.value.push({ id, message, type })
+    setTimeout(() => {
+      toasts.value = toasts.value.filter(t => t.id !== id)
+    }, duration)
+  }
+
+  function dismiss(id) {
+    toasts.value = toasts.value.filter(t => t.id !== id)
+  }
+
+  return { toasts, addToast, dismiss }
+}

--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -1,6 +1,6 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 
-export function useWebSocket({ onConnect } = {}) {
+export function useWebSocket({ onConnect, onEvent } = {}) {
   const events = ref([])
   const connected = ref(false)
   const worldState = ref(null)
@@ -49,6 +49,7 @@ export function useWebSocket({ onConnect } = {}) {
         if (events.value.length > 200) {
           events.value.length = 200
         }
+        if (onEvent) onEvent(event)
       }
     }
 


### PR DESCRIPTION
## Summary
Lightweight auto-dismissing toast notifications for critical simulation events.

### Components
- `ui/src/composables/useToasts.js` — Manages toast lifecycle (add, auto-dismiss, manual dismiss)
- `ui/src/components/ToastOverlay.vue` — Fixed overlay with TransitionGroup slide-in animations
- `ui/src/composables/useWebSocket.js` — Added `onEvent` callback for event-driven triggers

### Toast triggers
- **mission_success** → green success toast (6s)
- **mission_aborted** → red error toast (6s)
- **alert** → amber warning toast (4s)
- **analyze** (vein found) → blue info toast (4s)

### Interaction
- Click to dismiss early
- Stacks vertically from top-right
- Backdrop blur for readability

Co-Authored-By: Oz <oz-agent@warp.dev>