### PR TITLE
fix(ui): add error handling for WS JSON.parse and fetch calls (#95)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -130,6 +130,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Toast timer management**: Dedup resets dismiss timer; evicted toasts clean up their timers
 - **EventLog skeleton state**: 6 pulsing skeleton rows with staggered animation delays shown before WebSocket data arrives
 
+### Fixed
+
+- Added error handling for WebSocket JSON.parse and fetch API calls in UI ([#95](https://github.com/mhack-agent-one/agent-one/issues/95))
+
 ### Fixed (Zoom Scaling)
 
 - **Dynamic viewport tile count**: WorldMap zoom now scales tile count proportionally — zooming out (0.7x) renders ~29×29 tiles, zooming in (2.2x) renders ~10×10 tiles, instead of fixed 20×20

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -52,13 +52,21 @@ async function onWsConnect() {
 }
 
 async function toggleNarration() {
-  const res = await fetch('/api/narration/toggle', { method: 'POST' })
-  const data = await res.json()
-  narrationEnabled.value = data.enabled
+  try {
+    const res = await fetch('/api/narration/toggle', { method: 'POST' })
+    const data = await res.json()
+    narrationEnabled.value = data.enabled
+  } catch (e) {
+    console.warn('toggleNarration failed', e)
+  }
 }
 
 async function abortMission() {
-  await fetch('/api/mission/abort', { method: 'POST' })
+  try {
+    await fetch('/api/mission/abort', { method: 'POST' })
+  } catch (e) {
+    console.warn('abortMission failed', e)
+  }
 }
 
 async function resetSimulation() {
@@ -94,10 +102,14 @@ function onSimEvent(event) {
 const { events, connected, worldState, agentIds, agentEvents, narration, narrationChunk } = useWebSocket({ onConnect: onWsConnect, onEvent: onSimEvent })
 
 async function togglePause() {
-  const endpoint = paused.value ? '/api/simulation/resume' : '/api/simulation/pause'
-  const res = await fetch(endpoint, { method: 'POST' })
-  const data = await res.json()
-  paused.value = data.paused
+  try {
+    const endpoint = paused.value ? '/api/simulation/resume' : '/api/simulation/pause'
+    const res = await fetch(endpoint, { method: 'POST' })
+    const data = await res.json()
+    paused.value = data.paused
+  } catch (e) {
+    console.warn('togglePause failed', e)
+  }
 }
 
 function selectAgent(id) {

--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -36,7 +36,13 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
     }
 
     ws.onmessage = (msg) => {
-      const event = JSON.parse(msg.data)
+      let event
+      try {
+        event = JSON.parse(msg.data)
+      } catch (e) {
+        console.warn('WS: failed to parse message', e)
+        return
+      }
       if (event.source === 'world' && event.name === 'state') {
         worldState.value = event.payload
       } else if (event.source === 'narrator' && event.name === 'narration') {


### PR DESCRIPTION
## Summary

Adds missing error handling for WebSocket `JSON.parse` and unguarded `fetch` API calls in the UI. Fixes #95.

## Change Type

- [x] `fix` — Bug fix

## Semantic Diff

### Added
- (none)

### Changed
- `ui/src/composables/useWebSocket.js` — Wrapped `JSON.parse(msg.data)` in try/catch; on parse failure logs warning and skips the malformed message instead of crashing all subsequent WS processing
- `ui/src/App.vue` — Wrapped `toggleNarration()`, `abortMission()`, and `togglePause()` fetch calls in try/catch with console.warn on error
- `Changelog.md` — Added entry under `[Unreleased] > Fixed`

### Removed
- (none)

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 3 |
| Files deleted | 0 |
| Lines added | +31 |
| Lines removed | -9 |

### Core Files Modified
- `ui/src/composables/useWebSocket.js` — WS JSON.parse try/catch
- `ui/src/App.vue` — fetch error handling in toggleNarration, abortMission, togglePause

### Tests
- (no test files — these are defensive error guards with console.warn only)

## How to Test

1. `cd ui && npm run build` — verify clean build
2. Open the app, disconnect the server mid-session — verify no uncaught exceptions in console
3. Send a malformed WS message (e.g. `ws.send("not json")` from devtools) — verify `WS: failed to parse message` warning instead of crash

## Changelog

- Added error handling for WebSocket JSON.parse and fetch API calls in UI (#95)

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>