### PR TITLE
feat(voice): add /api/voice-command endpoint with Voxtral transcription

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+* **voice:** add `/api/voice-command` endpoint — accepts audio uploads, transcribes via Mistral Voxtral, parses structured commands (recall_rover, abort_mission, pause/resume, etc.) via LLM, routes through Host, and broadcasts events via WebSocket
+* **voice:** new `VoiceCommandProcessor` class with lazy Mistral client, Mars domain context bias terms, and JSON command extraction
+* **voice:** add `voice_transcription_model` and `voice_command_model` settings to `config.py`
+* **deps:** add `python-multipart>=0.0.9` for `UploadFile` support
+* **tests:** 32 comprehensive tests for voice module (transcription, command parsing, pipeline, endpoint)
+
 ### Fixed
 
 * **ci:** apply ruff format to 7 unformatted files (agent.py, main.py, station.py, world.py, test_narrator.py, test_station.py, test_world.py) to fix server-lint CI failure

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -42,5 +42,9 @@ class Settings(BaseSettings):
     narration_model: str = "mistral-medium-latest"
     narration_min_interval_seconds: float = 5.0
 
+    # Voice command (Voxtral transcription)
+    voice_transcription_model: str = "voxtral-mini-latest"
+    voice_command_model: str = "mistral-small-latest"
+
 
 settings = Settings()

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -2,7 +2,7 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from rich.logging import RichHandler
@@ -14,6 +14,7 @@ from .db import init_db, close_db
 from .host import Host
 from .narrator import Narrator
 from .views import router as views_router
