### PR TITLE
fix(tests): replace blocking sleep with asyncio.sleep, add file leak guard (#162)

### DIFF
--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -140,7 +140,9 @@ ROVER_TOOLS = [
 class MistralRoverReasoner:
     """Rover reasoner that decides via Mistral LLM. Returns action dict, does not execute."""
 
-    def __init__(self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -240,11 +242,7 @@ class MistralRoverReasoner:
             f"Objective: {mission['objective']}\n"
             f"Target: collect {target_quantity} units of basalt and deliver to station.\n"
             f"Your inventory: {len(inventory)}/{MAX_INVENTORY_ROVER} veins"
-            + (
-                "\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!"
-                if inventory_full
-                else ""
-            )
+            + ("\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!" if inventory_full else "")
         )
 
         current_task = agent.get("tasks", [None])[0] if agent.get("tasks") else None
@@ -268,11 +266,7 @@ class MistralRoverReasoner:
                 else ""
             )
             + f"\nSolar panels remaining: {agent.get('solar_panels_remaining', 0)}"
-            + (
-                "\n⚠️ BATTERY CRITICAL — return to station now!"
-                if battery_critical
-                else ""
-            )
+            + ("\n⚠️ BATTERY CRITICAL — return to station now!" if battery_critical else "")
         )
 
         # Nearby solar panels
@@ -481,7 +475,9 @@ DRONE_TOOLS = [DRONE_MOVE_TOOL, SCAN_TOOL, NOTIFY_TOOL]
 class DroneAgent:
     """Drone scout agent powered by Mistral LLM. Moves fast, scans for basalt vein deposits."""
 
-    def __init__(self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -594,11 +590,7 @@ class DroneAgent:
             f"Battery: {battery:.0%} ({moves_on_battery} moves remaining, {FUEL_CAPACITY_DRONE} fuel capacity)\n"
             f"Distance to station: {dist_to_station} tiles (need {safety_margin} moves to return safely)\n"
             f"Tiles visited: {len(agent.get('visited', []))}"
-            + (
-                "\n⚠️ BATTERY CRITICAL — return to station now!"
-                if battery_critical
-                else ""
-            )
+            + ("\n⚠️ BATTERY CRITICAL — return to station now!" if battery_critical else "")
         )
 
         # -- Last Scan --
@@ -611,9 +603,7 @@ class DroneAgent:
             )
             # Check if hotspot was notified
             if scan_peak >= 0.5:
-                last_action_was_notify = (
-                    memory and "notify" in memory[-1].lower()
-                )
+                last_action_was_notify = memory and "notify" in memory[-1].lower()
                 if not last_action_was_notify:
                     parts.append("⚠️ HOTSPOT — notify station before moving!")
 
@@ -625,9 +615,7 @@ class DroneAgent:
         if best_target:
             tx, ty = best_target
             hint = direction_hint(tx - x, ty - y)
-            parts.append(
-                f"Nearest unscanned area: ({tx},{ty}) — {hint}, {best_dist} tiles"
-            )
+            parts.append(f"Nearest unscanned area: ({tx},{ty}) — {hint}, {best_dist} tiles")
         else:
             parts.append("Nearest unscanned area: none within range")
 
@@ -758,7 +746,6 @@ class MockDroneAgent:
                     thinking = f"Recall received but already at station ({x}, {y})."
                     return {
                         "thinking": thinking,
-                        
                         "action": {"name": "move", "params": {"direction": "north", "distance": 1}},
                     }
                 if abs(dx) >= abs(dy):
