### PR TITLE
feat(ui): finalize color token cleanup and add EventLog color coding

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -180,14 +180,14 @@ useKeyboard({
             v-for="id in mobileAgents"
             :key="id"
             :class="['follow-btn', { active: followAgent === id }]"
-            :style="{ borderColor: agentColor(id), color: followAgent === id ? '#0a0a0f' : agentColor(id), backgroundColor: followAgent === id ? agentColor(id) : 'transparent' }"
+            :style="{ borderColor: agentColor(id), color: followAgent === id ? 'var(--bg-primary)' : agentColor(id), backgroundColor: followAgent === id ? agentColor(id) : 'transparent' }"
             @click="setFollowAgent(id)"
           >
             {{ id }}
           </button>
           <button
             :class="['follow-btn', { active: !followAgent }]"
-            :style="{ borderColor: '#555', color: !followAgent ? '#0a0a0f' : '#555', backgroundColor: !followAgent ? '#555' : 'transparent' }"
+            :style="{ borderColor: 'var(--accent-free)', color: !followAgent ? 'var(--bg-primary)' : 'var(--accent-free)', backgroundColor: !followAgent ? 'var(--accent-free)' : 'transparent' }"
             @click="followAgent = null"
           >
             Free
@@ -274,6 +274,11 @@ useKeyboard({
   --accent-task: #e0a040;
   --accent-memory: #7a9a7a;
   --accent-mission: #8a8a6a;
+  --accent-think: #668;
+  --accent-unknown: #4a4a6a;
+  --accent-unknown-border: #2a2a3a;
+  --accent-free: #555;
+  --accent-panel-stroke: #aa8020;
 
   /* Status backgrounds */
   --bg-status-ok: #113311;
@@ -281,6 +286,8 @@ useKeyboard({
   --bg-status-info: #1a1a30;
   --bg-status-warn: #2a1a0a;
   --bg-status-narration: #2a1a30;
+  --bg-minimap: #060609;
+  --bg-minimap-revealed: #1a1a28;
 
   /* Typography */
   --font-mono: 'JetBrains Mono', monospace;

--- a/ui/src/components/AgentDetailModal.vue
+++ b/ui/src/components/AgentDetailModal.vue
@@ -292,8 +292,8 @@ function batteryPct() {
 }
 
 .inv-stone.unknown {
-  color: #4a4a6a;
-  border-color: #2a2a3a;
+  color: var(--accent-unknown);
+  border-color: var(--accent-unknown-border);
 }
 
 .modal-context {

--- a/ui/src/components/AgentPane.vue
+++ b/ui/src/components/AgentPane.vue
@@ -193,7 +193,7 @@ const emit = defineEmits(['select-agent'])
 }
 
 .ae-type.think {
-  color: #668;
+  color: var(--accent-think);
 }
 
 .ae-type.action {
@@ -213,7 +213,7 @@ const emit = defineEmits(['select-agent'])
 }
 
 .ae-text.action-text {
-  color: #7a9a7a;
+  color: var(--accent-memory);
 }
 
 @media (max-width: 768px) {

--- a/ui/src/components/EventLog.vue
+++ b/ui/src/components/EventLog.vue
@@ -8,6 +8,29 @@ defineProps({
   },
 })
 
+function eventNameClass(event) {
+  switch (event.name) {
+    case 'mission_success':
+      return 'event-name-success'
+    case 'mission_aborted':
+    case 'mission_failed':
+    case 'alert':
+      return 'event-name-error'
+    case 'analyze':
+    case 'dig':
+    case 'pickup':
+      return 'event-name-resource'
+    case 'move':
+    case 'scan':
+    case 'analyze_ground':
+      return 'event-name-map'
+    case 'thinking':
+      return 'event-name-think'
+    default:
+      return 'event-name-default'
+  }
+}
+
 function formatPayload(event) {
   const p = event.payload
   if (!p) return ''
@@ -79,7 +102,7 @@ function formatPayload(event) {
           :style="{ color: agentColor(event.source) }"
         >{{ event.source }}</span>
         <span class="event-type">{{ event.type }}</span>
-        <span class="event-name">{{ event.name }}</span>
+        <span :class="['event-name', eventNameClass(event)]">{{ event.name }}</span>
         <span
           v-if="event.payload && formatPayload(event)"
           class="event-payload"
@@ -129,6 +152,13 @@ function formatPayload(event) {
   color: var(--accent-gold);
   font-size: 0.8rem;
 }
+
+.event-name-default { color: var(--accent-gold); }
+.event-name-success { color: var(--accent-green); }
+.event-name-error { color: var(--accent-red); }
+.event-name-resource { color: var(--accent-amber); }
+.event-name-map { color: var(--accent-blue); }
+.event-name-think { color: var(--accent-teal); }
 
 .event-payload {
   font-size: 0.7rem;

--- a/ui/src/components/MiniMap.vue
+++ b/ui/src/components/MiniMap.vue
@@ -124,7 +124,7 @@ function onClick(e) {
         y="0"
         :width="mapW"
         :height="mapH"
-        fill="#060609"
+        fill="var(--bg-minimap)"
       />
 
       <!-- Revealed tiles -->
@@ -135,7 +135,7 @@ function onClick(e) {
         :y="t.sy"
         :width="MINI_TILE"
         :height="MINI_TILE"
-        fill="#1a1a28"
+        fill="var(--bg-minimap-revealed)"
       />
 
       <!-- Agent dots -->
@@ -167,7 +167,7 @@ function onClick(e) {
         :width="viewRect.w"
         :height="viewRect.h"
         fill="none"
-        stroke="#668"
+        stroke="var(--accent-think)"
         stroke-width="1"
         opacity="0.7"
       />

--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -497,7 +497,7 @@ defineExpose({ camX, camY, panCamera })
           :y="stoneScreenY(s)"
           :width="veinSize(s)"
           :height="veinSize(s)"
-          :fill="VEIN_COLORS[veinGrade(s)] || '#666'"
+          :fill="VEIN_COLORS[veinGrade(s)] || 'var(--text-tertiary)'"
           :opacity="veinHasGlow(s) ? 0.95 : 0.85"
           :transform="stoneRotateCenter(s)"
           :filter="veinHasGlow(s) ? 'url(#vein-glow)' : undefined"
@@ -527,7 +527,7 @@ defineExpose({ camX, camY, panCamera })
             :y1="panelScreenY(p)"
             :x2="panelScreenX(p) + (TILE_SIZE - 4) / 2"
             :y2="panelScreenY(p) + TILE_SIZE - 4"
-            :stroke="p.depleted ? '#333' : '#aa8020'"
+            :stroke="p.depleted ? 'var(--text-dim)' : 'var(--accent-panel-stroke)'"
             stroke-width="0.5"
           />
           <line
@@ -535,7 +535,7 @@ defineExpose({ camX, camY, panCamera })
             :y1="panelScreenY(p) + (TILE_SIZE - 4) / 2"
             :x2="panelScreenX(p) + TILE_SIZE - 4"
             :y2="panelScreenY(p) + (TILE_SIZE - 4) / 2"
-            :stroke="p.depleted ? '#333' : '#aa8020'"
+            :stroke="p.depleted ? 'var(--text-dim)' : 'var(--accent-panel-stroke)'"
             stroke-width="0.5"
           />
         </g>
@@ -547,7 +547,7 @@ defineExpose({ camX, camY, panCamera })
         y="0"
         :width="MAP_W"
         :height="MAP_H"
-        fill="#020208"
+        fill="var(--bg-primary)"
         opacity="0.6"
         mask="url(#fog-mask)"
         class="fog-overlay"


### PR DESCRIPTION
## Summary
Final Round 2 cleanup pass:
1) remove remaining hardcoded component colors using tokens
2) color-code EventLog event names by event category

### Color token cleanup
- Added new  tokens in  for leftover semantic colors
- Replaced hardcoded colors in:
  - 
  - 
  - 
  - 
  - follow button inline styles in 

### EventLog color coding
- Added  mapper in 
- Event name colors:
  - success → green
  - alert/failure → red
  - resource ops → amber
  - map/nav ops → blue
  - thinking → teal
  - default → gold

Co-Authored-By: Oz <oz-agent@warp.dev>