### PR TITLE
fix: remove legacy GRID_W/GRID_H boundary check from observe_rover and drone (#131)

### DIFF
--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -140,7 +140,9 @@ ROVER_TOOLS = [
 class MistralRoverReasoner:
     """Rover reasoner that decides via Mistral LLM. Returns action dict, does not execute."""
 
-    def __init__(self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -237,11 +239,7 @@ class MistralRoverReasoner:
             f"Objective: {mission['objective']}\n"
             f"Target: collect {target_quantity} units of basalt and deliver to station.\n"
             f"Your inventory: {len(inventory)}/{MAX_INVENTORY_ROVER} veins"
-            + (
-                "\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!"
-                if inventory_full
-                else ""
-            )
+            + ("\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!" if inventory_full else "")
         )
 
         current_task = agent.get("tasks", [None])[0] if agent.get("tasks") else None
@@ -265,11 +263,7 @@ class MistralRoverReasoner:
                 else ""
             )
             + f"\nSolar panels remaining: {agent.get('solar_panels_remaining', 0)}"
-            + (
-                "\n⚠️ BATTERY CRITICAL — return to station now!"
-                if battery_critical
-                else ""
-            )
+            + ("\n⚠️ BATTERY CRITICAL — return to station now!" if battery_critical else "")
         )
 
         # Nearby solar panels
@@ -465,7 +459,9 @@ DRONE_TOOLS = [DRONE_MOVE_TOOL, SCAN_TOOL, NOTIFY_TOOL]
 class DroneAgent:
     """Drone scout agent powered by Mistral LLM. Moves fast, scans for basalt vein deposits."""
 