@@ -771,7 +758,6 @@ class MockDroneAgent:
                 thinking = f"RECALL received: {reason}. Heading to station at ({sp[0]},{sp[1]})."
                 return {
                     "thinking": thinking,
-                    
                     "action": {
                         "name": "move",
                         "params": {"direction": direction, "distance": distance},
@@ -799,7 +785,6 @@ class MockDroneAgent:
             )
             return {
                 "thinking": thinking,
-                
                 "action": {
                     "name": "move",
                     "params": {"direction": direction, "distance": distance},
@@ -845,7 +830,6 @@ class MockDroneAgent:
             )
             return {
                 "thinking": thinking,
-                
                 "action": {
                     "name": "move",
                     "params": {"direction": direction, "distance": distance},
@@ -858,7 +842,6 @@ class MockDroneAgent:
         thinking = f"I'm at ({x}, {y}). All nearby areas covered, exploring outward."
         return {
             "thinking": thinking,
-            
             "action": {
                 "name": "move",
                 "params": {"direction": direction, "distance": MAX_MOVE_DISTANCE_DRONE},
@@ -942,12 +925,16 @@ class RoverLoop(BaseAgent):
                     station_state = self._world.get_agents().get("station")
                     if station_state:
                         mem = station_state.setdefault("memory", [])
-                        mem.append(f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}")
+                        mem.append(
+                            f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"
+                        )
                     station_log = make_message(
                         source="station",
                         type="event",
                         name="thinking",
-                        payload={"text": f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"},
+                        payload={
+                            "text": f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"
+                        },
                     )
                     messages.append(station_log)
 
@@ -1005,7 +992,9 @@ class RoverLoop(BaseAgent):
 class RoverMistralLoop(RoverLoop):
     """Rover loop wired to MistralRoverReasoner."""
 
-    def __init__(self, agent_id: str = "rover-mistral", interval: float = 3.0, world: World | None = None):
+    def __init__(
+        self, agent_id: str = "rover-mistral", interval: float = 3.0, world: World | None = None
+    ):
         super().__init__(agent_id=agent_id, interval=interval, world=world)
         self._reasoner = MistralRoverReasoner(agent_id=self.agent_id, world=self._world)
         set_agent_model(self.agent_id, self._reasoner.model)
@@ -1033,9 +1022,10 @@ class DroneLoop(BaseAgent):
 
         # During abort, force recall so drone heads to station
         if mission_status == "aborted":
-            self._world.set_pending_commands(self.agent_id, [
-                {"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}
-            ])
+            self._world.set_pending_commands(
+                self.agent_id,
+                [{"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}],
+            )
 
         turn = await asyncio.to_thread(self._reasoner.run_turn)
         next_tick()
@@ -1071,12 +1061,16 @@ class DroneLoop(BaseAgent):
                     station_state = self._world.get_agents().get("station")
                     if station_state:
                         mem = station_state.setdefault("memory", [])
-                        mem.append(f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}")
+                        mem.append(
+                            f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"
+                        )
                     station_log = make_message(
                         source="station",
                         type="event",
                         name="thinking",
-                        payload={"text": f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"},
+                        payload={
+                            "text": f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"
+                        },
                     )
                     messages.append(station_log)
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -29,8 +29,12 @@ narrator = Narrator(broadcast_fn=broadcaster.send)
 host = Host(narrator=narrator)
 
 AGENT_MAP = {
-    "rover-mistral": lambda: RoverMistralLoop(agent_id="rover-mistral", interval=settings.llm_turn_interval_seconds),
-    "rover-2": lambda: RoverMistralLoop(agent_id="rover-2", interval=settings.llm_turn_interval_seconds),
+    "rover-mistral": lambda: RoverMistralLoop(
+        agent_id="rover-mistral", interval=settings.llm_turn_interval_seconds
+    ),
+    "rover-2": lambda: RoverMistralLoop(
+        agent_id="rover-2", interval=settings.llm_turn_interval_seconds
+    ),
     "drone-mistral": lambda: DroneMistralLoop(interval=2.0),
 }
 

--- a/server/app/station.py
+++ b/server/app/station.py
@@ -206,13 +206,10 @@ class StationAgent:
                 " 'Explore south and west quadrant')."
             )
         if drone_count > 1:
-            agent_hint += (
-                f" You have {drone_count} drones — send each to a different sector."
-            )
+            agent_hint += f" You have {drone_count} drones — send each to a different sector."
         return self._call_llm(
             "The mission is starting. Review the world state and assign initial "
-            "missions to ALL agents (rovers and drones)."
-            + agent_hint,
+            "missions to ALL agents (rovers and drones)." + agent_hint,
             context,
         )
 

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -255,16 +255,21 @@ def _update_bounds(x, y):
 
 def _tools_for_ui(tool_schemas):
     """Extract {name, description} from Mistral tool schemas for the UI."""
-    return [{"name": t["function"]["name"], "description": t["function"]["description"]} for t in tool_schemas]
+    return [
+        {"name": t["function"]["name"], "description": t["function"]["description"]}
+        for t in tool_schemas
+    ]
 
 
 def _rover_tools_for_ui():
     from .agent import ROVER_TOOLS
+
     return _tools_for_ui(ROVER_TOOLS)
 
 
 def _drone_tools_for_ui():
     from .agent import DRONE_TOOLS
+
     return _tools_for_ui(DRONE_TOOLS)
 
 
@@ -712,7 +717,12 @@ def _execute_charge(agent_id, agent):
     logger.info(
         "Agent %s charged %.0f%% -> %.0f%%", agent_id, old_battery * 100, agent["battery"] * 100
     )
-    return {"ok": True, "agent_id": agent_id, "battery_before": old_battery, "battery_after": agent["battery"]}
+    return {
+        "ok": True,
+        "agent_id": agent_id,
+        "battery_before": old_battery,
+        "battery_after": agent["battery"],
+    }
 
 
 def charge_agent(agent_id):

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,6 +1,6 @@
 import unittest
 import subprocess
-import time
+import asyncio
 import os
 import socket
 
@@ -28,31 +28,36 @@ async def rut_session_setup():
     log_file_path = os.path.join(os.getcwd(), "test_surrealdb.log")
     _surreal_log_file = open(log_file_path, "w")
 
-    _surreal_process = subprocess.Popen(
-        [
-            "surreal",
-            "start",
-            "--log",
-            "error",
-            "--user",
-            "root",
-            "--pass",
-            "root",
-            "--bind",
-            f"127.0.0.1:{_test_port}",
-            "memory",
-        ],
-        stdout=_surreal_log_file,
-        stderr=_surreal_log_file,
-    )
+    try:
+        _surreal_process = subprocess.Popen(
+            [
+                "surreal",
+                "start",
+                "--log",
+                "error",
+                "--user",
+                "root",
+                "--pass",
+                "root",
+                "--bind",
+                f"127.0.0.1:{_test_port}",
+                "memory",
+            ],
+            stdout=_surreal_log_file,
+            stderr=_surreal_log_file,
+        )
 
-    for _ in range(30):  # 30 attempts × 0.2s = 6s max
-        if is_port_in_use(_test_port):
-            break
-        time.sleep(0.2)
-    else:
-        raise RuntimeError(f"SurrealDB failed to start on port {_test_port}")
-    print(f"Started in-memory SurrealDB on port {_test_port}")
+        for _ in range(30):  # 30 attempts × 0.2s = 6s max
+            if is_port_in_use(_test_port):
+                break
+            await asyncio.sleep(0.2)
+        else:
+            raise RuntimeError(f"SurrealDB failed to start on port {_test_port}")
+        print(f"Started in-memory SurrealDB on port {_test_port}")
+    except Exception:
+        _surreal_log_file.close()
+        _surreal_log_file = None
+        raise
 
 
 async def rut_session_teardown():

--- a/server/tests/test_narrator.py
+++ b/server/tests/test_narrator.py
@@ -116,7 +116,11 @@ class TestBuildNarrationPrompt(unittest.TestCase):
             {
                 "source": "station",
                 "name": "charge_agent",
-                "payload": {"agent_id": "rover-mistral", "battery_before": 0.3, "battery_after": 1.0},
+                "payload": {
+                    "agent_id": "rover-mistral",
+                    "battery_before": 0.3,
+                    "battery_after": 1.0,
+                },
             }
         ]
         prompt = _build_narration_prompt(events, "")

--- a/server/tests/test_station.py
+++ b/server/tests/test_station.py
@@ -119,8 +119,20 @@ class TestDefineMissionDroneHint(unittest.TestCase):
             grid_w=20,
             grid_h=20,
             rovers=[
-                RoverSummary(id="drone-1", agent_type="drone", position=[0, 0], battery=1.0, mission=AgentMission(objective="", plan=[])),
-                RoverSummary(id="drone-2", agent_type="drone", position=[0, 0], battery=1.0, mission=AgentMission(objective="", plan=[])),
+                RoverSummary(
+                    id="drone-1",
+                    agent_type="drone",
+                    position=[0, 0],
+                    battery=1.0,
+                    mission=AgentMission(objective="", plan=[]),
+                ),
+                RoverSummary(
+                    id="drone-2",
+                    agent_type="drone",
+                    position=[0, 0],
+                    battery=1.0,
+                    mission=AgentMission(objective="", plan=[]),
+                ),
             ],
             stones=[],
         )
@@ -147,8 +159,20 @@ class TestDefineMissionRoverDroneHint(unittest.TestCase):
             grid_w=20,
             grid_h=20,
             rovers=[
-                RoverSummary(id="rover-mistral", agent_type="rover", position=[0, 0], battery=1.0, mission=AgentMission(objective="", plan=[])),
-                RoverSummary(id="drone-mistral", agent_type="drone", position=[0, 0], battery=1.0, mission=AgentMission(objective="", plan=[])),
+                RoverSummary(
+                    id="rover-mistral",
+                    agent_type="rover",
+                    position=[0, 0],
+                    battery=1.0,
+                    mission=AgentMission(objective="", plan=[]),
+                ),
+                RoverSummary(
+                    id="drone-mistral",
+                    agent_type="drone",
+                    position=[0, 0],
+                    battery=1.0,
+                    mission=AgentMission(objective="", plan=[]),
+                ),
             ],
             stones=[],
         )

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -139,7 +139,9 @@ class TestExecuteAction(unittest.TestCase):
     def test_execute_move_drains_battery(self):
         result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE
+        )
 
     def test_execute_move_negative_ok(self):
         """Infinite grid: moving to negative coords succeeds."""
@@ -477,7 +479,9 @@ class TestDig(unittest.TestCase):
 
     def test_dig_drains_battery(self):
         execute_action("rover-mistral", "dig", {})
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG
+        )
 
     def test_dig_no_stone(self):
         world.state["stones"] = []
@@ -490,7 +494,9 @@ class TestDig(unittest.TestCase):
         result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5
+        )
 
     def test_dig_failed_no_drain(self):
         world.state["stones"] = []
@@ -611,7 +617,9 @@ class TestCharge(unittest.TestCase):
         charge_rover("rover-mistral")
         self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + CHARGE_RATE)
         charge_rover("rover-mistral")
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE
+        )
 
     def test_charge_rover_unknown_agent(self):
         result = charge_rover("rover-99")
@@ -646,16 +654,18 @@ class TestFogOfWar(unittest.TestCase):
         ]
         # Give drone an empty revealed so it doesn't interfere
         if "drone-mistral" in world.state["agents"]:
-            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get("revealed", [])
+            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get(
+                "revealed", []
+            )
             world.state["agents"]["drone-mistral"]["revealed"] = []
         self._original_stones = world.state.get("stones", [])
 
     def tearDown(self):
         world.state["stones"] = self._original_stones
         # Restore rover-mistral revealed
-        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"]["rover-mistral"].get(
-            "revealed", []
-        )
+        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"][
+            "rover-mistral"
+        ].get("revealed", [])
         if "drone-mistral" in world.state["agents"]:
             world.state["agents"]["drone-mistral"]["revealed"] = self._original_drone_revealed
 
