### PR TITLE
fix(ui): preserve event log on WebSocket reconnect (#72)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -121,6 +121,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **WebSocket reconnect**: Event log is no longer cleared on reconnect — only on initial page load. World state continues to reset since the server repopulates it (#72)
+
 ### Added (UI Polish Round 3 — Phases 3–8)
 
 - **Persisted zoom preference**: Zoom level saved to `localStorage` via `usePreferences` composable; survives page refresh

--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -8,6 +8,7 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
   const narrationChunk = ref(null)
   let ws = null
   let eventUid = 0
+  let isFirstConnect = true
 
   const agentEvents = computed(() => {
     const byAgent = {}
@@ -30,7 +31,10 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
 
     ws.onopen = () => {
       connected.value = true
-      events.value = []
+      if (isFirstConnect) {
+        events.value = []
+      }
+      isFirstConnect = false
       worldState.value = null
       if (onConnect) onConnect()
     }


### PR DESCRIPTION
## Summary

- Add `isFirstConnect` flag to `useWebSocket.js` so the event log is only cleared on initial page load, not on WebSocket reconnects
- World state continues to reset on reconnect since the server repopulates it

> Replaces #82 which was contaminated with unrelated server changes causing CI failures.

## Semantic Diff

| Section | Files | Lines Changed |
|---------|-------|---------------|
| 🖥️ UI | 1 | +5 / -1 |
| 📝 Docs | 1 | +4 / -0 |

### File Impact

| Status | File | +/- |
|--------|------|-----|
| Changed | `ui/src/composables/useWebSocket.js` | +5 / -1 |
| Changed | `Changelog.md` | +4 / -0 |

## Changelog

- **WebSocket reconnect**: Event log is no longer cleared on reconnect — only on initial page load. World state continues to reset since the server repopulates it (#72)

Closes #72

Co-Authored-By: agent-one team <agent-one@yanok.ai>