### PR TITLE
fix(ui): guard AgentDetailModal against null mission (#89)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -130,6 +130,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Toast timer management**: Dedup resets dismiss timer; evicted toasts clean up their timers
 - **EventLog skeleton state**: 6 pulsing skeleton rows with staggered animation delays shown before WebSocket data arrives
 
+### Fixed
+
+- **AgentDetailModal crash when agent.mission is null (#89)**: Added optional chaining to `agent.mission?.objective` with fallback text to prevent crash when agent has no mission assigned
+
 ### Fixed (Zoom Scaling)
 
 - **Dynamic viewport tile count**: WorldMap zoom now scales tile count proportionally — zooming out (0.7x) renders ~29×29 tiles, zooming in (2.2x) renders ~10×10 tiles, instead of fixed 20×20

--- a/ui/src/components/AgentDetailModal.vue
+++ b/ui/src/components/AgentDetailModal.vue
@@ -65,7 +65,7 @@ function batteryPct() {
             Mission
           </div>
           <div class="modal-value">
-            {{ agent.mission.objective }}
+            {{ agent.mission?.objective || 'No mission assigned' }}
           </div>
         </div>
         <div


### PR DESCRIPTION
## Summary

Fixes AgentDetailModal crash when `agent.mission` is null by adding optional chaining (`?.`) with a fallback string.

## Change Type

- [x] `fix` — Bug fix

## Semantic Diff

### Added
- (none)

### Changed
- `ui/src/components/AgentDetailModal.vue` — line 68: `agent.mission.objective` → `agent.mission?.objective || 'No mission assigned'`
- `Changelog.md` — added Fixed entry for #89

### Removed
- (none)

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 2 |
| Files deleted | 0 |
| Lines added | +5 |
| Lines removed | -1 |

### Core Files Modified
- `ui/src/components/AgentDetailModal.vue`

### Tests
- (no test changes — template guard fix only)

## How to Test

1. Start the simulation with `./run` (server) and `npm run dev` (ui)
2. Click on any agent that has no mission assigned (or mock an agent with `mission: null`)
3. Verify the modal opens without crashing and shows "No mission assigned"

## Changelog

### Fixed
- **AgentDetailModal crash when agent.mission is null (#89)**: Added optional chaining to `agent.mission?.objective` with fallback text to prevent crash when agent has no mission assigned

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>