### PR TITLE
refactor(ui): extract revealedSet into useRevealedSet composable (#159)

### DIFF
--- a/ui/src/components/MiniMap.vue
+++ b/ui/src/components/MiniMap.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import MapLegend from './MapLegend.vue'
 import { VIEWPORT_W, VIEWPORT_H, VEIN_COLORS, agentColor } from '../constants.js'
+import { useRevealedSet } from '../composables/useRevealedSet.js'
 
 const props = defineProps({
   worldState: {
@@ -51,16 +52,7 @@ const bounds = computed(() => {
 const mapW = computed(() => (bounds.value.max_x - bounds.value.min_x + 1) * MINI_TILE)
 const mapH = computed(() => (bounds.value.max_y - bounds.value.min_y + 1) * MINI_TILE)
 
-const revealedSet = computed(() => {
-  const set = new Set()
-  if (!props.worldState) return set
-  for (const agent of Object.values(props.worldState.agents)) {
-    for (const cell of (agent.revealed || [])) {
-      set.add(`${cell[0]},${cell[1]}`)
-    }
-  }
-  return set
-})
+const { revealedSet } = useRevealedSet(() => props.worldState)
 
 const revealedTiles = computed(() => {
   const tiles = []

--- a/ui/src/components/StatsBar.vue
+++ b/ui/src/components/StatsBar.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import { useRevealedSet } from '../composables/useRevealedSet.js'
 
 const props = defineProps({
   worldState: {
@@ -18,16 +19,7 @@ const props = defineProps({
 
 const tick = computed(() => props.worldState?.tick ?? 0)
 
-const tilesRevealed = computed(() => {
-  if (!props.worldState) return 0
-  const set = new Set()
-  for (const agent of Object.values(props.worldState.agents || {})) {
-    for (const cell of (agent.revealed || [])) {
-      set.add(`${cell[0]},${cell[1]}`)
-    }
-  }
-  return set.size
-})
+const { revealedCount } = useRevealedSet(() => props.worldState)
 
 const mobileCount = computed(() => {
   if (!props.worldState) return 0
@@ -60,7 +52,7 @@ const targetQty = computed(() => {
       <span class="stat-sep" />
       <span class="stat">
         <span class="stat-label">Revealed</span>
-        <span class="stat-value">{{ tilesRevealed }} tiles</span>
+        <span class="stat-value">{{ revealedCount }} tiles</span>
       </span>
       <span class="stat-sep" />
       <span class="stat">

--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
 import { TILE_SIZE, VIEWPORT_W, VIEWPORT_H, VEIN_COLORS, VEIN_SIZES, SOLAR_PANEL_COLOR, SOLAR_PANEL_DEPLETED_COLOR, agentColor, revealRadius } from '../constants.js'
 import { usePreferences } from '../composables/usePreferences.js'
+import { useRevealedSet } from '../composables/useRevealedSet.js'
 
 const props = defineProps({
   worldState: {
@@ -115,20 +116,7 @@ const stations = computed(() => {
   })
 })
 
-const revealedSet = computed(() => {
-  const set = new Set()
-  if (!props.worldState) return set
-  for (const agent of Object.values(props.worldState.agents)) {
-    for (const cell of (agent.revealed || [])) {
-      set.add(`${cell[0]},${cell[1]}`)
-    }
-  }
-  return set
-})
-
-function isRevealed(x, y) {
-  return revealedSet.value.has(`${x},${y}`)
-}
+const { isRevealed } = useRevealedSet(() => props.worldState)
 
 // Grade weights for concentration radius (mirrors server logic)
 const GRADE_ORDER = ['low', 'medium', 'high', 'rich', 'pristine']

--- a/ui/src/composables/useRevealedSet.js
+++ b/ui/src/composables/useRevealedSet.js
@@ -1,0 +1,30 @@
+import { computed, toValue } from 'vue'
+
+/**
+ * Shared composable that builds a Set of revealed tile keys ("x,y")
+ * from the world state's agent data.
+ *
+ * @param {import('vue').MaybeRefOrGetter<Object|null>} worldState
+ * @returns {{ revealedSet: import('vue').ComputedRef<Set<string>>, isRevealed: (x: number, y: number) => boolean, revealedCount: import('vue').ComputedRef<number> }}
+ */
+export function useRevealedSet(worldState) {
+  const revealedSet = computed(() => {
+    const set = new Set()
+    const ws = toValue(worldState)
+    if (!ws) return set
+    for (const agent of Object.values(ws.agents || {})) {
+      for (const cell of (agent.revealed || [])) {
+        set.add(`${cell[0]},${cell[1]}`)
+      }
+    }
+    return set
+  })
+
+  function isRevealed(x, y) {
+    return revealedSet.value.has(`${x},${y}`)
+  }
+
+  const revealedCount = computed(() => revealedSet.value.size)
+
+  return { revealedSet, isRevealed, revealedCount }
+}


### PR DESCRIPTION
## Summary
- Extract identical `revealedSet` computed logic from WorldMap.vue, MiniMap.vue, and StatsBar.vue into a shared `useRevealedSet` composable
- Composable provides `revealedSet` (Set), `isRevealed(x,y)` (function), and `revealedCount` (computed number)
- Each component now imports only what it needs: WorldMap uses `isRevealed`, MiniMap uses `revealedSet`, StatsBar uses `revealedCount`

Closes #159

---

## Semantic Diff

### File Impact

| Category | Files | Lines Added | Lines Removed |
|----------|-------|-------------|---------------|
| Core     | 4     | 37          | 35            |
| Tests    | 0     | 0           | 0             |
| Docs     | 0     | 0           | 0             |
| Config   | 0     | 0           | 0             |
| **Total**| **4** | **37**      | **35**        |

### Added
- `ui/src/composables/useRevealedSet.js` (+31) — Shared composable for revealed tile computation

### Changed
- `ui/src/components/WorldMap.vue` (+2 / -13) — Use `isRevealed` from composable
- `ui/src/components/MiniMap.vue` (+3 / -11) — Use `revealedSet` from composable
- `ui/src/components/StatsBar.vue` (+3 / -12) — Use `revealedCount` from composable

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>