### PR TITLE
fix(docker): add PYTHONUNBUFFERED and PYTHONDONTWRITEBYTECODE env vars (#180)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm run build
 # Stage 2: Python backend + built UI
 FROM python:3.14-slim
 WORKDIR /app
+ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/


### PR DESCRIPTION
## Summary
- Add `ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1` to the Python stage of the Dockerfile
- `PYTHONUNBUFFERED=1` ensures Python output is immediately flushed to Docker logs (critical for debugging in production)
- `PYTHONDONTWRITEBYTECODE=1` prevents `.pyc` file creation in the container, reducing layer noise

Closes #180

## Semantic Diff

### Changed
| File | +/− | What changed |
|------|-----|-------------|
| `Dockerfile` | +1/−0 | Added `ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1` after `WORKDIR /app` |

### File Impact
| Category | Files | Lines Added | Lines Removed |
|----------|-------|-------------|---------------|
| Core | 1 | 1 | 0 |
| **Total** | **1** | **1** | **0** |

## Verification
- Standard Docker best practice — no runtime behavior change, only log flushing and bytecode suppression

Co-Authored-By: agent-one team <agent-one@yanok.ai>