### PR TITLE
feat(ui): add toggleable MiniMap legend (R3P3)

### DIFF
--- a/specs/003-ui-polish-r3/spec.md
+++ b/specs/003-ui-polish-r3/spec.md
@@ -1,0 +1,40 @@
+# Feature Specification: UI Polish Round 3 (UX, Perf, Accessibility)
+
+**Feature Branch**: `feature/ui-polish-r3`
+**Status**: Active
+**Goal**: Refine user experience, improve rendering performance under load, and maximize accessibility.
+
+## Scope
+
+### Phase 1: Accessibility Baseline (Completed)
+- ARIA roles/labels, focus-visible, reduced-motion.
+- **Added bonus**: Rover carried-ore visuals.
+
+### Phase 2: EventLog Virtualization (Completed)
+- **Problem**: Long-running simulations generate thousands of DOM nodes in the EventLog.
+- **Solution**: Windowing implemented in `EventLog.vue` (dynamic slicing).
+- **Status**: Merged in `9e7647f`.
+
+### Phase 3: MiniMap Legends (UX)
+- **Problem**: Users may not know what dot colors mean.
+- **Solution**: Collapsible legend overlay on MiniMap showing Agents (colors) and Veins (grades).
+
+### Phase 4: Camera Inertia Tuning (UX)
+- **Problem**: Linear lerp feels robotic.
+- **Solution**: Adaptive lerp speed — fast when far, slow when close.
+
+### Phase 5: Toast Deduplication (UX)
+- **Problem**: Spammy events flood the toast stack.
+- **Solution**: `useToasts` checks for duplicates.
+
+### Phase 6: Loading Skeletons (UX)
+- **Problem**: UI looks broken before WebSocket connects.
+- **Solution**: Skeleton loaders.
+
+### Phase 7: Persisted UI Preferences (UX)
+- **Problem**: Refreshing resets state.
+- **Solution**: `localStorage` hook.
+
+### Phase 8: Command Palette / Help (UX)
+- **Problem**: Hidden keyboard shortcuts.
+- **Solution**: Help overlay.

--- a/specs/003-ui-polish-r3/tasks.md
+++ b/specs/003-ui-polish-r3/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: UI Polish Round 3
+
+**Status**: Active
+**Progress**: 2/8 Phases Complete
+
+## Phase 1: Accessibility Baseline (R3P1) ✅
+- [x] T001 Add ARIA labels, roles, and focus-visible outlines
+- [x] T002 Add prefers-reduced-motion media query
+- [x] T003 Implement rover carried-ore visuals (bonus)
+
+## Phase 2: EventLog Virtualization (R3P2) ✅
+- [x] T004 Implement windowing/limit logic in `EventLog.vue`
+- [x] T005 Limit backing array in `useWebSocket` (200 items)
+
+## Phase 3: MiniMap Legends (R3P3) 🎯
+**Goal**: Explain map symbology.
+- [ ] T007 Create `MapLegend.vue` component
+- [ ] T008 Integrate into `MiniMap.vue` as a toggleable overlay
+
+## Phase 4: Camera Inertia (R3P4)
+**Goal**: Cinematic smooth panning.
+- [ ] T009 Refine `cameraLoop` in `WorldMap.vue` with adaptive lerp
+
+## Phase 5: Toast Dedupe (R3P5)
+**Goal**: Reduce visual noise.
+- [ ] T010 Update `useToasts.js` to reject duplicate messages within N seconds
+
+## Phase 6: Loading Skeletons (R3P6)
+**Goal**: Better startup UX.
+- [ ] T011 Create skeleton styles/components
+- [ ] T012 Show skeletons when `!worldState`
+
+## Phase 7: Persisted Prefs (R3P7)
+**Goal**: Save user config.
+- [ ] T013 Create `usePreferences` composable
+- [ ] T014 Wire up zoom, narration, and follow-mode to prefs
+
+## Phase 8: Help Overlay (R3P8)
+**Goal**: Discoverability.
+- [ ] T015 Create `HelpModal.vue` with shortcuts
+- [ ] T016 Bind `?` key to toggle help