+from .voice import VoiceCommandProcessor, SUPPORTED_AUDIO_TYPES
 from .world import reset_world, set_agent_model
 
 logging.basicConfig(
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 narrator = Narrator(broadcast_fn=broadcaster.send)
 host = Host(narrator=narrator)
+voice_processor = VoiceCommandProcessor()
 
 AGENT_MAP = {
     "rover-mistral": lambda: RoverMistralLoop(
@@ -130,6 +132,76 @@ async def abort_mission(reason: str = "Manual abort from mission control"):
 @app.post("/rover/{rover_id}/recall")
 async def recall_rover(rover_id: str):
     return await host.recall_rover(rover_id)
+
+
+# ── Voice command endpoint ──────────────────────────────────────────────────
+
+
+@app.post("/api/voice-command")
+async def voice_command(audio: UploadFile):
+    """Accept audio upload, transcribe via Voxtral, parse command, and route."""
+    from .protocol import make_message
+
+    # Validate content type
+    content_type = audio.content_type or ""
+    if content_type and content_type not in SUPPORTED_AUDIO_TYPES:
+        return {
+            "ok": False,
+            "error": f"Unsupported audio format: {content_type}. "
+            f"Supported: {', '.join(sorted(SUPPORTED_AUDIO_TYPES))}",
+        }
+
+    # Read audio bytes
+    audio_bytes = await audio.read()
+    if not audio_bytes:
+        return {"ok": False, "error": "Empty audio file"}
+
+    # Process: transcribe + parse command
+    try:
+        result = await voice_processor.process(
+            audio_bytes=audio_bytes,
+            filename=audio.filename or "audio.wav",
+        )
+    except RuntimeError as exc:
+        return {"ok": False, "error": str(exc)}
+    except Exception:
+        logger.exception("Voice command processing failed")
+        return {"ok": False, "error": "Voice command processing failed"}
+
+    # Broadcast the voice command event to all WebSocket clients
+    msg = make_message(
+        source="human",
+        type="command",
+        name="voice_command",
+        payload={
+            "transcript": result["transcript"],
+            "command": result["command"],
+            "params": result["params"],
+            "confidence": result["confidence"],
+        },
+    )
+    await broadcaster.send(msg.to_dict())
+
+    # Route recognized commands through the Host
+    command = result["command"]
+    params = result["params"]
+
+    if command == "recall_rover":
+        rover_id = params.get("rover_id", "rover-mistral")
+        action_result = await host.recall_rover(rover_id)
+        result["action_result"] = action_result
+    elif command == "abort_mission":
+        reason = params.get("reason", "Voice command abort")
+        action_result = await host.abort_mission(reason)
+        result["action_result"] = action_result
+    elif command == "pause_simulation":
+        host.paused = True
+        result["action_result"] = {"ok": True, "paused": True}
+    elif command == "resume_simulation":
+        host.paused = False
+        result["action_result"] = {"ok": True, "paused": False}
+
+    return {"ok": True, **result}
 
 
 # Serve Vue static files (must be after all API routes)

--- a/server/app/voice.py
+++ b/server/app/voice.py
@@ -1,0 +1,216 @@
+"""Voice command processor — Voxtral transcription + LLM command parsing.
+
+Accepts audio from the human operator, transcribes it via Mistral's Voxtral
+model, then uses an LLM call to extract a structured command intent for
+routing through the Host.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mistralai import Mistral
+from mistralai.models import File
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+# Audio formats accepted by the Voxtral transcription API
+SUPPORTED_AUDIO_TYPES = {
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/wav",
+    "audio/x-wav",
+    "audio/flac",
+    "audio/ogg",
+    "audio/webm",
+}
+
+# Mars domain terms to improve transcription accuracy
+CONTEXT_BIAS_TERMS = [
+    "rover",
+    "drone",
+    "station",
+    "drill",
+    "scan",
+    "navigate",
+    "abort",
+    "mars",
+    "sol",
+    "regolith",
+    "basalt",
+    "vein",
+    "recall",
+    "mission",
+    "battery",
+    "charge",
+    "explore",
+    "crater",
+    "sample",
+    "deploy",
+    "solar",
+    "panel",
+]
+
+# ── Command parsing prompt ──────────────────────────────────────────────────
+
+COMMAND_PARSE_SYSTEM_PROMPT = """\
+You are a Mars mission command parser. You receive transcribed voice commands \
+from a human mission operator and extract the structured intent.
+
+AVAILABLE COMMANDS:
+- recall_rover: Recall a rover back to station. Params: rover_id (string).
+- abort_mission: Abort the current mission. Params: reason (string).
+- pause_simulation: Pause the simulation. No params.
+- resume_simulation: Resume the simulation. No params.
+- reset_simulation: Reset the simulation. No params.
+- toggle_narration: Toggle narration on/off. No params.
+- general_message: A general message/instruction to the mission. Params: message (string).
+
+RULES:
+- Extract the most likely command from the transcript
+- If the operator mentions a specific rover (e.g., "rover one", "rover 2", \
+"the rover"), map it to the appropriate rover_id
+- Common rover IDs: "rover-mistral", "rover-2"
+- If no clear command is detected, use "general_message"
+- Always include the original transcript in your response
+- Respond with ONLY valid JSON, no markdown formatting
+
+OUTPUT FORMAT (JSON only):
+{"command": "<command_name>", "params": {<parameters>}, "confidence": <0.0-1.0>}
+
+Examples:
+Transcript: "Recall rover one immediately"
+{"command": "recall_rover", "params": {"rover_id": "rover-mistral"}, "confidence": 0.95}
+
+Transcript: "Abort the mission, we have a critical failure"
+{"command": "abort_mission", "params": {"reason": "Critical failure reported by operator"}, "confidence": 0.9}
+
+Transcript: "How are the rovers doing?"
+{"command": "general_message", "params": {"message": "How are the rovers doing?"}, "confidence": 0.6}
+"""
+
+
+# ── Voice command processor ─────────────────────────────────────────────────
+
+
+class VoiceCommandProcessor:
+    """Transcribes audio and parses voice commands for the Mars mission."""
+
+    def __init__(self):
+        self._client: Mistral | None = None
+
+    def _get_client(self) -> Mistral:
+        """Lazy-init Mistral client."""
+        if self._client is None:
+            if not settings.mistral_api_key:
+                raise RuntimeError("MISTRAL_API_KEY not set — cannot process voice commands")
+            self._client = Mistral(api_key=settings.mistral_api_key)
+        return self._client
+
+    async def transcribe(
+        self,
+        audio_bytes: bytes,
+        filename: str = "audio.wav",
+        language: str = "en",
+    ) -> dict[str, Any]:
+        """Transcribe audio bytes via Voxtral.
+
+        Returns a dict with 'text', 'language', and 'model' keys.
+        """
+        client = self._get_client()
+
+        response = await client.audio.transcriptions.complete_async(
+            model=settings.voice_transcription_model,
+            file=File(content=audio_bytes, file_name=filename),
+            language=language,
+            context_bias=CONTEXT_BIAS_TERMS,
+        )
+
+        return {
+            "text": response.text,
+            "language": response.language,
+            "model": response.model,
+        }
+
+    async def parse_command(self, transcript: str) -> dict[str, Any]:
+        """Use LLM to extract a structured command from the transcript.
+
+        Returns a dict with 'command', 'params', and 'confidence' keys.
+        """
+        client = self._get_client()
+
+        response = await client.chat.complete_async(
+            model=settings.voice_command_model,
+            messages=[
+                {"role": "system", "content": COMMAND_PARSE_SYSTEM_PROMPT},
+                {"role": "user", "content": f'Transcript: "{transcript}"'},
+            ],
+            max_tokens=200,
+            temperature=0.1,
+            response_format={"type": "json_object"},
+        )
+
+        import json
+
+        text = response.choices[0].message.content
+        if not text:
+            return {
+                "command": "general_message",
+                "params": {"message": transcript},
+                "confidence": 0.0,
+            }
+
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            logger.warning("Voice command LLM returned invalid JSON: %s", text)
+            return {
+                "command": "general_message",
+                "params": {"message": transcript},
+                "confidence": 0.0,
+            }
+
+        # Ensure required keys exist
+        return {
+            "command": parsed.get("command", "general_message"),
+            "params": parsed.get("params", {"message": transcript}),
+            "confidence": parsed.get("confidence", 0.5),
+        }
+
+    async def process(
+        self,
+        audio_bytes: bytes,
+        filename: str = "audio.wav",
+        language: str = "en",
+    ) -> dict[str, Any]:
+        """Full pipeline: transcribe audio → parse command → return result.
+
+        Returns a dict with 'transcript', 'command', 'params', 'confidence',
+        and 'transcription_model' keys.
+        """
+        # Step 1: Transcribe
+        transcription = await self.transcribe(audio_bytes, filename, language)
+        transcript_text = transcription["text"]
+
+        if not transcript_text or not transcript_text.strip():
+            return {
+                "transcript": "",
+                "command": "general_message",
+                "params": {"message": ""},
+                "confidence": 0.0,
+                "transcription_model": transcription.get("model", ""),
+            }
+
+        # Step 2: Parse command
+        parsed = await self.parse_command(transcript_text)
+
+        return {
+            "transcript": transcript_text,
+            "command": parsed["command"],
+            "params": parsed["params"],
+            "confidence": parsed["confidence"],
+            "transcription_model": transcription.get("model", ""),
+        }

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "surrealdb>=1.0.7",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
+    "python-multipart>=0.0.9",
     "rich>=13.0.0",
     "mistralai>=1.0.0",
     "elevenlabs>=1.0.0",

--- a/server/tests/test_voice.py
+++ b/server/tests/test_voice.py
@@ -1,0 +1,451 @@
+"""Tests for app.voice — Voxtral transcription + command parsing."""
+
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.voice import (
+    COMMAND_PARSE_SYSTEM_PROMPT,
+    CONTEXT_BIAS_TERMS,
+    SUPPORTED_AUDIO_TYPES,
+    VoiceCommandProcessor,
+)
+
+
+class TestSupportedAudioTypes(unittest.TestCase):
+    """Test audio format validation constants."""
+
+    def test_mp3_supported(self):
+        self.assertIn("audio/mpeg", SUPPORTED_AUDIO_TYPES)
+        self.assertIn("audio/mp3", SUPPORTED_AUDIO_TYPES)
+
+    def test_wav_supported(self):
+        self.assertIn("audio/wav", SUPPORTED_AUDIO_TYPES)
+        self.assertIn("audio/x-wav", SUPPORTED_AUDIO_TYPES)
+
+    def test_flac_supported(self):
+        self.assertIn("audio/flac", SUPPORTED_AUDIO_TYPES)
+
+    def test_ogg_supported(self):
+        self.assertIn("audio/ogg", SUPPORTED_AUDIO_TYPES)
+
+    def test_webm_supported(self):
+        self.assertIn("audio/webm", SUPPORTED_AUDIO_TYPES)
+
+
+class TestContextBiasTerms(unittest.TestCase):
+    """Test Mars domain terms for transcription context bias."""
+
+    def test_contains_core_terms(self):
+        for term in ["rover", "drone", "station", "mars", "basalt", "mission"]:
+            self.assertIn(term, CONTEXT_BIAS_TERMS, f"Missing term: {term}")
+
+    def test_contains_action_terms(self):
+        for term in ["drill", "scan", "navigate", "abort", "recall"]:
+            self.assertIn(term, CONTEXT_BIAS_TERMS, f"Missing term: {term}")
+
+
+class TestVoiceCommandProcessorInit(unittest.TestCase):
+    """Test VoiceCommandProcessor initialization."""
+
+    def test_client_starts_none(self):
+        processor = VoiceCommandProcessor()
+        self.assertIsNone(processor._client)
+
+    @patch("app.voice.settings")
+    def test_get_client_raises_without_api_key(self, mock_settings):
+        mock_settings.mistral_api_key = ""
+        processor = VoiceCommandProcessor()
+        with self.assertRaises(RuntimeError) as ctx:
+            processor._get_client()
+        self.assertIn("MISTRAL_API_KEY", str(ctx.exception))
+
+    @patch("app.voice.settings")
+    @patch("app.voice.Mistral")
+    def test_get_client_creates_client(self, mock_mistral_cls, mock_settings):
+        mock_settings.mistral_api_key = "test-key"
+        processor = VoiceCommandProcessor()
+        client = processor._get_client()
+        mock_mistral_cls.assert_called_once_with(api_key="test-key")
+        self.assertEqual(client, mock_mistral_cls.return_value)
+
+    @patch("app.voice.settings")
+    @patch("app.voice.Mistral")
+    def test_get_client_caches(self, mock_mistral_cls, mock_settings):
+        mock_settings.mistral_api_key = "test-key"
+        processor = VoiceCommandProcessor()
+        client1 = processor._get_client()
+        client2 = processor._get_client()
+        self.assertIs(client1, client2)
+        mock_mistral_cls.assert_called_once()
+
+
+class TestTranscribe(unittest.IsolatedAsyncioTestCase):
+    """Test audio transcription via Voxtral."""
+
+    @patch("app.voice.settings")
+    @patch("app.voice.Mistral")
+    async def test_transcribe_success(self, mock_mistral_cls, mock_settings):
+        mock_settings.mistral_api_key = "test-key"
+        mock_settings.voice_transcription_model = "voxtral-mini-latest"
+
+        # Mock transcription response
+        mock_response = MagicMock()
+        mock_response.text = "Recall rover one immediately"
+        mock_response.language = "en"
+        mock_response.model = "voxtral-mini-2602"
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.complete_async = AsyncMock(return_value=mock_response)
+        mock_mistral_cls.return_value = mock_client
+
+        processor = VoiceCommandProcessor()
+        result = await processor.transcribe(b"fake-audio-data", "test.wav")
+
+        self.assertEqual(result["text"], "Recall rover one immediately")
+        self.assertEqual(result["language"], "en")
+        self.assertEqual(result["model"], "voxtral-mini-2602")
+
+        # Verify correct API call
+        mock_client.audio.transcriptions.complete_async.assert_called_once()
+        call_kwargs = mock_client.audio.transcriptions.complete_async.call_args[1]
+        self.assertEqual(call_kwargs["model"], "voxtral-mini-latest")
+        self.assertEqual(call_kwargs["language"], "en")
+        self.assertEqual(call_kwargs["context_bias"], CONTEXT_BIAS_TERMS)
+
+    @patch("app.voice.settings")
+    @patch("app.voice.Mistral")
+    async def test_transcribe_custom_language(self, mock_mistral_cls, mock_settings):
+        mock_settings.mistral_api_key = "test-key"
+        mock_settings.voice_transcription_model = "voxtral-mini-latest"
+
+        mock_response = MagicMock()
+        mock_response.text = "Rappeler le rover"
+        mock_response.language = "fr"
+        mock_response.model = "voxtral-mini-2602"
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.complete_async = AsyncMock(return_value=mock_response)
+        mock_mistral_cls.return_value = mock_client
+
+        processor = VoiceCommandProcessor()
+        result = await processor.transcribe(b"fake-audio", "test.wav", language="fr")
+
+        self.assertEqual(result["language"], "fr")
+        call_kwargs = mock_client.audio.transcriptions.complete_async.call_args[1]
+        self.assertEqual(call_kwargs["language"], "fr")
+
+
+class TestParseCommand(unittest.IsolatedAsyncioTestCase):
+    """Test LLM-based command parsing from transcript."""
+
+    def _make_processor_with_mock(self, llm_response_text):
+        """Helper to create a processor with a mocked LLM client."""
+        mock_choice = MagicMock()
+        mock_choice.message.content = llm_response_text
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = MagicMock()
+        mock_client.chat.complete_async = AsyncMock(return_value=mock_response)
+
+        processor = VoiceCommandProcessor()
+        processor._client = mock_client
+        return processor, mock_client
+
+    async def test_parse_recall_command(self):
+        llm_output = json.dumps(
+            {
+                "command": "recall_rover",
+                "params": {"rover_id": "rover-mistral"},
+                "confidence": 0.95,
+            }
+        )
+        processor, _ = self._make_processor_with_mock(llm_output)
+        result = await processor.parse_command("Recall rover one immediately")
+
+        self.assertEqual(result["command"], "recall_rover")
+        self.assertEqual(result["params"]["rover_id"], "rover-mistral")
+        self.assertAlmostEqual(result["confidence"], 0.95)
+
+    async def test_parse_abort_command(self):
+        llm_output = json.dumps(
+            {
+                "command": "abort_mission",
+                "params": {"reason": "Critical failure"},
+                "confidence": 0.9,
+            }
+        )
+        processor, _ = self._make_processor_with_mock(llm_output)
+        result = await processor.parse_command("Abort the mission, critical failure")
+
+        self.assertEqual(result["command"], "abort_mission")
+        self.assertEqual(result["params"]["reason"], "Critical failure")
+
+    async def test_parse_general_message(self):
+        llm_output = json.dumps(
+            {
+                "command": "general_message",
+                "params": {"message": "How are things going?"},
+                "confidence": 0.6,
+            }
+        )
+        processor, _ = self._make_processor_with_mock(llm_output)
+        result = await processor.parse_command("How are things going?")
+
+        self.assertEqual(result["command"], "general_message")
+        self.assertEqual(result["confidence"], 0.6)
+
+    async def test_parse_empty_llm_response(self):
+        """Empty LLM response falls back to general_message."""
+        mock_choice = MagicMock()
+        mock_choice.message.content = ""
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = MagicMock()
+        mock_client.chat.complete_async = AsyncMock(return_value=mock_response)
+
+        processor = VoiceCommandProcessor()
+        processor._client = mock_client
+
+        result = await processor.parse_command("test transcript")
+        self.assertEqual(result["command"], "general_message")
+        self.assertEqual(result["confidence"], 0.0)
+
+    async def test_parse_invalid_json_falls_back(self):
+        """Invalid JSON from LLM falls back to general_message."""
+        processor, _ = self._make_processor_with_mock("not valid json at all")
+        result = await processor.parse_command("test transcript")
+
+        self.assertEqual(result["command"], "general_message")
+        self.assertEqual(result["confidence"], 0.0)
+
+    async def test_parse_missing_keys_uses_defaults(self):
+        """Missing keys in LLM JSON get defaults."""
+        llm_output = json.dumps({"command": "pause_simulation"})
+        processor, _ = self._make_processor_with_mock(llm_output)
+        result = await processor.parse_command("pause it")
+
+        self.assertEqual(result["command"], "pause_simulation")
+        self.assertIn("message", result["params"])
+        self.assertEqual(result["confidence"], 0.5)
+
+    @patch("app.voice.settings")
+    async def test_parse_uses_correct_model(self, mock_settings):
+        mock_settings.mistral_api_key = "test-key"
+        mock_settings.voice_command_model = "mistral-small-latest"
+
+        llm_output = json.dumps(
+            {
+                "command": "general_message",
+                "params": {"message": "hello"},
+                "confidence": 0.5,
+            }
+        )
+        processor, mock_client = self._make_processor_with_mock(llm_output)
+        await processor.parse_command("hello")
+
+        call_kwargs = mock_client.chat.complete_async.call_args[1]
+        self.assertEqual(call_kwargs["model"], "mistral-small-latest")
+        self.assertEqual(call_kwargs["temperature"], 0.1)
+        self.assertEqual(call_kwargs["response_format"], {"type": "json_object"})
+
+
+class TestProcess(unittest.IsolatedAsyncioTestCase):
+    """Test the full process pipeline (transcribe + parse)."""
+
+    async def test_process_full_pipeline(self):
+        """Test end-to-end: transcribe → parse → return."""
+        processor = VoiceCommandProcessor()
+
+        # Mock transcribe
+        processor.transcribe = AsyncMock(
+            return_value={
+                "text": "Recall rover one",
+                "language": "en",
+                "model": "voxtral-mini-2602",
+            }
+        )
+
+        # Mock parse_command
+        processor.parse_command = AsyncMock(
+            return_value={
+                "command": "recall_rover",
+                "params": {"rover_id": "rover-mistral"},
+                "confidence": 0.95,
+            }
+        )
+
+        result = await processor.process(b"audio-data", "test.mp3")
+
+        self.assertEqual(result["transcript"], "Recall rover one")
+        self.assertEqual(result["command"], "recall_rover")
+        self.assertEqual(result["params"]["rover_id"], "rover-mistral")
+        self.assertEqual(result["confidence"], 0.95)
+        self.assertEqual(result["transcription_model"], "voxtral-mini-2602")
+
+    async def test_process_empty_transcript(self):
+        """Empty transcript returns general_message with 0 confidence."""
+        processor = VoiceCommandProcessor()
+        processor.transcribe = AsyncMock(
+            return_value={
+                "text": "",
+                "language": "en",
+                "model": "voxtral-mini-2602",
+            }
+        )
+
+        result = await processor.process(b"audio-data")
+
+        self.assertEqual(result["transcript"], "")
+        self.assertEqual(result["command"], "general_message")
+        self.assertEqual(result["confidence"], 0.0)
+        # parse_command should NOT be called for empty transcript
+
+    async def test_process_whitespace_transcript(self):
+        """Whitespace-only transcript returns general_message."""
+        processor = VoiceCommandProcessor()
+        processor.transcribe = AsyncMock(
+            return_value={
+                "text": "   ",
+                "language": "en",
+                "model": "voxtral-mini-2602",
+            }
+        )
+
+        result = await processor.process(b"audio-data")
+        self.assertEqual(result["command"], "general_message")
+        self.assertEqual(result["confidence"], 0.0)
+
+
+class TestCommandParsePrompt(unittest.TestCase):
+    """Test the command parsing system prompt content."""
+
+    def test_prompt_contains_all_commands(self):
+        commands = [
+            "recall_rover",
+            "abort_mission",
+            "pause_simulation",
+            "resume_simulation",
+            "reset_simulation",
+            "toggle_narration",
+            "general_message",
+        ]
+        for cmd in commands:
+            self.assertIn(cmd, COMMAND_PARSE_SYSTEM_PROMPT, f"Missing command: {cmd}")
+
+    def test_prompt_contains_rover_ids(self):
+        self.assertIn("rover-mistral", COMMAND_PARSE_SYSTEM_PROMPT)
+        self.assertIn("rover-2", COMMAND_PARSE_SYSTEM_PROMPT)
+
+    def test_prompt_requests_json(self):
+        self.assertIn("JSON", COMMAND_PARSE_SYSTEM_PROMPT)
+
+
+class TestVoiceCommandEndpoint(unittest.TestCase):
+    """Test the /api/voice-command FastAPI endpoint."""
+
+    def setUp(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        self.client = TestClient(app)
+
+    def test_empty_audio_returns_error(self):
+        """Empty file upload returns error."""
+        from io import BytesIO
+
+        resp = self.client.post(
+            "/api/voice-command",
+            files={"audio": ("test.wav", BytesIO(b""), "audio/wav")},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("Empty", data["error"])
+
+    def test_unsupported_format_returns_error(self):
+        """Unsupported content type returns error."""
+        from io import BytesIO
+
+        resp = self.client.post(
+            "/api/voice-command",
+            files={"audio": ("test.txt", BytesIO(b"not audio"), "text/plain")},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("Unsupported", data["error"])
+
+    @patch("app.main.voice_processor")
+    def test_successful_voice_command(self, mock_processor):
+        """Successful voice command returns transcript and parsed command."""
+        from io import BytesIO
+
+        mock_processor.process = AsyncMock(
+            return_value={
+                "transcript": "Recall rover one",
+                "command": "recall_rover",
+                "params": {"rover_id": "rover-mistral"},
+                "confidence": 0.95,
+                "transcription_model": "voxtral-mini-2602",
+            }
+        )
+
+        resp = self.client.post(
+            "/api/voice-command",
+            files={"audio": ("test.wav", BytesIO(b"fake-audio"), "audio/wav")},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["transcript"], "Recall rover one")
+        self.assertEqual(data["command"], "recall_rover")
+
+    @patch("app.main.voice_processor")
+    def test_runtime_error_returns_error(self, mock_processor):
+        """RuntimeError (e.g., missing API key) returns error."""
+        from io import BytesIO
+
+        mock_processor.process = AsyncMock(side_effect=RuntimeError("MISTRAL_API_KEY not set"))
+
+        resp = self.client.post(
+            "/api/voice-command",
+            files={"audio": ("test.wav", BytesIO(b"fake-audio"), "audio/wav")},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("MISTRAL_API_KEY", data["error"])
+
+    @patch("app.main.voice_processor")
+    def test_unexpected_error_returns_generic_error(self, mock_processor):
+        """Unexpected exception returns generic error."""
+        from io import BytesIO
+
+        mock_processor.process = AsyncMock(side_effect=ValueError("unexpected"))
+
+        resp = self.client.post(
+            "/api/voice-command",
+            files={"audio": ("test.wav", BytesIO(b"fake-audio"), "audio/wav")},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("failed", data["error"])
+
+    def test_no_content_type_accepted(self):
+        """File upload without content type should be accepted (no validation)."""
+        from io import BytesIO
+
+        # When content_type is empty string, we skip validation
+        resp = self.client.post(
+            "/api/voice-command",
+            files={"audio": ("test.wav", BytesIO(b"fake-audio"), "")},
+        )
+        # Should proceed past content type check (may fail on processing without API key)
+        self.assertEqual(resp.status_code, 200)

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -418,6 +418,7 @@ dependencies = [
     { name = "mistralai" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "rich" },
     { name = "surrealdb" },
     { name = "uvicorn", extra = ["standard"] },
@@ -437,6 +438,7 @@ requires-dist = [
     { name = "mistralai", specifier = ">=1.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "surrealdb", specifier = ">=1.0.7" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
@@ -756,6 +758,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]

--- a/tasks/voice-command.md
+++ b/tasks/voice-command.md
@@ -1,0 +1,39 @@
+# Voice Command Endpoint — Implementation Plan
+
+## Overview
+Add a `/api/voice-command` POST endpoint that accepts audio from the human operator,
+transcribes it via Mistral's Voxtral model, parses the transcript into a structured
+command, routes it through the Host, and broadcasts the event to all WebSocket clients.
+
+## Tasks
+
+- [x] 1. Create feature branch `feat/voice-command`
+- [x] 2. Add `python-multipart` dependency to `pyproject.toml`
+- [x] 3. Add voice config settings to `config.py` (model name, context bias terms)
+- [x] 4. Create `server/app/voice.py` — Voxtral transcription + command parsing
+  - [x] 4a. `VoiceCommandProcessor` class with lazy Mistral client init
+  - [x] 4b. `transcribe()` — call `client.audio.transcriptions.complete_async()`
+  - [x] 4c. `parse_command()` — LLM-based intent extraction from transcript
+  - [x] 4d. `process()` — orchestrate transcribe → parse → return result
+- [x] 5. Add `/api/voice-command` POST endpoint to `main.py`
+  - [x] 5a. Accept `UploadFile` audio
+  - [x] 5b. Call `VoiceCommandProcessor.process()`
+  - [x] 5c. Route parsed command through Host
+  - [x] 5d. Broadcast voice_command event via WebSocket
+- [x] 6. Create `server/tests/test_voice.py` with full test coverage
+  - [x] 6a. Test `transcribe()` with mocked Mistral client
+  - [x] 6b. Test `parse_command()` with mocked LLM
+  - [x] 6c. Test `process()` end-to-end with mocks
+  - [x] 6d. Test error handling (no API key, transcription failure, parse failure)
+  - [x] 6e. Test endpoint via FastAPI TestClient
+- [x] 7. Update `Changelog.md`
+- [x] 8. Run tests, verify, and submit PR
+
+## Architecture Decisions
+
+1. **Batch transcription** (not realtime) — suitable for push-to-talk UX
+2. **Model**: `voxtral-mini-latest` for transcription endpoint
+3. **Command parsing**: Use Mistral LLM to extract structured intent from transcript
+4. **No new API key**: Reuses `MISTRAL_API_KEY`
+5. **`context_bias`**: Mars domain terms improve transcription accuracy
+6. **Supported audio formats**: MP3, WAV, FLAC, OGG, WEBM


### PR DESCRIPTION
## Summary

Add a voice command processing pipeline that accepts audio uploads via `POST /api/voice-command`, transcribes them using Mistral's Voxtral model, extracts structured mission commands via LLM, and routes them through the Host for execution.

## Change Type

- [x] `feat` — New feature
- [x] `test` — Adding or updating tests

## Semantic Diff

### Added
- `server/app/voice.py` — `VoiceCommandProcessor` class: Voxtral transcription + LLM command parsing with Mars domain context bias (+216 lines)
- `server/tests/test_voice.py` — 32 comprehensive tests: transcription, command parsing, pipeline, endpoint integration (+451 lines)
- `tasks/voice-command.md` — Implementation plan document (+39 lines)

### Changed
- `server/app/main.py` — Added `POST /api/voice-command` endpoint, `voice_processor` singleton, content-type validation, Host command routing, WebSocket broadcast (+73/-1 lines)
- `server/app/config.py` — Added `voice_transcription_model` and `voice_command_model` settings (+4 lines)
- `server/pyproject.toml` — Added `python-multipart>=0.0.9` dependency for `UploadFile` support (+1 line)
- `server/uv.lock` — Lock file updated with new dependency (+11 lines)
- `Changelog.md` — Added voice command feature entry under [Unreleased] (+8 lines)

### Removed
- (none)

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 3 |
| Files modified | 5 |
| Files deleted | 0 |
| Lines added | +803 |
| Lines removed | -1 |

### Core Files Modified
- `server/app/voice.py` — New voice command processor (transcription + parsing)
- `server/app/main.py` — New `/api/voice-command` endpoint + routing
- `server/app/config.py` — Voice model settings
- `server/pyproject.toml` — python-multipart dependency

### Tests
- `server/tests/test_voice.py` — 32 tests across 7 test classes: `TestSupportedAudioTypes` (5), `TestContextBiasTerms` (2), `TestVoiceCommandProcessorInit` (3), `TestTranscribe` (2), `TestParseCommand` (7), `TestProcess` (3), `TestCommandParsePrompt` (3), `TestVoiceCommandEndpoint` (6)

## How to Test

1. Run `cd server && uv sync` to install `python-multipart`
2. Run `uv run rut tests/test_voice.py` — all 32 tests should pass
3. Run `uv run rut tests/` — full suite (335 tests) should pass
4. Start server with `MISTRAL_API_KEY` set, then:
   ```bash
   curl -X POST http://localhost:4009/api/voice-command \
     -F "audio=@recording.wav;type=audio/wav"
   ```

## Changelog

- **voice:** add `/api/voice-command` endpoint — accepts audio uploads, transcribes via Mistral Voxtral, parses structured commands (recall_rover, abort_mission, pause/resume, etc.) via LLM, routes through Host, and broadcasts events via WebSocket
- **voice:** new `VoiceCommandProcessor` class with lazy Mistral client, Mars domain context bias terms, and JSON command extraction
- **voice:** add `voice_transcription_model` and `voice_command_model` settings to `config.py`
- **deps:** add `python-multipart>=0.0.9` for `UploadFile` support
- **tests:** 32 comprehensive tests for voice module (transcription, command parsing, pipeline, endpoint)

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>