### PR TITLE
fix: replace f-string logging and print() with lazy logger (#134, #135)

### DIFF
--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -140,7 +140,9 @@ ROVER_TOOLS = [
 class MistralRoverReasoner:
     """Rover reasoner that decides via Mistral LLM. Returns action dict, does not execute."""
 
-    def __init__(self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -237,11 +239,7 @@ class MistralRoverReasoner:
             f"Objective: {mission['objective']}\n"
             f"Target: collect {target_quantity} units of basalt and deliver to station.\n"
             f"Your inventory: {len(inventory)}/{MAX_INVENTORY_ROVER} veins"
-            + (
-                "\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!"
-                if inventory_full
-                else ""
-            )
+            + ("\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!" if inventory_full else "")
         )
 
         current_task = agent.get("tasks", [None])[0] if agent.get("tasks") else None
@@ -265,11 +263,7 @@ class MistralRoverReasoner:
                 else ""
             )
             + f"\nSolar panels remaining: {agent.get('solar_panels_remaining', 0)}"
-            + (
-                "\n⚠️ BATTERY CRITICAL — return to station now!"
-                if battery_critical
-                else ""
-            )
+            + ("\n⚠️ BATTERY CRITICAL — return to station now!" if battery_critical else "")
         )
 
         # Nearby solar panels
@@ -465,7 +459,9 @@ DRONE_TOOLS = [DRONE_MOVE_TOOL, SCAN_TOOL, NOTIFY_TOOL]
 class DroneAgent:
     """Drone scout agent powered by Mistral LLM. Moves fast, scans for basalt vein deposits."""
 