--- a/ui/src/components/MapLegend.vue
+++ b/ui/src/components/MapLegend.vue
@@ -1,0 +1,181 @@
+<script setup>
+import { ref } from 'vue'
+import { AGENT_COLORS, VEIN_COLORS } from '../constants.js'
+
+const visible = ref(false)
+
+function toggle() {
+  visible.value = !visible.value
+}
+</script>
+
+<template>
+  <div class="legend-wrapper">
+    <button
+      class="legend-toggle"
+      :class="{ active: visible }"
+      title="Toggle Map Legend"
+      type="button"
+      aria-expanded="visible"
+      aria-controls="map-legend-content"
+      @click="toggle"
+    >
+      ?
+    </button>
+    <Transition name="legend">
+      <div
+        v-if="visible"
+        id="map-legend-content"
+        class="legend-content"
+      >
+        <div class="legend-section">
+          <h4>Agents</h4>
+          <div class="legend-grid">
+            <div class="legend-item">
+              <span
+                class="dot agent"
+                :style="{ background: AGENT_COLORS['station'] }"
+              />
+              <span>Station</span>
+            </div>
+            <div class="legend-item">
+              <span
+                class="dot agent"
+                :style="{ background: AGENT_COLORS['rover-mistral'] }"
+              />
+              <span>Rover</span>
+            </div>
+            <div class="legend-item">
+              <span
+                class="dot agent"
+                :style="{ background: AGENT_COLORS['drone-mistral'] }"
+              />
+              <span>Drone</span>
+            </div>
+          </div>
+        </div>
+        <div class="legend-section">
+          <h4>Veins</h4>
+          <div class="legend-grid">
+            <div
+              v-for="(color, grade) in VEIN_COLORS"
+              :key="grade"
+              class="legend-item"
+            >
+              <span
+                class="dot vein"
+                :style="{ background: color }"
+              />
+              <span class="grade-label">{{ grade }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped>
+.legend-wrapper {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.legend-toggle {
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  border: 1px solid var(--text-muted);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  z-index: 10;
+}
+
+.legend-toggle:hover,
+.legend-toggle.active {
+  border-color: var(--accent-blue);
+  color: var(--accent-blue);
+  background: var(--bg-card);
+}
+
+.legend-content {
+  background: rgba(12, 12, 20, 0.95);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 0.5rem;
+  font-size: 0.65rem;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  min-width: 120px;
+}
+
+.legend-section {
+  margin-bottom: 0.5rem;
+}
+
+.legend-section:last-child {
+  margin-bottom: 0;
+}
+
+h4 {
+  font-size: 0.6rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.3rem;
+  border-bottom: 1px solid var(--border-dim);
+  padding-bottom: 0.1rem;
+}
+
+.legend-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.3rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--text-secondary);
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dot.agent {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.grade-label {
+  text-transform: capitalize;
+}
+
+/* Transitions */
+.legend-enter-active,
+.legend-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.legend-enter-from,
+.legend-leave-to {
+  opacity: 0;
+  transform: translateY(5px);
+}
+</style>

--- a/ui/src/components/MiniMap.vue
+++ b/ui/src/components/MiniMap.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import MapLegend from './MapLegend.vue'
 import { VIEWPORT_W, VIEWPORT_H, VEIN_COLORS, agentColor } from '../constants.js'
 
 const props = defineProps({
@@ -180,6 +181,7 @@ function onClick(e) {
     >
       No data
     </div>
+    <MapLegend />
   </section>
 </template>
 
@@ -189,6 +191,7 @@ function onClick(e) {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   background: var(--bg-card);
+  position: relative;
 }
 
 .minimap-svg {


### PR DESCRIPTION
## Summary
Adds a collapsible legend to the MiniMap to explain the color coding.

### Changes
- New `MapLegend.vue` component.
- Integrated into `MiniMap.vue`.
- Shows:
  - **Agents**: Station, Rover, Drone.
  - **Veins**: All 6 grades (Pristine to Unknown) using `VEIN_COLORS`.

### UX
- Defaults to hidden to save space.
- Toggle via small `?` button in the corner.
- Translucent backdrop with blur for readability.

Co-Authored-By: Oz <oz-agent@warp.dev>