### PR TITLE
fix(tests): add tearDown to 5 test classes to prevent state leakage

### DIFF
--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -140,7 +140,9 @@ ROVER_TOOLS = [
 class MistralRoverReasoner:
     """Rover reasoner that decides via Mistral LLM. Returns action dict, does not execute."""
 
-    def __init__(self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="rover-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -240,11 +242,7 @@ class MistralRoverReasoner:
             f"Objective: {mission['objective']}\n"
             f"Target: collect {target_quantity} units of basalt and deliver to station.\n"
             f"Your inventory: {len(inventory)}/{MAX_INVENTORY_ROVER} veins"
-            + (
-                "\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!"
-                if inventory_full
-                else ""
-            )
+            + ("\n🏁 INVENTORY FULL — RETURN TO STATION NOW TO DELIVER!" if inventory_full else "")
         )
 
         current_task = agent.get("tasks", [None])[0] if agent.get("tasks") else None
@@ -268,11 +266,7 @@ class MistralRoverReasoner:
                 else ""
             )
             + f"\nSolar panels remaining: {agent.get('solar_panels_remaining', 0)}"
-            + (
-                "\n⚠️ BATTERY CRITICAL — return to station now!"
-                if battery_critical
-                else ""
-            )
+            + ("\n⚠️ BATTERY CRITICAL — return to station now!" if battery_critical else "")
         )
 
         # Nearby solar panels
@@ -481,7 +475,9 @@ DRONE_TOOLS = [DRONE_MOVE_TOOL, SCAN_TOOL, NOTIFY_TOOL]
 class DroneAgent:
     """Drone scout agent powered by Mistral LLM. Moves fast, scans for basalt vein deposits."""
 
-    def __init__(self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None):
+    def __init__(
+        self, agent_id="drone-mistral", model="mistral-small-latest", world: World | None = None
+    ):
         self.agent_id = agent_id
         self.model = model
         self._client = None
@@ -594,11 +590,7 @@ class DroneAgent:
             f"Battery: {battery:.0%} ({moves_on_battery} moves remaining, {FUEL_CAPACITY_DRONE} fuel capacity)\n"
             f"Distance to station: {dist_to_station} tiles (need {safety_margin} moves to return safely)\n"
             f"Tiles visited: {len(agent.get('visited', []))}"
-            + (
-                "\n⚠️ BATTERY CRITICAL — return to station now!"
-                if battery_critical
-                else ""
-            )
+            + ("\n⚠️ BATTERY CRITICAL — return to station now!" if battery_critical else "")
         )
 
         # -- Last Scan --
@@ -611,9 +603,7 @@ class DroneAgent:
             )
             # Check if hotspot was notified
             if scan_peak >= 0.5:
-                last_action_was_notify = (
-                    memory and "notify" in memory[-1].lower()
-                )
+                last_action_was_notify = memory and "notify" in memory[-1].lower()
                 if not last_action_was_notify:
                     parts.append("⚠️ HOTSPOT — notify station before moving!")
 
@@ -625,9 +615,7 @@ class DroneAgent:
         if best_target:
             tx, ty = best_target
             hint = direction_hint(tx - x, ty - y)
-            parts.append(
-                f"Nearest unscanned area: ({tx},{ty}) — {hint}, {best_dist} tiles"
-            )
+            parts.append(f"Nearest unscanned area: ({tx},{ty}) — {hint}, {best_dist} tiles")
         else:
             parts.append("Nearest unscanned area: none within range")
 
@@ -758,7 +746,6 @@ class MockDroneAgent:
                     thinking = f"Recall received but already at station ({x}, {y})."
                     return {
                         "thinking": thinking,
-                        
                         "action": {"name": "move", "params": {"direction": "north", "distance": 1}},
                     }
                 if abs(dx) >= abs(dy):
