### PR TITLE
ci: pin SurrealDB to v2.2.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           python-version: "3.14"
       - name: Install SurrealDB
         run: |
-          curl -sSf https://install.surrealdb.com | sh
+          curl -sSf https://install.surrealdb.com | sh -s -- --version v2.2.1
           echo "$HOME/.surrealdb" >> $GITHUB_PATH
       - run: uv sync --frozen --all-groups
       - run: uv run rut tests/


### PR DESCRIPTION
## Summary
- Pins SurrealDB installation in CI to v2.2.1 to prevent surprise breakage from upstream releases
- Uses the `--version` flag supported by the install script for reproducible builds

Closes #178

## Semantic Diff

### File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| CI/Config | 1 (ci.yml) | 1 | 1 |
| **Total** | **1** | **1** | **1** |

### Changes

| Status | File | +/- |
|--------|------|-----|
| Changed | `.github/workflows/ci.yml` | +1/-1 |

## Changelog
- **ci**: Pin SurrealDB to v2.2.1 in server-test job

@schettino72 — requesting your review and approval 🙏

Co-Authored-By: agent-one team <agent-one@yanok.ai>