### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     permissions:
       contents: read
       pull-requests: read
@@ -39,6 +40,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.server == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: server
@@ -56,6 +58,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.server == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: server
@@ -76,6 +79,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ui == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ui
@@ -94,6 +98,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - run: docker build -t agent-one-ci .


### PR DESCRIPTION
## Summary
- Adds explicit `timeout-minutes` to all 5 CI jobs to prevent runaway workflows from consuming GitHub Actions minutes indefinitely
- Values: changes (2 min), server-lint (10), server-test (10), ui-lint-build (10), docker-build (15)

Closes #175

## Semantic Diff

### File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| CI/Config | 1 (ci.yml) | 5 | 0 |
| **Total** | **1** | **5** | **0** |

### Changes

| Status | File | +/- |
|--------|------|-----|
| Changed | `.github/workflows/ci.yml` | +5/-0 |

## Changelog
- **ci**: Add `timeout-minutes` to all CI jobs (2/10/10/10/15 minutes)

@schettino72 — requesting your review and approval 🙏

Co-Authored-By: agent-one team <agent-one@yanok.ai>