### PR TITLE
feat(ui): implement toast deduplication (R3P5)

### DIFF
--- a/specs/003-ui-polish-r3/tasks.md
+++ b/specs/003-ui-polish-r3/tasks.md
@@ -12,16 +12,14 @@
 - [x] T004 Implement windowing/limit logic in `EventLog.vue`
 - [x] T005 Limit backing array in `useWebSocket` (200 items)
 
-## Phase 3: MiniMap Legends (R3P3) 🎯
-**Goal**: Explain map symbology.
-- [ ] T007 Create `MapLegend.vue` component
-- [ ] T008 Integrate into `MiniMap.vue` as a toggleable overlay
+## Phase 3: MiniMap Legends (R3P3) ✅
+- [x] T007 Create `MapLegend.vue` component
+- [x] T008 Integrate into `MiniMap.vue` as a toggleable overlay
 
-## Phase 4: Camera Inertia (R3P4)
-**Goal**: Cinematic smooth panning.
-- [ ] T009 Refine `cameraLoop` in `WorldMap.vue` with adaptive lerp
+## Phase 4: Camera Inertia (R3P4) ✅
+- [x] T009 Refine `cameraLoop` in `WorldMap.vue` with adaptive lerp
 
-## Phase 5: Toast Dedupe (R3P5)
+## Phase 5: Toast Dedupe (R3P5) 🎯
 **Goal**: Reduce visual noise.
 - [ ] T010 Update `useToasts.js` to reject duplicate messages within N seconds
 

--- a/ui/src/composables/useToasts.js
+++ b/ui/src/composables/useToasts.js
@@ -10,6 +10,9 @@ export function useToasts() {
   const toasts = ref([])
 
   function addToast(message, { type = 'info', duration = 4000 } = {}) {
+    // Deduplicate: if duplicate message exists, ignore
+    if (toasts.value.some(t => t.message === message)) return
+
     const id = ++toastId
     toasts.value.push({ id, message, type })
     setTimeout(() => {


### PR DESCRIPTION
## Summary
Prevents duplicate toast notifications from stacking up.

### Changes
- Updated `useToasts.js` to check if a toast with the same message exists before adding.
- If it exists, the new toast is ignored (debounce effect).

### UX Improvement
- Prevents "wall of text" when repetitive events occur (e.g. rapid-fire alerts).

Co-Authored-By: Oz <oz-agent@warp.dev>