### PR TITLE
fix(ui): add flex-wrap and mobile breakpoint to MissionBar (#163)

### DIFF
--- a/ui/src/components/MissionBar.vue
+++ b/ui/src/components/MissionBar.vue
@@ -60,6 +60,7 @@ const progressPct = computed(() => Math.min(100, Math.round((collected.value / t
 <style scoped>
 .mission-bar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
   padding: 0.4rem 0.75rem;
@@ -155,5 +156,19 @@ const progressPct = computed(() => Math.min(100, Math.round((collected.value / t
 .abort-btn:hover {
   border-color: var(--accent-red);
   color: var(--accent-red-light);
+}
+
+@media (max-width: 600px) {
+  .mission-bar {
+    gap: 0.5rem;
+    padding: 0.35rem 0.5rem;
+    font-size: 0.7rem;
+  }
+  .mission-status {
+    margin-left: 0;
+  }
+  .progress-track {
+    width: 3rem;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- Add `flex-wrap: wrap` to `.mission-bar` to prevent horizontal overflow on narrow screens
- Add `@media (max-width: 600px)` breakpoint with tighter gap, padding, and narrower progress track
- Remove `margin-left: auto` on `.mission-status` at mobile breakpoint so wrapped items align naturally

Closes #163

---

## Semantic Diff

### File Impact

| Category | Files | Lines Added | Lines Removed |
|----------|-------|-------------|---------------|
| Core     | 1     | 15          | 0             |
| Tests    | 0     | 0           | 0             |
| Docs     | 0     | 0           | 0             |
| Config   | 0     | 0           | 0             |
| **Total**| **1** | **15**      | **0**         |

### Changed
- `ui/src/components/MissionBar.vue` (+15 / -0) — flex-wrap + mobile breakpoint

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>