### PR TITLE
style: fix pre-existing ruff format violations

### DIFF
--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -122,7 +122,9 @@ ROVER_TOOLS = [
 class MistralRoverReasoner:
     """Rover reasoner that decides via Mistral LLM. Returns action dict, does not execute."""
 
-    def __init__(self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -220,11 +222,7 @@ class MistralRoverReasoner:
             f"Objective: {mission['objective']}\n"
             f"Target: collect {target_quantity} units of basalt and deliver to station.\n"
             f"Your inventory: {len(inventory)}/{MAX_INVENTORY_ROVER} veins"
-            + (
-                "\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!"
-                if inventory_full
-                else ""
-            )
+            + ("\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!" if inventory_full else "")
         )
 
         tasks = agent.get("tasks", [])
@@ -252,11 +250,7 @@ class MistralRoverReasoner:
                 else ""
             )
             + f"\nSolar panels remaining: {agent.get('solar_panels_remaining', 0)}"
-            + (
-                "\n⚠️ BATTERY CRITICAL — return to station now!"
-                if battery_critical
-                else ""
-            )
+            + ("\n⚠️ BATTERY CRITICAL — return to station now!" if battery_critical else "")
         )
 
         # Nearby solar panels
@@ -456,7 +450,9 @@ DRONE_TOOLS = [DRONE_MOVE_TOOL, SCAN_TOOL, NOTIFY_TOOL]
 class DroneAgent:
     """Drone scout agent powered by Mistral LLM. Moves fast, scans for basalt vein deposits."""
 
-    def __init__(self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -927,9 +923,10 @@ class DroneLoop(BaseAgent):
 
         # During abort, force recall so drone heads to station
         if mission_status == "aborted":
-            self._world.set_pending_commands(self.agent_id, [
-                {"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}
-            ])
+            self._world.set_pending_commands(
+                self.agent_id,
+                [{"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}],
+            )
 
         turn = await asyncio.to_thread(self._reasoner.run_turn)
         next_tick()

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -256,16 +256,21 @@ def _update_bounds(x, y):
 
 def _tools_for_ui(tool_schemas):
     """Extract {name, description} from Mistral tool schemas for the UI."""
-    return [{"name": t["function"]["name"], "description": t["function"]["description"]} for t in tool_schemas]
+    return [
+        {"name": t["function"]["name"], "description": t["function"]["description"]}
+        for t in tool_schemas
+    ]
 
 
 def _rover_tools_for_ui():
     from .agent import ROVER_TOOLS
+
     return _tools_for_ui(ROVER_TOOLS)
 
 
 def _drone_tools_for_ui():
     from .agent import DRONE_TOOLS
+
     return _tools_for_ui(DRONE_TOOLS)
 
 

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -139,7 +139,9 @@ class TestExecuteAction(unittest.TestCase):
     def test_execute_move_drains_battery(self):
         result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE
+        )
 
     def test_execute_move_negative_ok(self):
         """Infinite grid: moving to negative coords succeeds."""
@@ -477,7 +479,9 @@ class TestDig(unittest.TestCase):
 
     def test_dig_drains_battery(self):
         execute_action("rover-mistral", "dig", {})
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG
+        )
 
     def test_dig_no_stone(self):
         world.state["stones"] = []
@@ -490,7 +494,9 @@ class TestDig(unittest.TestCase):
         result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5
+        )
 
     def test_dig_failed_no_drain(self):
         world.state["stones"] = []
@@ -610,7 +616,9 @@ class TestCharge(unittest.TestCase):
         charge_rover("rover-mistral")
         self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + CHARGE_RATE)
         charge_rover("rover-mistral")
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE
+        )
 
     def test_charge_rover_unknown_agent(self):
         result = charge_rover("rover-99")
@@ -645,16 +653,18 @@ class TestFogOfWar(unittest.TestCase):
         ]
         # Give drone an empty revealed so it doesn't interfere
         if "drone-mistral" in world.state["agents"]:
-            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get("revealed", [])
+            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get(
+                "revealed", []
+            )
             world.state["agents"]["drone-mistral"]["revealed"] = []
         self._original_stones = world.state.get("stones", [])
 
     def tearDown(self):
         world.state["stones"] = self._original_stones
         # Restore rover-mistral revealed
-        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"]["rover-mistral"].get(
-            "revealed", []
-        )
+        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"][
+            "rover-mistral"
+        ].get("revealed", [])
         if "drone-mistral" in world.state["agents"]:
             world.state["agents"]["drone-mistral"]["revealed"] = self._original_drone_revealed
 
@@ -1490,7 +1500,9 @@ class TestNotify(unittest.TestCase):
         )
 
     def test_notify_drone_success(self):
-        result = execute_action("drone-mistral", "notify", {"message": "High concentration detected"})
+        result = execute_action(
+            "drone-mistral", "notify", {"message": "High concentration detected"}
+        )
         self.assertTrue(result["ok"])
         self.assertEqual(result["position"], [3, 3])
         self.assertEqual(result["message"], "High concentration detected")
@@ -1553,7 +1565,9 @@ class TestWorldSetters(unittest.TestCase):
 
     def test_set_pending_commands_set_and_clear(self):
         set_pending_commands("rover-mistral", [{"name": "recall"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}]
+        )
         set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1562,6 +1576,7 @@ class TestWorldClass(unittest.TestCase):
     def test_singleton_wraps_module_world(self):
         """Module-level `world` singleton is the canonical instance."""
         from app.world import world as w
+
         self.assertIs(w.state, world.state)
 
     def test_get_agent(self):
@@ -1585,7 +1600,9 @@ class TestWorldClass(unittest.TestCase):
         self.assertEqual(world.state["agents"]["rover-mistral"]["last_context"], "ctx-via-class")
 
         world.set_pending_commands("rover-mistral", [{"name": "test"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}]
+        )
         world.set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1595,6 +1612,7 @@ class TestWorldClass(unittest.TestCase):
     def test_fresh_instance_independent(self):
         """A World() with no args gets its own state, independent of the singleton."""
         from app.world import World
+
         w2 = World()
         w2.set_agent_model("rover-mistral", "independent-model")
         self.assertNotEqual(


### PR DESCRIPTION
## Summary
- Fix pre-existing ruff format violations in `agent.py`, `world.py`, and `test_world.py` that have been causing server-lint CI failures on all server-touching branches

## Semantic Diff

### File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| Changed | 3 | 47 | 27 |

### Changed
- `server/app/agent.py` (+12, -15) — ruff format fixes
- `server/app/world.py` (+6, -1) — ruff format fixes
- `server/tests/test_world.py` (+29, -11) — ruff format fixes

## Changelog
- **style**: Fix pre-existing ruff format violations that were causing CI failures on PRs #107, #110, #111

## Review
@schettino72 — This is a formatting-only change (no logic changes). These violations have been present on main and causing `server-lint` failures on every server-touching PR branch. Please approve so we can unblock the other PRs.

Co-Authored-By: agent-one team <agent-one@yanok.ai>