@@ -771,7 +758,6 @@ class MockDroneAgent:
                 thinking = f"RECALL received: {reason}. Heading to station at ({sp[0]},{sp[1]})."
                 return {
                     "thinking": thinking,
-                    
                     "action": {
                         "name": "move",
                         "params": {"direction": direction, "distance": distance},
@@ -799,7 +785,6 @@ class MockDroneAgent:
             )
             return {
                 "thinking": thinking,
-                
                 "action": {
                     "name": "move",
                     "params": {"direction": direction, "distance": distance},
@@ -845,7 +830,6 @@ class MockDroneAgent:
             )
             return {
                 "thinking": thinking,
-                
                 "action": {
                     "name": "move",
                     "params": {"direction": direction, "distance": distance},
@@ -858,7 +842,6 @@ class MockDroneAgent:
         thinking = f"I'm at ({x}, {y}). All nearby areas covered, exploring outward."
         return {
             "thinking": thinking,
-            
             "action": {
                 "name": "move",
                 "params": {"direction": direction, "distance": MAX_MOVE_DISTANCE_DRONE},
@@ -942,12 +925,16 @@ class RoverLoop(BaseAgent):
                     station_state = self._world.get_agents().get("station")
                     if station_state:
                         mem = station_state.setdefault("memory", [])
-                        mem.append(f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}")
+                        mem.append(
+                            f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"
+                        )
                     station_log = make_message(
                         source="station",
                         type="event",
                         name="thinking",
-                        payload={"text": f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"},
+                        payload={
+                            "text": f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"
+                        },
                     )
                     messages.append(station_log)
 
@@ -1005,7 +992,9 @@ class RoverLoop(BaseAgent):
 class RoverMistralLoop(RoverLoop):
     """Rover loop wired to MistralRoverReasoner."""
 
-    def __init__(self, agent_id: str = "rover-mistral", interval: float = 3.0, world: World | None = None):
+    def __init__(
+        self, agent_id: str = "rover-mistral", interval: float = 3.0, world: World | None = None
+    ):
         super().__init__(agent_id=agent_id, interval=interval, world=world)
         self._reasoner = MistralRoverReasoner(agent_id=self.agent_id, world=self._world)
         set_agent_model(self.agent_id, self._reasoner.model)
@@ -1033,9 +1022,10 @@ class DroneLoop(BaseAgent):
 
         # During abort, force recall so drone heads to station
         if mission_status == "aborted":
-            self._world.set_pending_commands(self.agent_id, [
-                {"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}
-            ])
+            self._world.set_pending_commands(
+                self.agent_id,
+                [{"name": "recall", "payload": {"reason": "Mission aborted — return to station"}}],
+            )
 
         turn = await asyncio.to_thread(self._reasoner.run_turn)
         next_tick()
@@ -1071,12 +1061,16 @@ class DroneLoop(BaseAgent):
                     station_state = self._world.get_agents().get("station")
                     if station_state:
                         mem = station_state.setdefault("memory", [])
-                        mem.append(f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}")
+                        mem.append(
+                            f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"
+                        )
                     station_log = make_message(
                         source="station",
                         type="event",
                         name="thinking",
-                        payload={"text": f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"},
+                        payload={
+                            "text": f"Radio from {self.agent_id} at ({pos[0]},{pos[1]}): {result['message']}"
+                        },
                     )
                     messages.append(station_log)
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -29,8 +29,12 @@ narrator = Narrator(broadcast_fn=broadcaster.send)
 host = Host(narrator=narrator)
 
 AGENT_MAP = {
-    "rover-mistral": lambda: RoverMistralLoop(agent_id="rover-mistral", interval=settings.llm_turn_interval_seconds),
-    "rover-2": lambda: RoverMistralLoop(agent_id="rover-2", interval=settings.llm_turn_interval_seconds),
+    "rover-mistral": lambda: RoverMistralLoop(
+        agent_id="rover-mistral", interval=settings.llm_turn_interval_seconds
+    ),
+    "rover-2": lambda: RoverMistralLoop(
+        agent_id="rover-2", interval=settings.llm_turn_interval_seconds
+    ),
     "drone-mistral": lambda: DroneMistralLoop(interval=2.0),
 }
 

--- a/server/app/station.py
+++ b/server/app/station.py
@@ -206,13 +206,10 @@ class StationAgent:
                 " 'Explore south and west quadrant')."
             )
         if drone_count > 1:
-            agent_hint += (
-                f" You have {drone_count} drones — send each to a different sector."
-            )
+            agent_hint += f" You have {drone_count} drones — send each to a different sector."
         return self._call_llm(
             "The mission is starting. Review the world state and assign initial "
-            "missions to ALL agents (rovers and drones)."
-            + agent_hint,
+            "missions to ALL agents (rovers and drones)." + agent_hint,
             context,
         )
 

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -255,16 +255,21 @@ def _update_bounds(x, y):
 
 def _tools_for_ui(tool_schemas):
     """Extract {name, description} from Mistral tool schemas for the UI."""
-    return [{"name": t["function"]["name"], "description": t["function"]["description"]} for t in tool_schemas]
+    return [
+        {"name": t["function"]["name"], "description": t["function"]["description"]}
+        for t in tool_schemas
+    ]
 
 
 def _rover_tools_for_ui():
     from .agent import ROVER_TOOLS
+
     return _tools_for_ui(ROVER_TOOLS)
 
 
 def _drone_tools_for_ui():
     from .agent import DRONE_TOOLS
+
     return _tools_for_ui(DRONE_TOOLS)
 
 
@@ -712,7 +717,12 @@ def _execute_charge(agent_id, agent):
     logger.info(
         "Agent %s charged %.0f%% -> %.0f%%", agent_id, old_battery * 100, agent["battery"] * 100
     )
-    return {"ok": True, "agent_id": agent_id, "battery_before": old_battery, "battery_after": agent["battery"]}
+    return {
+        "ok": True,
+        "agent_id": agent_id,
+        "battery_before": old_battery,
+        "battery_after": agent["battery"],
+    }
 
 
 def charge_agent(agent_id):

--- a/server/tests/test_narrator.py
+++ b/server/tests/test_narrator.py
@@ -116,7 +116,11 @@ class TestBuildNarrationPrompt(unittest.TestCase):
             {
                 "source": "station",
                 "name": "charge_agent",
-                "payload": {"agent_id": "rover-mistral", "battery_before": 0.3, "battery_after": 1.0},
+                "payload": {
+                    "agent_id": "rover-mistral",
+                    "battery_before": 0.3,
+                    "battery_after": 1.0,
+                },
             }
         ]
         prompt = _build_narration_prompt(events, "")

--- a/server/tests/test_station.py
+++ b/server/tests/test_station.py
@@ -119,8 +119,20 @@ class TestDefineMissionDroneHint(unittest.TestCase):
             grid_w=20,
             grid_h=20,
             rovers=[
-                RoverSummary(id="drone-1", agent_type="drone", position=[0, 0], battery=1.0, mission=AgentMission(objective="", plan=[])),
-                RoverSummary(id="drone-2", agent_type="drone", position=[0, 0], battery=1.0, mission=AgentMission(objective="", plan=[])),
+                RoverSummary(
+                    id="drone-1",
+                    agent_type="drone",
+                    position=[0, 0],
+                    battery=1.0,
+                    mission=AgentMission(objective="", plan=[]),
+                ),
+                RoverSummary(
+                    id="drone-2",
+                    agent_type="drone",
+                    position=[0, 0],
+                    battery=1.0,
+                    mission=AgentMission(objective="", plan=[]),
+                ),
             ],
             stones=[],
         )
@@ -147,8 +159,20 @@ class TestDefineMissionRoverDroneHint(unittest.TestCase):
             grid_w=20,
             grid_h=20,
             rovers=[
-                RoverSummary(id="rover-mistral", agent_type="rover", position=[0, 0], battery=1.0, mission=AgentMission(objective="", plan=[])),
-                RoverSummary(id="drone-mistral", agent_type="drone", position=[0, 0], battery=1.0, mission=AgentMission(objective="", plan=[])),
+                RoverSummary(
+                    id="rover-mistral",
+                    agent_type="rover",
+                    position=[0, 0],
+                    battery=1.0,
+                    mission=AgentMission(objective="", plan=[]),
+                ),
+                RoverSummary(
+                    id="drone-mistral",
+                    agent_type="drone",
+                    position=[0, 0],
+                    battery=1.0,
+                    mission=AgentMission(objective="", plan=[]),
+                ),
             ],
             stones=[],
         )

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -34,13 +34,25 @@ def _make_vein(pos, grade="high", quantity=200, analyzed=False):
 
 class TestMoveAgent(unittest.TestCase):
     def setUp(self):
-        world.state["agents"]["rover-mistral"]["position"] = [2, 10]
-        world.state["agents"]["rover-mistral"]["battery"] = 1.0
-        world.state["agents"]["rover-mistral"]["mission"] = {
+        agent = world.state["agents"]["rover-mistral"]
+        self._orig_position = list(agent["position"])
+        self._orig_battery = agent["battery"]
+        self._orig_mission = dict(agent["mission"])
+        self._orig_visited = list(agent["visited"])
+        agent["position"] = [2, 10]
+        agent["battery"] = 1.0
+        agent["mission"] = {
             "objective": "Explore the terrain",
             "plan": [],
         }
-        world.state["agents"]["rover-mistral"]["visited"] = [[2, 10]]
+        agent["visited"] = [[2, 10]]
+
+    def tearDown(self):
+        agent = world.state["agents"]["rover-mistral"]
+        agent["position"] = self._orig_position
+        agent["battery"] = self._orig_battery
+        agent["mission"] = self._orig_mission
+        agent["visited"] = self._orig_visited
 
     def test_move_success(self):
         result = move_agent("rover-mistral", 3, 10)
@@ -121,13 +133,25 @@ class TestMoveAgent(unittest.TestCase):
 
 class TestExecuteAction(unittest.TestCase):
     def setUp(self):
-        world.state["agents"]["rover-mistral"]["position"] = [2, 10]
-        world.state["agents"]["rover-mistral"]["battery"] = 1.0
-        world.state["agents"]["rover-mistral"]["mission"] = {
+        agent = world.state["agents"]["rover-mistral"]
+        self._orig_position = list(agent["position"])
+        self._orig_battery = agent["battery"]
+        self._orig_mission = dict(agent["mission"])
+        self._orig_visited = list(agent["visited"])
+        agent["position"] = [2, 10]
+        agent["battery"] = 1.0
+        agent["mission"] = {
             "objective": "Explore the terrain",
             "plan": [],
         }
-        world.state["agents"]["rover-mistral"]["visited"] = [[2, 10]]
+        agent["visited"] = [[2, 10]]
+
+    def tearDown(self):
+        agent = world.state["agents"]["rover-mistral"]
+        agent["position"] = self._orig_position
+        agent["battery"] = self._orig_battery
+        agent["mission"] = self._orig_mission
+        agent["visited"] = self._orig_visited
 
     def test_execute_move_east(self):
         result = execute_action("rover-mistral", "move", {"direction": "east"})
@@ -139,7 +163,9 @@ class TestExecuteAction(unittest.TestCase):
     def test_execute_move_drains_battery(self):
         result = execute_action("rover-mistral", "move", {"direction": "east"})
         self.assertTrue(result["ok"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_MOVE
+        )
 
     def test_execute_move_negative_ok(self):
         """Infinite grid: moving to negative coords succeeds."""
@@ -287,13 +313,27 @@ class TestStones(unittest.TestCase):
 
 class TestVisited(unittest.TestCase):
     def setUp(self):
-        world.state["agents"]["rover-mistral"]["position"] = [10, 10]
-        world.state["agents"]["rover-mistral"]["battery"] = 1.0
-        world.state["agents"]["rover-mistral"]["mission"] = {
+        agent = world.state["agents"]["rover-mistral"]
+        self._orig_position = list(agent["position"])
+        self._orig_battery = agent["battery"]
+        self._orig_mission = dict(agent["mission"])
+        self._orig_visited = list(agent["visited"])
+        self._orig_revealed = list(agent.get("revealed", []))
+        agent["position"] = [10, 10]
+        agent["battery"] = 1.0
+        agent["mission"] = {
             "objective": "Explore the terrain",
             "plan": [],
         }
-        world.state["agents"]["rover-mistral"]["visited"] = [[10, 10]]
+        agent["visited"] = [[10, 10]]
+
+    def tearDown(self):
+        agent = world.state["agents"]["rover-mistral"]
+        agent["position"] = self._orig_position
+        agent["battery"] = self._orig_battery
+        agent["mission"] = self._orig_mission
+        agent["visited"] = self._orig_visited
+        agent["revealed"] = self._orig_revealed
 
     def test_visited_initial(self):
         self.assertEqual(world.state["agents"]["rover-mistral"]["visited"], [[10, 10]])
@@ -477,7 +517,9 @@ class TestDig(unittest.TestCase):
 
     def test_dig_drains_battery(self):
         execute_action("rover-mistral", "dig", {})
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 1.0 - BATTERY_COST_DIG
+        )
 
     def test_dig_no_stone(self):
         world.state["stones"] = []
@@ -490,7 +532,9 @@ class TestDig(unittest.TestCase):
         result = execute_action("rover-mistral", "dig", {})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], BATTERY_COST_DIG * 0.5
+        )
 
     def test_dig_failed_no_drain(self):
         world.state["stones"] = []
@@ -571,12 +615,28 @@ class TestCharge(unittest.TestCase):
     """Charging is a station-only action via charge_rover()."""
 
     def setUp(self):
-        world.state["agents"]["rover-mistral"]["position"] = [0, 0]
-        world.state["agents"]["rover-mistral"]["battery"] = 0.5
-        world.state["agents"]["rover-mistral"]["inventory"] = []
-        world.state["agents"]["rover-mistral"]["visited"] = [[0, 0]]
-        world.state["agents"]["rover-mistral"]["memory"] = []
+        rover = world.state["agents"]["rover-mistral"]
+        self._orig_position = list(rover["position"])
+        self._orig_battery = rover["battery"]
+        self._orig_inventory = list(rover.get("inventory", []))
+        self._orig_visited = list(rover["visited"])
+        self._orig_memory = list(rover.get("memory", []))
+        self._orig_station_pos = list(world.state["agents"]["station"]["position"])
+        rover["position"] = [0, 0]
+        rover["battery"] = 0.5
+        rover["inventory"] = []
+        rover["visited"] = [[0, 0]]
+        rover["memory"] = []
         world.state["agents"]["station"]["position"] = [0, 0]
+
+    def tearDown(self):
+        rover = world.state["agents"]["rover-mistral"]
+        rover["position"] = self._orig_position
+        rover["battery"] = self._orig_battery
+        rover["inventory"] = self._orig_inventory
+        rover["visited"] = self._orig_visited
+        rover["memory"] = self._orig_memory
+        world.state["agents"]["station"]["position"] = self._orig_station_pos
 
     def test_charge_rover_success(self):
         result = charge_rover("rover-mistral")
@@ -611,7 +671,9 @@ class TestCharge(unittest.TestCase):
         charge_rover("rover-mistral")
         self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + CHARGE_RATE)
         charge_rover("rover-mistral")
-        self.assertAlmostEqual(world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE)
+        self.assertAlmostEqual(
+            world.state["agents"]["rover-mistral"]["battery"], 0.1 + 2 * CHARGE_RATE
+        )
 
     def test_charge_rover_unknown_agent(self):
         result = charge_rover("rover-99")
@@ -646,16 +708,18 @@ class TestFogOfWar(unittest.TestCase):
         ]
         # Give drone an empty revealed so it doesn't interfere
         if "drone-mistral" in world.state["agents"]:
-            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get("revealed", [])
+            self._original_drone_revealed = world.state["agents"]["drone-mistral"].get(
+                "revealed", []
+            )
             world.state["agents"]["drone-mistral"]["revealed"] = []
         self._original_stones = world.state.get("stones", [])
 
     def tearDown(self):
         world.state["stones"] = self._original_stones
         # Restore rover-mistral revealed
-        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"]["rover-mistral"].get(
-            "revealed", []
-        )
+        world.state["agents"]["rover-mistral"]["revealed"] = world.state["agents"][
+            "rover-mistral"
+        ].get("revealed", [])
         if "drone-mistral" in world.state["agents"]:
             world.state["agents"]["drone-mistral"]["revealed"] = self._original_drone_revealed
 
@@ -958,17 +1022,36 @@ class TestDirectionHint(unittest.TestCase):
         self.assertEqual(direction_hint(0, 0), "here")
 
 
-
 class TestObserveRover(unittest.TestCase):
     def setUp(self):
-        world.state["agents"]["rover-mistral"]["position"] = [5, 5]
-        world.state["agents"]["rover-mistral"]["battery"] = 0.75
-        world.state["agents"]["rover-mistral"]["mission"] = {"objective": "Explore", "plan": []}
-        world.state["agents"]["rover-mistral"]["visited"] = [[0, 0], [5, 5]]
-        world.state["agents"]["rover-mistral"]["inventory"] = []
-        world.state["agents"]["rover-mistral"]["memory"] = ["moved east"]
-        world.state["agents"]["rover-mistral"]["tasks"] = []
+        agent = world.state["agents"]["rover-mistral"]
+        self._orig_position = list(agent["position"])
+        self._orig_battery = agent["battery"]
+        self._orig_mission = dict(agent["mission"])
+        self._orig_visited = list(agent["visited"])
+        self._orig_inventory = list(agent.get("inventory", []))
+        self._orig_memory = list(agent.get("memory", []))
+        self._orig_tasks = list(agent.get("tasks", []))
+        self._orig_stones = list(world.state.get("stones", []))
+        agent["position"] = [5, 5]
+        agent["battery"] = 0.75
+        agent["mission"] = {"objective": "Explore", "plan": []}
+        agent["visited"] = [[0, 0], [5, 5]]
+        agent["inventory"] = []
+        agent["memory"] = ["moved east"]
+        agent["tasks"] = []
         world.state["stones"] = []
+
+    def tearDown(self):
+        agent = world.state["agents"]["rover-mistral"]
+        agent["position"] = self._orig_position
+        agent["battery"] = self._orig_battery
+        agent["mission"] = self._orig_mission
+        agent["visited"] = self._orig_visited
+        agent["inventory"] = self._orig_inventory
+        agent["memory"] = self._orig_memory
+        agent["tasks"] = self._orig_tasks
+        world.state["stones"] = self._orig_stones
 
     def test_returns_rover_context_type(self):
         ctx = observe_rover("rover-mistral")
@@ -1152,7 +1235,6 @@ class TestDrone(unittest.TestCase):
         world.state["stones"] = [_make_vein([10, 10], grade="high", quantity=200, analyzed=True)]
         result = execute_action("drone-mistral", "dig", {})
         self.assertFalse(result["ok"])
-
 
 
 class TestChunkSystem(unittest.TestCase):
@@ -1397,7 +1479,9 @@ class TestNotify(unittest.TestCase):
         )
 
     def test_notify_drone_success(self):
-        result = execute_action("drone-mistral", "notify", {"message": "High concentration detected"})
+        result = execute_action(
+            "drone-mistral", "notify", {"message": "High concentration detected"}
+        )
         self.assertTrue(result["ok"])
         self.assertEqual(result["position"], [3, 3])
         self.assertEqual(result["message"], "High concentration detected")
@@ -1420,7 +1504,6 @@ class TestNotify(unittest.TestCase):
         result = execute_action("rover-mistral", "notify", {"message": "help"})
         self.assertFalse(result["ok"])
         self.assertIn("Not enough battery", result["error"])
-
 
 
 class TestInTransitQuantity(unittest.TestCase):
@@ -1461,7 +1544,9 @@ class TestWorldSetters(unittest.TestCase):
 
     def test_set_pending_commands_set_and_clear(self):
         set_pending_commands("rover-mistral", [{"name": "recall"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "recall"}]
+        )
         set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1470,6 +1555,7 @@ class TestWorldClass(unittest.TestCase):
     def test_singleton_wraps_module_world(self):
         """Module-level `world` singleton is the canonical instance."""
         from app.world import world as w
+
         self.assertIs(w.state, world.state)
 
     def test_get_agent(self):
@@ -1493,7 +1579,9 @@ class TestWorldClass(unittest.TestCase):
         self.assertEqual(world.state["agents"]["rover-mistral"]["last_context"], "ctx-via-class")
 
         world.set_pending_commands("rover-mistral", [{"name": "test"}])
-        self.assertEqual(world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}])
+        self.assertEqual(
+            world.state["agents"]["rover-mistral"]["pending_commands"], [{"name": "test"}]
+        )
         world.set_pending_commands("rover-mistral", None)
         self.assertNotIn("pending_commands", world.state["agents"]["rover-mistral"])
 
