### PR TITLE
docs: rewrite SPEC.md to match implementation, fix README inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Autonomous agents — a **Rover**, **Drone**, and **Station** — coordinate thr
   │ Move    │   │  Scan    │   │ Charge   │
   │ Dig     │   │  Map     │   │  Power   │
   │ Analyze │   │  Relay   │   │  Alert   │
-  │ Pickup  │   │          │   │          │
+  │ Notify  │   │          │   │          │
   └─────────┘   └──────────┘   └──────────┘
 ```
 
@@ -113,7 +113,7 @@ agent-one/
 
 ### World Model
 
-A Python dict representing the Mars environment: zones with hazards, rock types (core, basalt), agent positions, battery/power levels, storm intensity, visibility, and temperature.
+A Python dict representing the Mars environment: infinite chunk-based grid with fog-of-war, basalt veins with grades (low/medium/high/rich/pristine), agent positions, battery/power levels, and simulation tick state.
 
 ### Probabilistic Goals
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,282 +1,218 @@
-Here’s the **updated full spec Markdown** including **probabilistic goals, drone-assisted mapping, and LLM-driven agentic reasoning**:
+# Agent One: System Specification
+
+Multi-agent LLM-powered Mars mission simulation. Three autonomous agents (Rover, Drone, Station) collaborate on a procedurally generated Mars surface, coordinated by a central Coordinator. Each agent runs its own Mistral LLM reasoning loop to observe, decide, and act.
 
 ---
 
-# Autonomous Multi-Agent Mars Mission Simulation (LLM-Powered, Probabilistic Goals)
-
-A sandbox-style multi-robot simulation with **emergent behavior**, partially supervised by a base/control center.
-Humans mainly **choose missions and observe**, with optional strategic intervention.
-
----
-
-## 1. System Architecture
+## 1. Architecture
 
 ```
 +--------------------+
-|   Base / Control   |   <-- assigns missions, sets policies, monitors health, optional approvals
+|   Base / Control   |   <-- human operator: assigns missions, monitors, optional intervention
 +--------------------+
         |
         v
 +--------------------+       +--------------------+       +--------------------+
-|      Rover(s)      |       |       Drone(s)     |       |  Science Station(s)|
+|   rover-mistral    |       |   drone-mistral    |       |      station       |
 +--------------------+       +--------------------+       +--------------------+
 | LLM Decision Loop  |       | LLM Decision Loop  |       | LLM Decision Loop  |
