### PR TITLE
fix(ui): add exponential backoff to WebSocket reconnect

### DIFF
--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -6,6 +6,8 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
   const worldState = ref(null)
   const narration = ref(null)
   const narrationChunk = ref(null)
+  let reconnectDelay = 2000
+  const RECONNECT_MAX = 30000
   let ws = null
   let eventUid = 0
 
@@ -33,6 +35,7 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
       events.value = []
       worldState.value = null
       if (onConnect) onConnect()
+      reconnectDelay = 2000  // reset backoff on successful connection
     }
 
     ws.onmessage = (msg) => {
@@ -55,7 +58,8 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
 
     ws.onclose = () => {
       connected.value = false
-      setTimeout(connect, 2000)
+      setTimeout(connect, reconnectDelay)
+      reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX)
     }
 
     ws.onerror = () => {


### PR DESCRIPTION
## Summary
- Replace fixed 2-second WebSocket reconnect delay with exponential backoff (2s → 4s → 8s → ... → 30s cap)
- Reset backoff to 2s on successful connection
- Prevents hammering the server with rapid reconnect attempts during extended downtime

Closes #122

## Semantic Diff

### File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| Core    | 1     | 5           | 1             |
| Tests   | 0     | 0           | 0             |
| Docs    | 0     | 0           | 0             |
| **Total** | **1** | **5**     | **1**         |

### Changed

- `ui/src/composables/useWebSocket.js` (+5 −1) — Exponential backoff with 30s cap, reset on success

## Changelog

### Fixed
- `useWebSocket.js`: WebSocket reconnection now uses exponential backoff (2s→30s cap) instead of fixed 2s interval

Co-Authored-By: agent-one team <agent-one@yanok.ai>