### PR TITLE
perf: WorldMap tileConcentration spatial hash — O(tiles+stones)

### DIFF
--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -133,18 +133,42 @@ function isRevealed(x, y) {
 // Grade weights for concentration radius (mirrors server logic)
 const GRADE_ORDER = ['low', 'medium', 'high', 'rich', 'pristine']
 
-function tileConcentration(x, y) {
-  if (!props.worldState) return 0
-  const stones = props.worldState.stones || []
-  let max = 0
-  for (const s of stones) {
+// Pre-computed stone lookup: spatial hash for O(1) per-tile concentration
+const SPATIAL_CELL = 20  // bucket size ≥ max influence radius (18)
+const stoneIndex = computed(() => {
+  const idx = new Map()  // key: 'cx,cy' → stone[]
+  if (!props.worldState) return idx
+  for (const s of (props.worldState.stones || [])) {
     const [sx, sy] = s.position
-    const d = Math.abs(x - sx) + Math.abs(y - sy)
-    if (d === 0) return 1
-    const gi = GRADE_ORDER.indexOf(s.grade !== 'unknown' ? s.grade : 'low')
-    const radius = 10 + (gi >= 0 ? gi : 0) * 2
-    const c = Math.max(0, 1 - d / radius)
-    if (c > max) max = c
+    const ck = `${Math.floor(sx / SPATIAL_CELL)},${Math.floor(sy / SPATIAL_CELL)}`
+    let bucket = idx.get(ck)
+    if (!bucket) { bucket = []; idx.set(ck, bucket) }
+    bucket.push(s)
+  }
+  return idx
+})
+
+function tileConcentration(x, y) {
+  const idx = stoneIndex.value
+  if (idx.size === 0) return 0
+  const cx = Math.floor(x / SPATIAL_CELL)
+  const cy = Math.floor(y / SPATIAL_CELL)
+  let max = 0
+  // Check the 3×3 neighbourhood of spatial cells
+  for (let dcx = -1; dcx <= 1; dcx++) {
+    for (let dcy = -1; dcy <= 1; dcy++) {
+      const bucket = idx.get(`${cx + dcx},${cy + dcy}`)
+      if (!bucket) continue
+      for (const s of bucket) {
+        const [sx, sy] = s.position
+        const d = Math.abs(x - sx) + Math.abs(y - sy)
+        if (d === 0) return 1
+        const gi = GRADE_ORDER.indexOf(s.grade !== 'unknown' ? s.grade : 'low')
+        const radius = 10 + (gi >= 0 ? gi : 0) * 2
+        const c = Math.max(0, 1 - d / radius)
+        if (c > max) max = c
+      }
+    }
   }
   return max
 }


### PR DESCRIPTION
## Summary

- **Spatial hash optimization**: Replaces O(tiles×stones) brute-force concentration calculation with a spatial hash that groups stones into 20×20 buckets. Each tile now queries only its 3×3 bucket neighbourhood, reducing per-tile work from O(all_stones) to O(nearby_stones).
- **No visual change**: Same gradient calculation, grade weights, and radius logic — identical rendering output.

## Semantic Diff

### File Impact

| Section | Files | Lines (+/-) |
|---------|-------|-------------|
| Core | 1 | +34/−10 |
| **Total** | **1** | **+34/−10** |

### Changed

| File | +/- | Description |
|------|-----|-------------|
| `ui/src/components/WorldMap.vue` | +34/−10 | Spatial hash for stone concentration lookup |

## Changelog

- **perf**: WorldMap tileConcentration now uses spatial hash for O(tiles+stones) complexity instead of O(tiles×stones) brute-force (#141)

## Testing

- [x] eslint clean
- [x] Visual behavior unchanged (same gradient math)

Closes #141

Co-Authored-By: agent-one team <agent-one@yanok.ai>