### PR TITLE
fix(ui): floor camera coordinates in WorldMap tile computation

### DIFF
--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -80,8 +80,8 @@ const tiles = computed(() => {
   const vh = visibleH.value
   for (let dy = 0; dy < vh; dy++) {
     for (let dx = 0; dx < vw; dx++) {
-      const x = camX.value + dx
-      const y = camY.value + vh - 1 - dy  // flip Y for SVG
+      const x = Math.floor(camX.value) + dx
+      const y = Math.floor(camY.value) + vh - 1 - dy  // flip Y for SVG
       arr.push({ x, y, sx: dx * TILE_SIZE, sy: dy * TILE_SIZE, key: `${x}-${y}` })
     }
   }


### PR DESCRIPTION
## Summary
- Floor `camX.value` and `camY.value` in the `tiles` computed property so tile coordinates are always integers
- Prevents flicker where float-keyed tiles (e.g. `2.3-5`) don't match integer-keyed `revealedSet` entries (`2,5`) during smooth camera interpolation

Closes #120

## Semantic Diff

### File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| Core    | 1     | 2           | 2             |
| Tests   | 0     | 0           | 0             |
| Docs    | 0     | 0           | 0             |
| **Total** | **1** | **2**     | **2**         |

### Changed

- `ui/src/components/WorldMap.vue` (+2 −2) — `Math.floor()` camera values in tile coordinate computation

## Changelog

### Fixed
- `WorldMap.vue`: Tile coordinates now floored during smooth camera interpolation, preventing revealed-tile flicker

Co-Authored-By: agent-one team <agent-one@yanok.ai>