### PR TITLE
ci: use RELEASE_TOKEN for Release Please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -16,3 +12,4 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

- Switches Release Please workflow from `GITHUB_TOKEN` (blocked by enterprise policy) to `RELEASE_TOKEN` PAT secret
- Removes explicit `permissions` block (PAT carries its own permissions)

## Problem

Release Please failed with: `GitHub Actions is not permitted to create or approve pull requests`  
Enterprise policy: `Write permissions for workflows are disabled by the enterprise`

## Fix

Use the existing `RELEASE_TOKEN` repo secret which has the necessary permissions to create PRs.

## Test Plan

- [ ] Merge this PR → Release Please runs on push to main
- [ ] Verify Release Please creates a release PR with version bump

Co-Authored-By: agent-one team <agent-one@yanok.ai>