### PR TITLE
feat(ui): wire persisted preferences into WorldMap and MapLegend

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added (UI Polish Round 3 — Phases 3–8)
 
+- **Persisted zoom preference**: Zoom level saved to `localStorage` via `usePreferences` composable; survives page refresh
+- **Persisted legend visibility**: MiniMap legend open/closed state saved to `localStorage`; restored on load
 - **Toast rate-limiting**: Max 5 visible toasts; oldest evicted when capacity reached
 - **Toast dedup count badge**: Identical messages within 5s window show `×N` count badge instead of duplicating
 - **Toast timer management**: Dedup resets dismiss timer; evicted toasts clean up their timers

--- a/ui/src/components/MapLegend.vue
+++ b/ui/src/components/MapLegend.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { ref } from 'vue'
 import { AGENT_COLORS, VEIN_COLORS } from '../constants.js'
+import { usePreferences } from '../composables/usePreferences.js'
 
-const visible = ref(false)
+const { prefs } = usePreferences()
 
 function toggle() {
-  visible.value = !visible.value
+  prefs.showLegend = !prefs.showLegend
 }
 </script>
 
@@ -13,10 +13,10 @@ function toggle() {
   <div class="legend-wrapper">
     <button
       class="legend-toggle"
-      :class="{ active: visible }"
+      :class="{ active: prefs.showLegend }"
       title="Toggle Map Legend"
       type="button"
-      aria-expanded="visible"
+      :aria-expanded="prefs.showLegend"
       aria-controls="map-legend-content"
       @click="toggle"
     >
@@ -24,7 +24,7 @@ function toggle() {
     </button>
     <Transition name="legend">
       <div
-        v-if="visible"
+        v-if="prefs.showLegend"
         id="map-legend-content"
         class="legend-content"
       >

--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
 import { TILE_SIZE, VIEWPORT_W, VIEWPORT_H, VEIN_COLORS, VEIN_SIZES, SOLAR_PANEL_COLOR, SOLAR_PANEL_DEPLETED_COLOR, agentColor, revealRadius } from '../constants.js'
+import { usePreferences } from '../composables/usePreferences.js'
 
 const props = defineProps({
   worldState: {
@@ -27,14 +28,14 @@ const camY = ref(-Math.floor(VIEWPORT_H / 2))
 const targetCamX = ref(camX.value)
 const targetCamY = ref(camY.value)
 let rafId = null
-const zoom = ref(1)
+const { prefs } = usePreferences()
 const ZOOM_MIN = 0.7
 const ZOOM_MAX = 2.2
 const ZOOM_STEP = 0.1
 
 // Dynamic viewport dimensions: more tiles when zoomed out, fewer when zoomed in
-const visibleW = computed(() => Math.ceil(VIEWPORT_W / zoom.value))
-const visibleH = computed(() => Math.ceil(VIEWPORT_H / zoom.value))
+const visibleW = computed(() => Math.ceil(VIEWPORT_W / prefs.zoom))
+const visibleH = computed(() => Math.ceil(VIEWPORT_H / prefs.zoom))
 const dynamicMapW = computed(() => visibleW.value * TILE_SIZE)
 const dynamicMapH = computed(() => visibleH.value * TILE_SIZE)
 
@@ -271,15 +272,15 @@ function clamp(v, min, max) {
 }
 
 function zoomIn() {
-  zoom.value = clamp(Number((zoom.value + ZOOM_STEP).toFixed(2)), ZOOM_MIN, ZOOM_MAX)
+  prefs.zoom = clamp(Number((prefs.zoom + ZOOM_STEP).toFixed(2)), ZOOM_MIN, ZOOM_MAX)
 }
 
 function zoomOut() {
-  zoom.value = clamp(Number((zoom.value - ZOOM_STEP).toFixed(2)), ZOOM_MIN, ZOOM_MAX)
+  prefs.zoom = clamp(Number((prefs.zoom - ZOOM_STEP).toFixed(2)), ZOOM_MIN, ZOOM_MAX)
 }
 
 function resetZoom() {
-  zoom.value = 1
+  prefs.zoom = 1
 }
 
 function onWheel(e) {
@@ -289,7 +290,7 @@ function onWheel(e) {
 }
 
 // Re-center camera when zoom changes so the viewport expands/contracts around center
-watch(zoom, (newZ, oldZ) => {
+watch(() => prefs.zoom, (newZ, oldZ) => {
   const oldW = Math.ceil(VIEWPORT_W / oldZ)
   const oldH = Math.ceil(VIEWPORT_H / oldZ)
   const newW = Math.ceil(VIEWPORT_W / newZ)
@@ -440,7 +441,7 @@ defineExpose({ camX, camY, visibleW, visibleH, panCamera, navigateTo })
       >
         −
       </button>
-      <span class="zoom-label">{{ Math.round(zoom * 100) }}%</span>
+      <span class="zoom-label">{{ Math.round(prefs.zoom * 100) }}%</span>
       <button
         class="zoom-btn"
         title="Zoom in"


### PR DESCRIPTION
## Summary

- **Zoom persistence**: `WorldMap.vue` now uses `prefs.zoom` from `usePreferences` composable instead of a local `ref`. Zoom level survives page refresh.
- **Legend persistence**: `MapLegend.vue` now uses `prefs.showLegend` instead of a local `ref`. Legend open/closed state persists across sessions.
- Supersedes #57 which had merge conflicts and `ui-lint-build` failure (unused `e` variable)

## Change Type

- [x] Feature (new functionality)

## Semantic Diff

### Changed
| File | Lines (+/-) | Description |
|------|-------------|-------------|
| `ui/src/components/WorldMap.vue` | +3/-2 | Import usePreferences, replace `zoom` ref with `prefs.zoom` |
| `ui/src/components/MapLegend.vue` | +4/-4 | Import usePreferences, replace `visible` ref with `prefs.showLegend` |
| `Changelog.md` | +2/0 | Document persisted preferences |

## File Impact

| Metric | Count |
|--------|-------|
| Files modified | 3 |
| Lines added | 17 |
| Lines removed | 14 |

## Test Plan

- [ ] Set zoom to 150%, refresh page → zoom restored at 150%
- [ ] Open legend, refresh page → legend still open
- [ ] Close legend, refresh page → legend still closed
- [ ] Reset zoom, refresh → zoom at 100%
- [ ] Clear localStorage, refresh → defaults restored (zoom=1, legend=closed)
- [ ] `npm run build` passes with zero errors

Closes #57

Co-Authored-By: agent-one team <agent-one@yanok.ai>