-| Goal Evaluator     |       | Goal Evaluator     |       | Goal Evaluator     |
-| Task Scheduler     |       | Task Scheduler     |       | Task Scheduler     |
-| World Interface    |       | World Interface    |       | World Interface    |
-| Action Emitter     |       | Action Emitter     |       | Action Emitter     |
+| Tool Executor      |       | Tool Executor      |       | Charge / Allocate  |
+| World Interface    |       | World Interface    |       | Mission Manager    |
 +--------------------+       +--------------------+       +--------------------+
 ```
 
-* **Base / Control Center:** assigns missions, monitors agent events, optionally approves high-risk tasks
-* **Agents:** autonomous, **LLM-powered**, probabilistic reasoning, execute tasks, interact via Actions
-* **World:** shared simulation state with terrain, hazards, storm, agent positions, rocks, etc.
+- **Coordinator**: Spawns agent tasks, injects world state into prompts, routes messages between agents, handles timed events. Agents communicate through the Coordinator, never directly.
+- **Agents**: `rover-mistral`, `drone-mistral`, `station`. Each runs an observe, reason (LLM), act, update loop.
+- **World Model**: Python dict holding the chunk-based grid, stones, agent positions/battery, and simulation state. Updated by tool call results and external events.
+- **Broadcaster**: Singleton for WebSocket fan-out to connected UI clients.
 
 ---
 
 ## 2. World Model
 
-### 2.1 World State Structure
+### 2.1 Chunk-Based Infinite Grid
+
+The world is an infinite 2D grid divided into chunks. Each chunk is `CHUNK_SIZE x CHUNK_SIZE` (16x16) tiles. Chunks generate procedurally with deterministic seeds as agents explore.
+
+- Positions are `(x, y)` integer coordinates (no zone IDs)
+- The origin chunk at `(0, 0)` is guaranteed to contain at least one basalt vein
+- World bounds expand dynamically as agents move into unexplored areas
+- No predefined map edges; the world grows with exploration
+
+### 2.2 Fog-of-War
+
+Agents reveal tiles within their visibility radius:
+
+| Agent | Reveal Radius |
+|-------|---------------|
+| Rover | 3 tiles       |
+| Drone | 6 tiles       |
+
+Unexplored tiles remain hidden until an agent moves close enough. Previously revealed tiles stay visible.
+
+### 2.3 Stones and Veins
+
+Stones are basalt veins embedded in the terrain. Each vein has a grade that determines its value:
+
+| Grade    | Rarity       |
+|----------|--------------|
+| low      | Common       |
+| medium   | Uncommon     |
+| high     | Rare         |
+| rich     | Very rare    |
+| pristine | Extremely rare |
+
+Rarity follows an exponential distribution. Veins start with `"unknown"` type and grade until analyzed by the rover.
+
+### 2.4 World State Structure
 
 ```json
 {
-  "time": "T+0230",
-  "environment": {
-    "storm_level": 2,
-    "visibility": 0.85,
-    "temperature": -35
-  },
-  "terrain": {
-    "hazard_zones": ["Z12","Z14"],
-    "rock_positions": ["R-101","R-102","R-103"],
-    "rock_types": { "R-101": "core", "R-102": "basalt", "R-103": "core" }
-  },
+  "tick": 42,
   "agents": {
-    "rover-1": {"position": "Z10","battery": 0.78,"mobility": 0.9},
-    "drone-1": {"position": "Z08","battery": 0.65},
-    "station-1": {"position": "Base","power": 0.85}
-  }
-}
-```
-
-### 2.2 Robot–World Interface
-
-| Robot   | Read                                                | Write / Affect                                  |
-| ------- | --------------------------------------------------- | ----------------------------------------------- |
-| Rover   | Terrain, hazards, battery, storm, drone scans       | Move, Drill, Carry sample                       |
-| Drone   | Terrain, hazard map, storm, rock probabilistic data | Scan, Map safe routes, Relay signals            |
-| Station | Storm data, agent telemetry, power levels           | Allocate power, Suggest tasks, Broadcast events |
-
-* External events (storm, terrain shifts) update world asynchronously
-* Drone scans provide **probabilistic data**, not the exact rock type
-
----
-
-## 3. Missions, Goals, Tasks
-
-### 3.1 Mission Example
-
-```json
-{
-  "mission_id": "M-01",
-  "name": "Crater Survey Alpha",
-  "status": "ACTIVE",
-  "goals": [
-    {"goal_id": "G-01","description":"Collect core sample from crater floor"},
-    {"goal_id": "G-02","description":"Maintain rover mobility > 60%"},
-    {"goal_id": "G-03","description":"Map storm progression"}
+    "rover-mistral": { "position": [3, 5], "battery": 0.78, "inventory": [] },
+    "drone-mistral": { "position": [8, -2], "battery": 0.65 },
+    "station":       { "position": [0, 0] }
+  },
+  "revealed_tiles": { "(3,5)": { "terrain": "sand", "vein": null }, "..." : "..." },
+  "stones": [
+    { "position": [4, 6], "type": "unknown", "grade": "unknown" }
   ]
 }
 ```
 
 ---
 
-### 3.2 Probabilistic Goal Structure
+## 3. Agents and Tools
+
+### 3.1 Rover (`rover-mistral`)
+
+Primary ground agent. Moves across the surface, digs veins, analyzes samples, manages solar panels.
+
+| Tool                  | Description                                    | Cost        |
+|-----------------------|------------------------------------------------|-------------|
+| `move`                | Move in direction (north/south/east/west), optional distance (max 3) | 1 fuel/tile |
+| `dig`                 | Extract vein at current position               | 6 fuel      |
+| `analyze`             | Reveal true grade/type of vein at position     | 3 fuel      |
+| `deploy_solar_panel`  | Deploy emergency solar panel at position       | -           |
+| `use_solar_battery`   | Consume deployed solar panel for battery       | -           |
+| `notify`              | Send message to other agents via coordinator   | -           |
+
+- Fuel capacity: 350 units
+- Battery stored as 0.0 to 1.0 fraction
+- Inventory: max 3 veins carried at once
+- Solar panels: 0.25 capacity each, max 2 deployed
+
+### 3.2 Drone (`drone-mistral`)
+
+Aerial scout. Covers large areas quickly with wider visibility.
+
+| Tool     | Description                                | Cost        |
+|----------|--------------------------------------------|-------------|
+| `move`   | Move in direction + distance (max 6 tiles) | 1 fuel/tile |
+| `scan`   | Area scan around drone position (radius 6) | 2 fuel      |
+| `notify` | Send message to other agents               | -           |
+
+- Fuel capacity: 250 units
+
+### 3.3 Station (`station`)
+
+Fixed at position `(0, 0)`. Manages power, charges agents, assigns missions.
+
+| Action         | Description                              |
+|----------------|------------------------------------------|
+| `charge_rover` | Charge rover battery (+20% per cycle)    |
+| `charge_drone` | Charge drone battery (+20% per cycle)    |
+| Mission assign | Assign missions to agents                |
+| Mission abort  | Cancel active missions                   |
+| Power alerts   | Broadcast power allocation warnings      |
+
+---
+
+## 4. Mission System
+
+### 4.1 Primary Mission
+
+Collect 100 units of basalt and deliver to station at `(0, 0)`.
+
+### 4.2 Mission Flow
+
+1. Station assigns mission to rover
+2. Drone scouts terrain, revealing veins through scan
+3. Rover moves to veins, analyzes them, digs high-grade samples
+4. Rover carries samples back to station (max 3 per trip)
+5. Repeat until 100 units collected
+
+### 4.3 Probabilistic Goal Structure
 
 ```json
 {
   "goal_id": "G-01",
-  "description": "Collect core sample",
-  "status": "PENDING",
-  "confidence": 0.0,     // probability that goal is satisfied
-  "threshold": 0.9        // considered satisfied if confidence >= 0.9
+  "description": "Collect basalt samples",
+  "confidence": 0.0,
+  "threshold": 0.9
 }
 ```
 
-* `confidence` is updated dynamically as rover samples candidate rocks
-* Goal is **partially satisfied** before reaching threshold
+`confidence` updates dynamically as the rover collects and delivers samples. Goal is satisfied when `confidence >= threshold`.
 
 ---
 
-### 3.3 Tasks
+## 5. Agent Loop
 
-```json
-{
-  "task_id": "T-01",
-  "goal_id": "G-01",
-  "type": "DrillSample",
-  "state": "PENDING",
-  "risk_score": 0.35
-}
-```
+Each tick, every agent runs this cycle:
 
-* Tasks map to **tool calls**
-* Stream progress (start → update → end)
-* Tasks may emit **Actions** to other agents or base
+### 5.1 Observe
 
----
+Read world state slice: position, battery level, nearby revealed tiles, visible stones, other agent positions.
 
-## 4. Event System
+### 5.2 Reason (LLM)
 
-### 4.1 Event Categories
+Mistral API call with the agent's system prompt, current observations, and available tools. The LLM evaluates state and proposes an action via tool call.
 
-| Category    | Name            | Description                |
-| ----------- | --------------- | -------------------------- |
-| Environment | StormIncrease   | Storm level increases      |
-| Environment | TerrainShift    | Hazard zones appear        |
-| Agent       | BatteryLow      | Battery below threshold    |
-| Agent       | MobilityReduced | Rover mobility degraded    |
-| Agent       | TaskFailed      | Task failed                |
-| Human       | InjectChaos     | Manual disruption injected |
-
-### 4.2 Actions (Agent-to-Agent Communication)
-
-| Action Name               | Trigger                 | Target         |
-| ------------------------- | ----------------------- | -------------- |
-| MechanicalAnomalyDetected | Rover sensor anomaly    | Drone, Station |
-| SafeRouteIdentified       | Drone maps safe path    | Rover          |
-| PowerBudgetWarning        | Station low power       | Rover, Drone   |
-| TaskCompleted             | Task ends               | Base           |
-| EmergencyModeActivated    | Critical goal violation | All            |
-
-Coordinator routes Actions; agents **do not call each other directly**.
-
----
-
-## 5. LLM-Powered Agent Loop (with Probabilistic Reasoning)
-
-At each tick (or on relevant events):
-
-### 5.1 Observe World
-
-* Read world state slice (terrain, hazards, agent positions, battery/power, storm level)
-* Read **probabilistic data** from drone scans
-
-### 5.2 Evaluate Goals (LLM)
-
-* LLM interprets state, evaluates goal health, and proposes **tasks**
-* Includes **probabilistic reasoning**: which rock to sample for `Collect core sample` goal
-
-**Example prompt:**
+Example prompt context:
 
 ```