@@ -958,7 +968,6 @@ class TestDirectionHint(unittest.TestCase):
         self.assertEqual(direction_hint(0, 0), "here")
 
 
-
 class TestObserveRover(unittest.TestCase):
     def setUp(self):
         world.state["agents"]["rover-mistral"]["position"] = [5, 5]
@@ -1152,7 +1161,6 @@ class TestDrone(unittest.TestCase):
         world.state["stones"] = [_make_vein([10, 10], grade="high", quantity=200, analyzed=True)]
         result = execute_action("drone-mistral", "dig", {})
         self.assertFalse(result["ok"])
-
 
 
 class TestChunkSystem(unittest.TestCase):
@@ -1397,7 +1405,9 @@ class TestNotify(unittest.TestCase):
         )
 
     def test_notify_drone_success(self):
-        result = execute_action("drone-mistral", "notify", {"message": "High concentration detected"})
+        result = execute_action(
+            "drone-mistral", "notify", {"message": "High concentration detected"}
+        )
         self.assertTrue(result["ok"])
         self.assertEqual(result["position"], [3, 3])
         self.assertEqual(result["message"], "High concentration detected")
@@ -1420,7 +1430,6 @@ class TestNotify(unittest.TestCase):
         result = execute_action("rover-mistral", "notify", {"message": "help"})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-
 
 
 class TestInTransitQuantity(unittest.TestCase):