-    def __init__(self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -532,7 +528,9 @@ class DroneAgent:
             "RULES:\n"
             f"- Battery: move costs 1 fuel unit/tile (~{BATTERY_COST_MOVE_DRONE:.2%}), scan costs 2 fuel units (~{BATTERY_COST_SCAN:.2%}), notify costs 2 fuel units (~{BATTERY_COST_NOTIFY:.2%}). You can fly up to {MAX_MOVE_DISTANCE_DRONE} tiles per move.\n"
             "- Station is at ({sx},{sy}). Return when battery is low for recharge.\n"
-            "- ALWAYS keep enough battery to return to station.".format(sx=station_pos[0], sy=station_pos[1])
+            "- ALWAYS keep enough battery to return to station.".format(
+                sx=station_pos[0], sy=station_pos[1]
+            )
         )
 
         parts.append(
@@ -665,7 +663,6 @@ class MockDroneAgent:
                     thinking = f"Recall received but already at station ({x}, {y})."
                     return {
                         "thinking": thinking,
-                        
                         "action": {"name": "move", "params": {"direction": "north", "distance": 1}},
                     }
                 if abs(dx) >= abs(dy):
@@ -678,7 +675,6 @@ class MockDroneAgent:
                 thinking = f"RECALL received: {reason}. Heading to station at ({sp[0]},{sp[1]})."
                 return {
                     "thinking": thinking,
-                    
                     "action": {
                         "name": "move",
                         "params": {"direction": direction, "distance": distance},
@@ -706,7 +702,6 @@ class MockDroneAgent:
             )
             return {
                 "thinking": thinking,
-                
                 "action": {
                     "name": "move",
                     "params": {"direction": direction, "distance": distance},
@@ -752,7 +747,6 @@ class MockDroneAgent:
             )
             return {
                 "thinking": thinking,
-                
                 "action": {
                     "name": "move",
                     "params": {"direction": direction, "distance": distance},
@@ -765,7 +759,6 @@ class MockDroneAgent:
         thinking = f"I'm at ({x}, {y}). All nearby areas covered, exploring outward."
         return {
             "thinking": thinking,
-            
             "action": {
                 "name": "move",
                 "params": {"direction": direction, "distance": MAX_MOVE_DISTANCE_DRONE},
@@ -935,9 +928,10 @@ class DroneLoop(BaseAgent):
 
         # During abort, force recall so drone heads to station
         if mission_status == "aborted":
-            self._world.set_pending_commands(self.agent_id, [
-                {"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}
-            ])
+            self._world.set_pending_commands(
+                self.agent_id,
+                [{"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}],
+            )
 
         turn = await asyncio.to_thread(self._reasoner.run_turn)
         next_tick()

--- a/server/app/broadcast.py
+++ b/server/app/broadcast.py
@@ -19,11 +19,11 @@ class Broadcaster:
     async def connect(self, ws: WebSocket):
         await ws.accept()
         self._connections.append(ws)
-        logger.info(f"Client connected ({len(self._connections)} total)")
+        logger.info("Client connected (%d total)", len(self._connections))
 
     def disconnect(self, ws: WebSocket):
         self._connections.remove(ws)
-        logger.info(f"Client disconnected ({len(self._connections)} total)")
+        logger.info("Client disconnected (%d total)", len(self._connections))
 
     async def send(self, event: dict):
         """Broadcast an event dict to all connected clients."""

--- a/server/app/db.py
+++ b/server/app/db.py
@@ -9,11 +9,14 @@ RecordID notes:
 
 from __future__ import annotations
 
+import logging
 from typing import Generator
 
 from surrealdb import Surreal
 
 from .config import settings
+
+logger = logging.getLogger(__name__)
 
 
 def _create_connection() -> Surreal:
@@ -28,22 +31,22 @@ def init_db():
     """Verify DB connection on startup, with retries for Railway cold starts."""
     import time as _time
 
-    print(f"Connecting to SurrealDB: {settings.surreal_url}")
-    print(f"Namespace: {settings.surreal_ns}, Database: {settings.surreal_db}")
+    logger.info("Connecting to SurrealDB: %s", settings.surreal_url)
+    logger.info("Namespace: %s, Database: %s", settings.surreal_ns, settings.surreal_db)
 
     max_attempts = 10
     for attempt in range(1, max_attempts + 1):
         try:
             client = _create_connection()
             client.close()
-            print("SurrealDB connection verified")
+            logger.info("SurrealDB connection verified")
             return
         except Exception as exc:
             if attempt == max_attempts:
                 raise RuntimeError(
                     f"Failed to connect to SurrealDB after {max_attempts} attempts"
                 ) from exc
-            print(f"SurrealDB not ready (attempt {attempt}/{max_attempts}): {exc}")
+            logger.warning("SurrealDB not ready (attempt %d/%d): %s", attempt, max_attempts, exc)
             _time.sleep(2)
 
 

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -255,16 +255,21 @@ def _update_bounds(x, y):
 
 def _tools_for_ui(tool_schemas):
     """Extract {name, description} from Mistral tool schemas for the UI."""
-    return [{"name": t["function"]["name"], "description": t["function"]["description"]} for t in tool_schemas]
+    return [
+        {"name": t["function"]["name"], "description": t["function"]["description"]}
+        for t in tool_schemas
+    ]
 
 
 def _rover_tools_for_ui():
     from .agent import ROVER_TOOLS
+
     return _tools_for_ui(ROVER_TOOLS)
 
 
 def _drone_tools_for_ui():
     from .agent import DRONE_TOOLS
+
     return _tools_for_ui(DRONE_TOOLS)
 
 

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -139,7 +139,9 @@ class TestExecuteAction(unittest.TestCase):
     def test_execute_move_drains_battery(self):
         result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE
+        )
 
     def test_execute_move_negative_ok(self):
         """Infinite grid: moving to negative coords succeeds."""
@@ -477,7 +479,9 @@ class TestDig(unittest.TestCase):
 
     def test_dig_drains_battery(self):
         execute_action("rover-mistral", "dig", {})
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG
+        )
 
     def test_dig_no_stone(self):
         world.state["stones"] = []
@@ -490,7 +494,9 @@ class TestDig(unittest.TestCase):
         result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5
+        )
 
     def test_dig_failed_no_drain(self):
         world.state["stones"] = []
@@ -610,7 +616,9 @@ class TestCharge(unittest.TestCase):
         charge_rover("rover-mistral")
         self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + CHARGE_RATE)
         charge_rover("rover-mistral")
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE
+        )
 
     def test_charge_rover_unknown_agent(self):
         result = charge_rover("rover-99")
@@ -645,16 +653,18 @@ class TestFogOfWar(unittest.TestCase):
         ]
         # Give drone an empty revealed so it doesn't interfere
         if "drone-mistral" in world.state["agents"]:
-            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get("revealed", [])
+            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get(
+                "revealed", []
+            )
             world.state["agents"]["drone-mistral"]["revealed"] = []
         self._original_stones = world.state.get("stones", [])
 
     def tearDown(self):
         world.state["stones"] = self._original_stones
         # Restore rover-mistral revealed
-        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"]["rover-mistral"].get(
-            "revealed", []
-        )
+        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"][
+            "rover-mistral"
+        ].get("revealed", [])
         if "drone-mistral" in world.state["agents"]:
             world.state["agents"]["drone-mistral"]["revealed"] = self._original_drone_revealed
 
@@ -952,7 +962,6 @@ class TestDirectionHint(unittest.TestCase):
         self.assertEqual(direction_hint(0, 0), "here")
 
 
-
 class TestObserveRover(unittest.TestCase):
     def setUp(self):
         world.state["agents"]["rover-mistral"]["position"] = [5, 5]
@@ -1140,7 +1149,6 @@ class TestDrone(unittest.TestCase):
         world.state["stones"] = [_make_vein([10, 10], grade="high", quantity=200, analyzed=True)]
         result = execute_action("drone-mistral", "dig", {})
         self.assertFalse(result["ok"])
-
 
 
 class TestChunkSystem(unittest.TestCase):
@@ -1385,7 +1393,9 @@ class TestNotify(unittest.TestCase):
         )
 
     def test_notify_drone_success(self):
-        result = execute_action("drone-mistral", "notify", {"message": "High concentration detected"})
+        result = execute_action(
+            "drone-mistral", "notify", {"message": "High concentration detected"}
+        )
         self.assertTrue(result["ok"])
         self.assertEqual(result["position"], [3, 3])
         self.assertEqual(result["message"], "High concentration detected")
@@ -1408,7 +1418,6 @@ class TestNotify(unittest.TestCase):
         result = execute_action("rover-mistral", "notify", {"message": "help"})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-
 
 
 class TestInTransitQuantity(unittest.TestCase):
@@ -1449,7 +1458,9 @@ class TestWorldSetters(unittest.TestCase):
 
     def test_set_pending_commands_set_and_clear(self):
         set_pending_commands("rover-mistral", [{"name": "recall"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}]
+        )
         set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1458,6 +1469,7 @@ class TestWorldClass(unittest.TestCase):
     def test_singleton_wraps_module_world(self):
         """Module-level `world` singleton is the canonical instance."""
         from app.world import world as w
+
         self.assertIs(w.state, world.state)
 
     def test_get_agent(self):
@@ -1481,7 +1493,9 @@ class TestWorldClass(unittest.TestCase):
         self.assertEqual(world.state["agents"]["rover-mistral"]["last_context"], "ctx-via-class")
 
         world.set_pending_commands("rover-mistral", [{"name": "test"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}]
+        )
         world.set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1491,6 +1505,7 @@ class TestWorldClass(unittest.TestCase):
     def test_fresh_instance_independent(self):
         """A World() with no args gets its own state, independent of the singleton."""
         from app.world import World
+
         w2 = World()
         w2.set_agent_model("rover-mistral", "independent-model")
         self.assertNotEqual(


### PR DESCRIPTION
## Summary

- **broadcast.py**: Replace f-string formatting in `logger.info()` calls with lazy `%s` formatting (lines 22, 26). F-strings evaluate eagerly even when log level is disabled.
- **db.py**: Replace bare `print()` calls with proper `logger.info()` / `logger.warning()` using lazy formatting. Adds `import logging` and `logger = logging.getLogger(__name__)`.

## Semantic Diff

### File Impact

| Section | Files | Lines (+/-) |
|---------|-------|-------------|
| Core | 2 | +8/−6 |
| Format | 3 | +51/−36 |
| **Total** | **5** | **+59/−42** |

### Changed

| File | +/- | Description |
|------|-----|-------------|
| `server/app/broadcast.py` | +2/−2 | f-string → lazy % formatting |
| `server/app/db.py` | +6/−4 | print() → logger with lazy formatting |
| `server/app/agent.py` | ruff fmt | Pre-existing format violations |
| `server/app/world.py` | ruff fmt | Pre-existing format violations |
| `server/tests/test_world.py` | ruff fmt | Pre-existing format violations |

## Testing

- [x] 291 tests passing
- [x] ruff format clean
- [x] ruff check clean

Closes #134
Closes #135

Co-Authored-By: agent-one team <agent-one@yanok.ai>