### PR TITLE
fix(ui): guard AgentDetailModal against null mission and visited (#157)

### DIFF
--- a/ui/src/components/AgentDetailModal.vue
+++ b/ui/src/components/AgentDetailModal.vue
@@ -65,7 +65,7 @@ function batteryPct() {
             Mission
           </div>
           <div class="modal-value">
-            {{ agent.mission.objective }}
+            {{ agent.mission?.objective ?? 'None' }}
           </div>
         </div>
         <div
@@ -100,7 +100,7 @@ function batteryPct() {
             Tiles visited
           </div>
           <div class="modal-value">
-            {{ agent.visited.length }}
+            {{ (agent.visited || []).length }}
           </div>
         </div>
         <div


### PR DESCRIPTION
## Summary
- Add optional chaining for `agent.mission?.objective` with `'None'` fallback to prevent TypeError when mission is null
- Add fallback for `agent.visited` (`(agent.visited || []).length`) to prevent TypeError when visited is undefined

Fixes #157

## Semantic Diff

| Section | Files | Insertions | Deletions |
|---------|-------|------------|-----------|
| **Changed** | 1 | 2 | 2 |

### Changed
- `ui/src/components/AgentDetailModal.vue` — safe property access for mission and visited

## Changelog
- fix(ui): guard AgentDetailModal against null agent.mission and agent.visited properties

## File Impact
| Category | Count |
|----------|-------|
| Core files changed | 1 |
| Test files changed | 0 |
| Config files changed | 0 |

@schettino72 — requesting review. This fixes a crash when clicking an agent whose server data is incomplete (mission or visited is null/undefined).

Co-Authored-By: agent-one team <agent-one@yanok.ai>