@@ -1503,6 +1591,7 @@ class TestWorldClass(unittest.TestCase):
     def test_fresh_instance_independent(self):
         """A World() with no args gets its own state, independent of the singleton."""
         from app.world import World
+
         w2 = World()
         w2.set_agent_model("rover-mistral", "independent-model")
         self.assertNotEqual(


### PR DESCRIPTION
## Summary
- Adds proper `setUp`/`tearDown` pairs to 5 test classes in `test_world.py` that were mutating shared `WORLD` state without cleanup: `TestMoveAgent`, `TestExecuteAction`, `TestVisited`, `TestCharge`, `TestObserveRover`
- Each `setUp` saves original state fields, each `tearDown` restores them — preventing test ordering dependencies and state leakage
- Includes `ruff format` fixes for pre-existing formatting violations on main

Closes #174

## Semantic Diff

### File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| Core    | 4 (agent.py, main.py, station.py, world.py) | 50 | 45 |
| Tests   | 3 (test_world.py, test_narrator.py, test_station.py) | 160 | 43 |
| **Total** | **7** | **210** | **88** |

### Changes

| Status | File | +/- |
|--------|------|-----|
| Changed | `server/tests/test_world.py` | +127/-38 |
| Changed | `server/app/agent.py` | +30/-36 |
| Changed | `server/tests/test_station.py` | +28/-4 |
| Changed | `server/app/world.py` | +12/-2 |
| Changed | `server/app/main.py` | +6/-2 |
| Changed | `server/tests/test_narrator.py` | +5/-1 |
| Changed | `server/app/station.py` | +2/-5 |

## Changelog
- **fix(tests)**: Add `tearDown` cleanup to 5 test classes in `test_world.py` to prevent shared state leakage between tests
- **style**: Apply `ruff format` to fix pre-existing formatting violations

## Test Results
All 303 tests pass locally.

@schettino72 — requesting your review and approval 🙏

Co-Authored-By: agent-one team <agent-one@yanok.ai>