-You are Rover-1. Current goal: Collect core sample.
-Probabilistic map from drone:
-- Z12: 70% chance core sample
-- Z13: 20% chance core sample
-- Z14: 0% chance core sample
-
-Storm in 3 ticks, battery: 0.6
-Propose next action, risk assessment, and alternatives.
+You are rover-mistral. Position: (3, 5). Battery: 0.72.
+Nearby tiles: sand at (3,6), basalt vein (unknown grade) at (4,5).
+Inventory: 1/3 slots used.
+Mission: collect 100 basalt units, 34 delivered so far.
 ```
 
-**Example LLM output:**
+### 5.3 Execute
 
-```json
-{
-  "proposed_task": "MoveTo(Z12) -> DrillSample(R-101)",
-  "expected_confidence_increase": 0.7,
-  "risk_score": 0.3,
-  "alternative": "MoveTo(Z13) if Z12 blocked"
-}
-```
+Tool call result mutates world state. Move updates position. Dig adds vein to inventory. Analyze reveals grade.
+
+### 5.4 Record
+
+Memory updated. Events broadcast to all connected WebSocket clients via the Broadcaster singleton.
 
 ---
 
-### 5.3 Select & Execute Task
+## 6. Event System
 
-* Combine LLM recommendation with policy & resource constraints
-* Execute via **tool calls**, updating world and goal confidence
+### 6.1 Event Categories
 
-**Tool Examples:**
+| Category    | Examples                               |
+|-------------|----------------------------------------|
+| Agent       | BatteryLow, VeinDiscovered, DigSuccess |
+| Mission     | MissionAssigned, DeliveryComplete       |
+| World       | ChunkGenerated, BoundsExpanded          |
+| Human       | ManualIntervention                      |
 
-| Task                   | Tool Call                        |
-| ---------------------- | -------------------------------- |
-| MoveTo(Z12)            | `move_agent("Z12")`              |
-| DrillSample(R-101)     | `drill_sample("R-101")`          |
-| ScanTerrain(Z12-Z14)   | `scan_area("Z12-Z14")`           |
-| AllocatePower(rover-1) | `allocate_power("rover-1", 0.1)` |
+### 6.2 Agent-to-Agent Communication
 
-* Stream **start → progress → completion**
+Agents use `notify` to send messages through the Coordinator. Typical patterns:
 
----
+- Drone notifies rover of discovered veins
+- Station alerts agents about low power
+- Rover reports delivery completion
 
-### 5.4 Update Goal Confidence
-
-```python
-# Pseudo-code
-sampled = world.get_rock_at(rover.position)
-prob = drone_scan.get_probability(rover.position)
-if sampled.type == "core":
-    goal.confidence = min(1.0, goal.confidence + prob)
-else:
-    goal.confidence = max(0.0, goal.confidence - 0.5)
-```
-
-* Goal considered **satisfied** if `confidence >= threshold`
+The Coordinator routes all messages. Agents never call each other directly.
 
 ---
 
-### 5.5 Emit Actions
-
-* Notify other agents or base of relevant events:
-
-  * SafeRouteIdentified
-  * MechanicalAnomalyDetected
-  * TaskCompleted
-
----
-
-## 6. Base / Control Center
-
-* Assigns missions and policies
-* Observes agent events and streaming reasoning
-* Approves high-risk tasks if required
-* Receives final goal confidence and mission outcome
-
----
-
-## 7. Human Interaction
-
-* Passive: select missions, set policies
-* Optional: inject chaos, approve/cancel high-risk tasks, adjust autonomy mode
-* Watch live streaming of LLM reasoning, probabilistic goal updates, and task execution
-
----
-
-## 8. Demo Timeline (5-Minute)
-
-| Time | Event / Action                                       | Agents / Base                  |
-| ---- | ---------------------------------------------------- | ------------------------------ |
-| 0:00 | Mission Assigned                                     | Base → All                     |
-| 0:15 | Drone scans crater, emits probabilistic map          | Drone → Rover                  |
-| 0:20 | Rover LLM proposes MoveTo(Z12) -> DrillSample(R-101) | Rover                          |
-| 0:25 | Rover executes MoveTo(Z12), streams progress         | Rover                          |
-| 0:45 | StormIncrease(Level2)                                | World → all agents             |
-| 1:00 | Rover drills rock, goal confidence updates (0.7)     | Rover                          |
-| 1:15 | Rover evaluates alternatives due to storm            | Rover LLM                      |
-| 1:30 | Drone identifies safe route if Z12 blocked           | Drone → Rover                  |
-| 2:00 | Station reallocates power to rover                   | Station                        |
-| 2:30 | Human optionally approves high-risk movement         | Base → Rover                   |
-| 3:00 | TerrainShift event                                   | World → all agents             |
-| 3:15 | Rover selects alternate rock, executes DrillSample   | Rover                          |
-| 4:00 | Drone continues mapping, streams updates             | Drone                          |
-| 4:30 | Rover reaches confidence threshold → goal satisfied  | Rover                          |
-| 5:00 | Mission complete, final goal confidence reported     | Base & agents emit final state |
-
----
-
-## 9. Message / Protocol Schema
+## 7. Message Protocol
 
 ```json
 {
@@ -290,30 +226,49 @@ else:
 }
 ```
 
-* Coordinator routes messages declaratively
-* Agents subscribe to relevant events only
+- Coordinator routes messages declaratively
+- Agents subscribe to relevant events only
+- All messages broadcast to UI via WebSocket
+
+---
+
+## 8. AI Narration
+
+Mistral LLM generates narrative commentary on simulation events in real time. The narration engine watches the event stream and produces human-readable descriptions of agent actions, discoveries, and mission progress.
+
+- Text narration generated by Mistral API
+- Optional voice narration via ElevenLabs TTS
+- Streaming delivery via WebSocket `narration_chunk` events
+- Configurable minimum interval between narrations
+
+---
+
+## 9. Demo Timeline (5-Minute)
+
+| Time | Event                                                    | Agents          |
+|------|----------------------------------------------------------|-----------------|
+| 0:00 | Mission assigned: collect 100 basalt units               | Station -> All  |
+| 0:15 | Drone takes off, scans area around origin                | drone-mistral   |
+| 0:30 | Drone discovers veins at (4, 5) and (6, 3)              | drone-mistral   |
+| 0:45 | Rover moves toward nearest vein, analyzes it             | rover-mistral   |
+| 1:00 | Rover digs high-grade basalt, adds to inventory          | rover-mistral   |
+| 1:30 | Drone expands search radius, finds more veins            | drone-mistral   |
+| 2:00 | Rover battery drops below 30%, heads back to station     | rover-mistral   |
+| 2:30 | Station charges rover, rover delivers samples            | station, rover  |
+| 3:00 | Rover deploys solar panel as backup power                | rover-mistral   |
+| 3:30 | Second exploration run, drone guides rover to rich veins | Both            |
+| 4:00 | Narration describes mission progress                     | Narration       |
+| 4:30 | Rover completes final delivery                           | rover-mistral   |
+| 5:00 | Mission target reached, confidence threshold met         | All             |
 
 ---
 
 ## 10. Emergent Simulation Characteristics
 
-* **LLM-driven probabilistic reasoning** generates emergent coordination
-* Agents dynamically adapt to storm, hazards, and incomplete information
-* Cascading failures, risk trade-offs, and alternative task planning
-* Human interventions optional but visually dramatic
-* Streaming of LLM reasoning, tasks, drone scans, and goal confidence is engaging
-
----
-
-This spec now explicitly integrates:
-
-* LLM reasoning loops for task selection and goal evaluation
-* Probabilistic goal satisfaction (drone provides partial info, rover decides)
-* Agentic outputs driving tool calls and action emissions
-* Dynamic, emergent mission flow for live demo
-
----
-
-If you want, I can also **draw a diagram of this probabilistic drone → rover → station LLM flow**, showing live reasoning, tool calls, and goal confidence updates — it would make the demo logic visually clear for the judges.
-
-
+- LLM-driven decision making produces non-deterministic, adaptive behavior
+- Agents respond to changing conditions: battery constraints force return trips, new vein discoveries redirect exploration paths
+- Drone-rover cooperation emerges naturally from shared world state and notify messages
+- Fog-of-war creates genuine exploration, not just pathfinding on a known map
+- Procedural generation means every simulation run produces a different terrain layout
+- Solar panel deployment adds resource management tension
+- Streaming LLM reasoning and narration makes the simulation watchable and engaging


### PR DESCRIPTION
## Summary
- **SPEC.md**: Full rewrite — the entire spec was outdated (zone-based terrain, DrillSample actions, wrong agent IDs). Now documents the actual chunk-based infinite grid, current tool sets, battery/fuel system, fog-of-war, vein grades, mission system, and AI narration.
- **README.md**: Fix 2 inaccuracies — replace "Pickup" with "Notify" in rover diagram, update world model description to chunk-based grid with vein grades.

Closes #137, closes #138

## Changes

### Changed
| File | +/- | What |
|------|-----|------|
| `SPEC.md` | +163/-208 | Full rewrite to match current implementation |
| `README.md` | +2/-2 | Fix rover diagram + world model description |

## File Impact
| Category | Files | Lines Changed |
|----------|-------|---------------|
| Docs | 2 | +163/-208 |
| **Total** | **2** | **+163/-208** |

Co-Authored-By: agent-one team <agent-one@yanok.ai>