-    def __init__(self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -496,7 +492,7 @@ class DroneAgent:
         unvisited_dirs = []
         for name, (dx, dy) in DIRECTIONS.items():
             nx, ny = x + dx, y + dy
-            if 0 <= nx < GRID_W and 0 <= ny < GRID_H and (nx, ny) not in visited_set:
+            if (nx, ny) not in visited_set:
                 unvisited_dirs.append(name)
 
         scanned_positions = {tuple(s["position"]) for s in self._world.get_drone_scans()}
@@ -532,7 +528,9 @@ class DroneAgent:
             "RULES:\n"
             f"- Battery: move costs 1 fuel unit/tile (~{BATTERY_COST_MOVE_DRONE:.2%}), scan costs 2 fuel units (~{BATTERY_COST_SCAN:.2%}), notify costs 2 fuel units (~{BATTERY_COST_NOTIFY:.2%}). You can fly up to {MAX_MOVE_DISTANCE_DRONE} tiles per move.\n"
             "- Station is at ({sx},{sy}). Return when battery is low for recharge.\n"
-            "- ALWAYS keep enough battery to return to station.".format(sx=station_pos[0], sy=station_pos[1])
+            "- ALWAYS keep enough battery to return to station.".format(
+                sx=station_pos[0], sy=station_pos[1]
+            )
         )
 
         parts.append(
@@ -665,7 +663,6 @@ class MockDroneAgent:
                     thinking = f"Recall received but already at station ({x}, {y})."
                     return {
                         "thinking": thinking,
-                        
                         "action": {"name": "move", "params": {"direction": "north", "distance": 1}},
                     }
                 if abs(dx) >= abs(dy):
@@ -678,7 +675,6 @@ class MockDroneAgent:
                 thinking = f"RECALL received: {reason}. Heading to station at ({sp[0]},{sp[1]})."
                 return {
                     "thinking": thinking,
-                    
                     "action": {
                         "name": "move",
                         "params": {"direction": direction, "distance": distance},
@@ -706,7 +702,6 @@ class MockDroneAgent:
             )
             return {
                 "thinking": thinking,
-                
                 "action": {
                     "name": "move",
                     "params": {"direction": direction, "distance": distance},
@@ -752,7 +747,6 @@ class MockDroneAgent:
             )
             return {
                 "thinking": thinking,
-                
                 "action": {
                     "name": "move",
                     "params": {"direction": direction, "distance": distance},
@@ -765,7 +759,6 @@ class MockDroneAgent:
         thinking = f"I'm at ({x}, {y}). All nearby areas covered, exploring outward."
         return {
             "thinking": thinking,
-            
             "action": {
                 "name": "move",
                 "params": {"direction": direction, "distance": MAX_MOVE_DISTANCE_DRONE},
@@ -935,9 +928,10 @@ class DroneLoop(BaseAgent):
 
         # During abort, force recall so drone heads to station
         if mission_status == "aborted":
-            self._world.set_pending_commands(self.agent_id, [
-                {"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}
-            ])
+            self._world.set_pending_commands(
+                self.agent_id,
+                [{"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}],
+            )
 
         turn = await asyncio.to_thread(self._reasoner.run_turn)
         next_tick()

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -255,16 +255,21 @@ def _update_bounds(x, y):
 
 def _tools_for_ui(tool_schemas):
     """Extract {name, description} from Mistral tool schemas for the UI."""
-    return [{"name": t["function"]["name"], "description": t["function"]["description"]} for t in tool_schemas]
+    return [
+        {"name": t["function"]["name"], "description": t["function"]["description"]}
+        for t in tool_schemas
+    ]
 
 
 def _rover_tools_for_ui():
     from .agent import ROVER_TOOLS
+
     return _tools_for_ui(ROVER_TOOLS)
 
 
 def _drone_tools_for_ui():
     from .agent import DRONE_TOOLS
+
     return _tools_for_ui(DRONE_TOOLS)
 
 
@@ -962,7 +967,7 @@ def observe_rover(agent_id):
     unvisited_dirs = []
     for name, (dx, dy) in DIRECTIONS.items():
         nx, ny = x + dx, y + dy
-        if 0 <= nx < GRID_W and 0 <= ny < GRID_H and (nx, ny) not in visited_set:
+        if (nx, ny) not in visited_set:
             unvisited_dirs.append(name)
 
     # Vein at current tile

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -139,7 +139,9 @@ class TestExecuteAction(unittest.TestCase):
     def test_execute_move_drains_battery(self):
         result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE
+        )
 
     def test_execute_move_negative_ok(self):
         """Infinite grid: moving to negative coords succeeds."""
@@ -477,7 +479,9 @@ class TestDig(unittest.TestCase):
 
     def test_dig_drains_battery(self):
         execute_action("rover-mistral", "dig", {})
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG
+        )
 
     def test_dig_no_stone(self):
         world.state["stones"] = []
@@ -490,7 +494,9 @@ class TestDig(unittest.TestCase):
         result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5
+        )
 
     def test_dig_failed_no_drain(self):
         world.state["stones"] = []
@@ -610,7 +616,9 @@ class TestCharge(unittest.TestCase):
         charge_rover("rover-mistral")
         self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + CHARGE_RATE)
         charge_rover("rover-mistral")
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE
+        )
 
     def test_charge_rover_unknown_agent(self):
         result = charge_rover("rover-99")
@@ -645,16 +653,18 @@ class TestFogOfWar(unittest.TestCase):
         ]
         # Give drone an empty revealed so it doesn't interfere
         if "drone-mistral" in world.state["agents"]:
-            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get("revealed", [])
+            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get(
+                "revealed", []
+            )
             world.state["agents"]["drone-mistral"]["revealed"] = []
         self._original_stones = world.state.get("stones", [])
 
     def tearDown(self):
         world.state["stones"] = self._original_stones
         # Restore rover-mistral revealed
-        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"]["rover-mistral"].get(
-            "revealed", []
-        )
+        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"][
+            "rover-mistral"
+        ].get("revealed", [])
         if "drone-mistral" in world.state["agents"]:
             world.state["agents"]["drone-mistral"]["revealed"] = self._original_drone_revealed
 
@@ -952,7 +962,6 @@ class TestDirectionHint(unittest.TestCase):
         self.assertEqual(direction_hint(0, 0), "here")
 
 
-
 class TestObserveRover(unittest.TestCase):
     def setUp(self):
         world.state["agents"]["rover-mistral"]["position"] = [5, 5]
@@ -992,6 +1001,16 @@ class TestObserveRover(unittest.TestCase):
         world.state["agents"]["rover-mistral"]["visited"].append([5, 6])
         ctx = observe_rover("rover-mistral")
         self.assertNotIn("north", ctx.computed.unvisited_dirs)
+
+    def test_unvisited_dirs_beyond_grid_boundary(self):
+        """Rover at (25,25) — beyond GRID_W/GRID_H=20 — should still see all 4 directions."""
+        world.state["agents"]["rover-mistral"]["position"] = [25, 25]
+        world.state["agents"]["rover-mistral"]["visited"] = []
+        ctx = observe_rover("rover-mistral")
+        self.assertEqual(
+            sorted(ctx.computed.unvisited_dirs),
+            sorted(["north", "south", "east", "west"]),
+        )
 
     def test_stone_line_none(self):
         ctx = observe_rover("rover-mistral")
@@ -1140,7 +1159,6 @@ class TestDrone(unittest.TestCase):
         world.state["stones"] = [_make_vein([10, 10], grade="high", quantity=200, analyzed=True)]
         result = execute_action("drone-mistral", "dig", {})
         self.assertFalse(result["ok"])
-
 
 
 class TestChunkSystem(unittest.TestCase):
@@ -1385,7 +1403,9 @@ class TestNotify(unittest.TestCase):
         )
 
     def test_notify_drone_success(self):
-        result = execute_action("drone-mistral", "notify", {"message": "High concentration detected"})
+        result = execute_action(
+            "drone-mistral", "notify", {"message": "High concentration detected"}
+        )
         self.assertTrue(result["ok"])
         self.assertEqual(result["position"], [3, 3])
         self.assertEqual(result["message"], "High concentration detected")
@@ -1408,7 +1428,6 @@ class TestNotify(unittest.TestCase):
         result = execute_action("rover-mistral", "notify", {"message": "help"})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-
 
 
 class TestInTransitQuantity(unittest.TestCase):
@@ -1449,7 +1468,9 @@ class TestWorldSetters(unittest.TestCase):
 
     def test_set_pending_commands_set_and_clear(self):
         set_pending_commands("rover-mistral", [{"name": "recall"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}]
+        )
         set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1458,6 +1479,7 @@ class TestWorldClass(unittest.TestCase):
     def test_singleton_wraps_module_world(self):
         """Module-level `world` singleton is the canonical instance."""
         from app.world import world as w
+
         self.assertIs(w.state, world.state)
 
     def test_get_agent(self):
@@ -1481,7 +1503,9 @@ class TestWorldClass(unittest.TestCase):
         self.assertEqual(world.state["agents"]["rover-mistral"]["last_context"], "ctx-via-class")
 
         world.set_pending_commands("rover-mistral", [{"name": "test"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}]
+        )
         world.set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1491,6 +1515,7 @@ class TestWorldClass(unittest.TestCase):
     def test_fresh_instance_independent(self):
         """A World() with no args gets its own state, independent of the singleton."""
         from app.world import World
+
         w2 = World()
         w2.set_agent_model("rover-mistral", "independent-model")
         self.assertNotEqual(


### PR DESCRIPTION
## Summary

- Removed legacy `0 <= nx < GRID_W and 0 <= ny < GRID_H` boundary check from `observe_rover()` in `world.py` and `_build_context()` in drone's `agent.py`
- On the infinite chunk-based grid, this check incorrectly restricted direction suggestions to the 20×20 origin area
- Added test verifying all 4 directions available at position (25,25) — beyond the legacy grid
- Applied ruff format to files with pre-existing violations

## Semantic Diff

| Category | Files | Lines Added | Lines Removed |
|----------|-------|-------------|---------------|
| Core     | 2     | +5          | -4            |
| Tests    | 1     | +12         | -1            |
| Format   | 3     | +45         | -33           |

### Changed
- `server/app/world.py` — removed boundary check in `observe_rover()`, ruff format
- `server/app/agent.py` — removed boundary check in drone `_build_context()`, ruff format

### Tests
- `server/tests/test_world.py` — added `test_unvisited_dirs_beyond_grid_boundary`, ruff format

## Changelog

### Fixed
- Rover and drone direction suggestions no longer restricted to legacy 20×20 grid boundary on infinite chunk-based grid (#131)

## Verification

- [x] ruff check passes
- [x] ruff format passes
- [x] 292 tests pass
- [x] New test verifies fix

Closes #131

Co-Authored-By: agent-one team <agent-one@yanok.ai>