@@ -1461,7 +1470,9 @@ class TestWorldSetters(unittest.TestCase):
 
     def test_set_pending_commands_set_and_clear(self):
         set_pending_commands("rover-mistral", [{"name": "recall"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}]
+        )
         set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1470,6 +1481,7 @@ class TestWorldClass(unittest.TestCase):
     def test_singleton_wraps_module_world(self):
         """Module-level `world` singleton is the canonical instance."""
         from app.world import world as w
+
         self.assertIs(w.state, world.state)
 
     def test_get_agent(self):
@@ -1493,7 +1505,9 @@ class TestWorldClass(unittest.TestCase):
         self.assertEqual(world.state["agents"]["rover-mistral"]["last_context"], "ctx-via-class")
 
         world.set_pending_commands("rover-mistral", [{"name": "test"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}]
+        )
         world.set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1503,6 +1517,7 @@ class TestWorldClass(unittest.TestCase):
     def test_fresh_instance_independent(self):
         """A World() with no args gets its own state, independent of the singleton."""
         from app.world import World
+
         w2 = World()
         w2.set_agent_model("rover-mistral", "independent-model")
         self.assertNotEqual(


### PR DESCRIPTION
## Summary
- Replace `time.sleep(0.2)` with `await asyncio.sleep(0.2)` in `rut_session_setup()` to avoid blocking the event loop
- Wrap `subprocess.Popen` in try/except so the log file handle is properly closed if SurrealDB fails to start
- Includes ruff format fixes for pre-existing format violations on main

Closes #162

---

## Semantic Diff

### File Impact

| Category | Files | Lines Added | Lines Removed |
|----------|-------|-------------|---------------|
| Core     | 4     | 53          | 48            |
| Tests    | 4     | 90          | 42            |
| Docs     | 0     | 0           | 0             |
| Config   | 0     | 0           | 0             |
| **Total**| **8** | **143**     | **90**        |

### Changed
- `server/tests/conftest.py` (+31 / -26) — asyncio.sleep + file leak guard
- `server/app/agent.py` (+33 / -33) — ruff format
- `server/app/main.py` (+5 / -3) — ruff format
- `server/app/station.py` (+3 / -4) — ruff format
- `server/app/world.py` (+12 / -2) — ruff format
- `server/tests/test_narrator.py` (+5 / -1) — ruff format
- `server/tests/test_station.py` (+27 / -5) — ruff format
- `server/tests/test_world.py` (+27 / -16) — ruff format

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>