### PR TITLE
feat(ui): add loading skeletons for core components (R3P6)

### DIFF
--- a/ui/src/components/AgentPanes.vue
+++ b/ui/src/components/AgentPanes.vue
@@ -70,21 +70,36 @@ function agentMemory(id) {
 
 <template>
   <section class="agent-panes">
-    <AgentPane
-      v-for="id in agentIds"
-      :key="id"
-      :agent-id="id"
-      :model="agentModel(id)"
-      :position="agentPosition(id)"
-      :battery="batteryPct(id)"
-      :battery-level="batteryRaw(id)"
-      :inventory-summary="inventorySummary(id)"
-      :mission="missionObjective(id)"
-      :memory="agentMemory(id)"
-      :events="agentEvents[id]"
-      :color="agentColor(id)"
-      @select-agent="emit('select-agent', $event)"
-    />
+    <template v-if="!worldState">
+      <div
+        v-for="i in 3"
+        :key="'skeleton-'+i"
+        class="agent-pane skeleton"
+      >
+        <div class="skeleton-header">
+          <div class="skeleton-title" />
+          <div class="skeleton-stats" />
+        </div>
+        <div class="skeleton-body" />
+      </div>
+    </template>
+    <template v-else>
+      <AgentPane
+        v-for="id in agentIds"
+        :key="id"
+        :agent-id="id"
+        :model="agentModel(id)"
+        :position="agentPosition(id)"
+        :battery="batteryPct(id)"
+        :battery-level="batteryRaw(id)"
+        :inventory-summary="inventorySummary(id)"
+        :mission="missionObjective(id)"
+        :memory="agentMemory(id)"
+        :events="agentEvents[id]"
+        :color="agentColor(id)"
+        @select-agent="emit('select-agent', $event)"
+      />
+    </template>
   </section>
 </template>
 
@@ -95,5 +110,55 @@ function agentMemory(id) {
   flex-direction: column;
   gap: 0.5rem;
   min-width: 0;
+}
+
+.agent-pane.skeleton {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.skeleton-header {
+  padding: 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  justify-content: space-between;
+}
+
+.skeleton-title {
+  width: 80px;
+  height: 12px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  animation: pulse 1.5s infinite ease-in-out;
+}
+
+.skeleton-stats {
+  width: 60px;
+  height: 12px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  animation: pulse 1.5s infinite ease-in-out;
+  animation-delay: 0.2s;
+}
+
+.skeleton-body {
+  flex: 1;
+  margin: 0.5rem;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  opacity: 0.5;
+  animation: pulse 1.5s infinite ease-in-out;
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.3; }
+  50% { opacity: 0.6; }
+  100% { opacity: 0.3; }
 }
 </style>

--- a/ui/src/components/StatsBar.vue
+++ b/ui/src/components/StatsBar.vue
@@ -51,39 +51,48 @@ const targetQty = computed(() => {
 </script>
 
 <template>
-  <div
-    v-if="worldState"
-    class="stats-bar"
-  >
-    <span class="stat">
-      <span class="stat-label">Tick</span>
-      <span class="stat-value">#{{ tick }}</span>
-    </span>
-    <span class="stat-sep" />
-    <span class="stat">
-      <span class="stat-label">Revealed</span>
-      <span class="stat-value">{{ tilesRevealed }} tiles</span>
-    </span>
-    <span class="stat-sep" />
-    <span class="stat">
-      <span class="stat-label">Agents</span>
-      <span class="stat-value">{{ mobileCount }}</span>
-    </span>
-    <span class="stat-sep" />
-    <span class="stat">
-      <span class="stat-label">Veins</span>
-      <span class="stat-value">{{ totalStones }}</span>
-    </span>
-    <span class="stat-sep" />
-    <span class="stat">
-      <span class="stat-label">Collected</span>
-      <span class="stat-value collected">{{ collectedQty }}<template v-if="targetQty"> / {{ targetQty }}</template></span>
-    </span>
-    <span class="stat-sep" />
-    <span class="stat">
-      <span class="stat-label">Events</span>
-      <span class="stat-value">{{ eventCount }}</span>
-    </span>
+  <div class="stats-bar">
+    <template v-if="worldState">
+      <span class="stat">
+        <span class="stat-label">Tick</span>
+        <span class="stat-value">#{{ tick }}</span>
+      </span>
+      <span class="stat-sep" />
+      <span class="stat">
+        <span class="stat-label">Revealed</span>
+        <span class="stat-value">{{ tilesRevealed }} tiles</span>
+      </span>
+      <span class="stat-sep" />
+      <span class="stat">
+        <span class="stat-label">Agents</span>
+        <span class="stat-value">{{ mobileCount }}</span>
+      </span>
+      <span class="stat-sep" />
+      <span class="stat">
+        <span class="stat-label">Veins</span>
+        <span class="stat-value">{{ totalStones }}</span>
+      </span>
+      <span class="stat-sep" />
+      <span class="stat">
+        <span class="stat-label">Collected</span>
+        <span class="stat-value collected">{{ collectedQty }}<template v-if="targetQty"> / {{ targetQty }}</template></span>
+      </span>
+      <span class="stat-sep" />
+      <span class="stat">
+        <span class="stat-label">Events</span>
+        <span class="stat-value">{{ eventCount }}</span>
+      </span>
+    </template>
+    <div
+      v-else
+      class="skeleton-stats"
+    >
+      <div
+        v-for="i in 6"
+        :key="i"
+        class="skeleton-item"
+      />
+    </div>
   </div>
 </template>
 
@@ -138,5 +147,25 @@ const targetQty = computed(() => {
   .stat-sep {
     display: none;
   }
+}
+
+.skeleton-stats {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+}
+
+.skeleton-item {
+  height: 10px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  flex: 1;
+  animation: pulse 1.5s infinite ease-in-out;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.3; }
+  50% { opacity: 0.6; }
+  100% { opacity: 0.3; }
 }
 </style>

--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -827,9 +827,18 @@ defineExpose({ camX, camY, visibleW, visibleH, panCamera, navigateTo })
     </svg>
     <div
       v-else
-      class="empty"
+      class="map-skeleton"
     >
-      Waiting for world state...
+      <div class="skeleton-grid">
+        <div
+          v-for="i in 100"
+          :key="i"
+          class="skeleton-tile"
+        />
+      </div>
+      <div class="skeleton-message">
+        Connecting to satellite feed...
+      </div>
     </div>
   </section>
 </template>
@@ -921,5 +930,52 @@ defineExpose({ camX, camY, visibleW, visibleH, panCamera, navigateTo })
 }
 .map-svg:active {
   cursor: grabbing;
+}
+
+.map-skeleton {
+  width: 100%;
+  aspect-ratio: 1;
+  background: var(--bg-primary);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: repeat(10, 1fr);
+  width: 100%;
+  height: 100%;
+  opacity: 0.1;
+}
+
+.skeleton-tile {
+  border: 1px solid var(--accent-blue);
+  animation: pulse-grid 2s infinite;
+}
+
+.skeleton-message {
+  position: absolute;
+  color: var(--accent-blue);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  background: rgba(10, 10, 15, 0.8);
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--accent-blue);
+  animation: pulse-text 1.5s infinite alternate;
+}
+
+@keyframes pulse-grid {
+  0%, 100% { opacity: 0.1; }
+  50% { opacity: 0.3; }
+}
+
+@keyframes pulse-text {
+  from { opacity: 0.7; }
+  to { opacity: 1; }
 }
 </style>


### PR DESCRIPTION
## Summary
Improves perceived performance and layout stability during startup.

### Changes
- **AgentPanes**: Shows 3 placeholder cards with pulsing blocks instead of empty space.
- **StatsBar**: Renders the bar structure with animated dashes for values.
- **WorldMap**: Replaces "Waiting..." text with a 10x10 pulsing grid and "Connecting to satellite feed..." badge.

### Visuals
- Uses `animation: pulse 1.5s infinite`
- Matches existing color tokens (elevated bg, borders).

Co-Authored-By: Oz <oz-agent@warp.dev>