### PR TITLE
feat: Agent Reasoning Transparency Panel (Feature C)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Added
+- **Agent Reasoning Transparency Panel (Feature C)**: Structured reasoning output from LLM agents with visual card display
+  - Compressed `STRUCTURED_REASONING_PROMPT` appended to rover and drone `_build_context()` — agents output SITUATION/OPTIONS/DECISION/RISK fields
+  - `_parse_structured_thinking()` parser extracts structured fields with graceful fallback defaults
+  - Risk-level logging: unrecognized risk values logged at DEBUG before defaulting to "low"
+  - `ReasoningCard.vue` component: risk-based color coding (green/amber/red), word-boundary option matching, fade-in animation
+  - `AgentPane.vue` integration: structured reasoning card shown when available, raw text tooltip fallback otherwise
+  - 6 unit tests for parser (full parse, defaults, partial, risk normalization, empty input, invalid risk warning)
 - **Agent Memory & Learning (Feature F)**: Persistent strategic memory system where agents periodically summarize exploration memories into strategic insights via LLM
   - `summarize_memories()` generates summary prompts from agent memories (triggers when >= 6 memories)
   - `record_strategic_insight()` stores insights with sliding window (capped at 5)

--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import random
+import re
 
 from mistralai import Mistral, SDKError
 
@@ -30,11 +31,7 @@ from .station import StationAgent
 logger = logging.getLogger(__name__)
 
 STRUCTURED_REASONING_PROMPT = (
-    "\n\nRESPONSE FORMAT — before choosing an action, output a reasoning block:\n"
-    "SITUATION: <one-line summary of current state>\n"
-    "OPTIONS: <comma-separated list of 2-4 candidate actions>\n"
-    "DECISION: <chosen action and why>\n"
-    "RISK: low | medium | high\n"
+    "\n\nBefore acting, output: SITUATION: <state> | OPTIONS: <a, b> | DECISION: <choice + why> | RISK: low/medium/high"
 )
 
 
@@ -51,6 +48,7 @@ def _parse_structured_thinking(raw_thinking: str) -> dict:
     if m:
         result["options"] = [o.strip() for o in m.group(1).split(",") if o.strip()]
     if result["risk"] not in ("low", "medium", "high"):
+        logger.debug("Unrecognized risk level %r, defaulting to 'low'", result["risk"])
         result["risk"] = "low"
     return result
 

--- a/server/tests/test_agent.py
+++ b/server/tests/test_agent.py
@@ -2,7 +2,7 @@ import unittest
 
 from app.world import world, execute_action
 from app.agent import MistralRoverReasoner, ROVER_TOOLS, DRONE_TOOLS
-from app.agent import parse_task_separator
+from app.agent import parse_task_separator, _parse_structured_thinking
 
 
 class TestRoverFallback(unittest.TestCase):
@@ -215,3 +215,44 @@ class TestRoverContextNoBoundaryClipping(unittest.TestCase):
         context = agent._build_context()
         self.assertIn("chunk-based", context)
         self.assertNotIn("Grid: 20x20", context)
+
+
+class TestParseStructuredThinking(unittest.TestCase):
+    """Tests for _parse_structured_thinking helper."""
+
+    def test_parses_all_fields(self):
+        text = "SITUATION: Low battery near vein\nOPTIONS: dig, return\nDECISION: return to station\nRISK: high"
+        result = _parse_structured_thinking(text)
+        self.assertEqual(result["situation"], "Low battery near vein")
+        self.assertEqual(result["options"], ["dig", "return"])
+        self.assertEqual(result["decision"], "return to station")
+        self.assertEqual(result["risk"], "high")
+
+    def test_returns_default_for_plain_text(self):
+        result = _parse_structured_thinking("Just thinking about stuff")
+        self.assertEqual(result["situation"], "")
+        self.assertEqual(result["options"], [])
+        self.assertEqual(result["risk"], "low")
+
+    def test_partial_tags_still_parsed(self):
+        text = "SITUATION: Exploring north\nDECISION: move north"
+        result = _parse_structured_thinking(text)
+        self.assertEqual(result["situation"], "Exploring north")
+        self.assertEqual(result["decision"], "move north")
+
+    def test_risk_normalized_to_lowercase(self):
+        text = "SITUATION: Storm approaching\nRISK: high"
+        result = _parse_structured_thinking(text)
+        self.assertEqual(result["risk"], "high")
+
+    def test_empty_string_returns_default(self):
+        result = _parse_structured_thinking("")
+        self.assertEqual(result["situation"], "")
+        self.assertEqual(result["risk"], "low")
+
+    def test_invalid_risk_defaults_with_warning(self):
+        text = "SITUATION: Unknown state\nRISK: extreme"
+        with self.assertLogs("app.agent", level="DEBUG") as cm:
+            result = _parse_structured_thinking(text)
+        self.assertEqual(result["risk"], "low")
+        self.assertTrue(any("Unrecognized risk level" in msg for msg in cm.output))

--- a/ui/src/components/AgentPane.vue
+++ b/ui/src/components/AgentPane.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import BatteryBar from './BatteryBar.vue'
+import ReasoningCard from './ReasoningCard.vue'
 
 const props = defineProps({
   agentId: {
@@ -56,7 +57,7 @@ const mergedEvents = computed(() => {
     if (e.name === 'thinking') {
       const next = raw[i + 1]
       if (next && next.name !== 'thinking') {
-        result.push({ ...next, reason: e.payload?.text || '' })
+        result.push({ ...next, reason: e.payload?.text || '', structured: e.payload?.structured || null })
         i++
       }
       // Drop orphan thinking events (no following action)
@@ -149,8 +150,12 @@ function eventText(e) {
             v-if="e.reason"
             class="ae-reason"
           >{{ e.reason }}</span>
+          <ReasoningCard
+            v-if="e.structured?.situation"
+            :structured="e.structured"
+          />
           <div
-            v-if="e.reason"
+            v-if="e.reason && !e.structured?.situation"
             class="ae-tooltip"
           >
             {{ e.reason }}
@@ -240,6 +245,7 @@ function eventText(e) {
   font-size: 0.75rem;
   border-bottom: 1px solid var(--border-dim);
   display: flex;
+  flex-wrap: wrap;
   gap: 0.4rem;
   align-items: baseline;
   position: relative;

--- a/ui/src/components/ReasoningCard.vue
+++ b/ui/src/components/ReasoningCard.vue
@@ -1,0 +1,132 @@
+<script setup>
+const props = defineProps({
+  structured: { type: Object, default: () => ({}) },
+})
+
+function isChosenOption(opt) {
+  const decision = (props.structured.decision || '').toLowerCase()
+  const optLower = opt.toLowerCase()
+  // Use word-boundary check to avoid substring false positives (e.g. "move" matching "move east")
+  const escaped = optLower.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`\\b${escaped}\\b`).test(decision)
+}
+</script>
+
+<template>
+  <div
+    class="reasoning-card"
+    :class="'risk-' + (structured.risk || 'low')"
+  >
+    <div
+      v-if="structured.situation"
+      class="rc-row"
+    >
+      <span class="rc-label">SIT</span>
+      <span class="rc-value">{{ structured.situation }}</span>
+    </div>
+    <div
+      v-if="structured.options?.length"
+      class="rc-row rc-options"
+    >
+      <span class="rc-label">OPT</span>
+      <span class="rc-value">
+        <span
+          v-for="(o, j) in structured.options"
+          :key="j"
+          class="rc-opt"
+          :class="{ chosen: isChosenOption(o) }"
+        >{{ o }}</span>
+      </span>
+    </div>
+    <div
+      v-if="structured.decision"
+      class="rc-row"
+    >
+      <span class="rc-label">DEC</span>
+      <span class="rc-value rc-decision">{{ structured.decision }}</span>
+    </div>
+    <div
+      v-if="structured.risk"
+      class="rc-row"
+    >
+      <span class="rc-label">RISK</span>
+      <span
+        class="rc-value rc-risk"
+        :class="'risk-text-' + structured.risk"
+      >{{ structured.risk }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.reasoning-card {
+  font-size: 0.65rem;
+  border-left: 3px solid var(--accent-action, #4ade80);
+  border-radius: 4px;
+  padding: 0.2rem 0.35rem;
+  margin: 0.15rem 0;
+  background: rgba(74, 222, 128, 0.06);
+  animation: rc-fade-in 0.3s ease;
+}
+
+.reasoning-card.risk-medium {
+  border-left-color: #f59e0b;
+  background: rgba(245, 158, 11, 0.06);
+}
+
+.reasoning-card.risk-high {
+  border-left-color: #ef4444;
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.rc-row {
+  display: flex;
+  gap: 0.3rem;
+  padding: 0.1rem 0;
+}
+
+.rc-label {
+  font-weight: 700;
+  color: var(--text-muted, #888);
+  flex-shrink: 0;
+  min-width: 2.2rem;
+}
+
+.rc-value {
+  color: var(--text-secondary, #ccc);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rc-decision {
+  font-weight: 600;
+  color: var(--text-primary, #eee);
+}
+
+.rc-options {
+  flex-wrap: wrap;
+}
+
+.rc-opt {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  padding: 0 0.25rem;
+  margin-right: 0.2rem;
+}
+
+.rc-opt.chosen {
+  background: rgba(74, 222, 128, 0.18);
+  color: #4ade80;
+  font-weight: 600;
+}
+
+.risk-text-low { color: #4ade80; }
+.risk-text-medium { color: #f59e0b; }
+.risk-text-high { color: #ef4444; }
+
+@keyframes rc-fade-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+</style>


### PR DESCRIPTION
## Summary

Add structured reasoning output (SITUATION/OPTIONS/DECISION/RISK) to rover and drone agents with visual ReasoningCard in the UI. Supersedes PR #151 with rebase on current main and reviewer feedback addressed.

## Change Type

- [x] `feat` — New feature
- [x] `test` — Adding or updating tests

## Semantic Diff

### Added
- `ui/src/components/ReasoningCard.vue` — New component: structured reasoning card with risk-based color coding (green/amber/red), word-boundary option matching, fade-in animation
- `server/tests/test_agent.py` — 6 new unit tests for `_parse_structured_thinking()` (full parse, defaults, partial, risk normalization, empty input, invalid risk warning)

### Changed
- `server/app/agent.py` — Added `import re`, compressed `STRUCTURED_REASONING_PROMPT` (1 line vs 5), `_parse_structured_thinking()` parser with debug logging for unrecognized risk, prompt appended to both rover and drone `_build_context()`, structured field in thinking payloads
- `ui/src/components/AgentPane.vue` — Import ReasoningCard, pass `structured` field in mergedEvents, conditional rendering (ReasoningCard when structured data available, raw text tooltip fallback), flex-wrap on agent-event
- `Changelog.md` — Feature C entry

### Removed
- None

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 1 |
| Files modified | 4 |
| Files deleted | 0 |
| Lines added | +192 |
| Lines removed | -8 |

### Core Files Modified
- `server/app/agent.py` (+3/-5) — STRUCTURED_REASONING_PROMPT, _parse_structured_thinking(), prompt injection
- `ui/src/components/AgentPane.vue` (+8/-2) — ReasoningCard integration
- `ui/src/components/ReasoningCard.vue` (+132/-0) — New component

### Tests
- `server/tests/test_agent.py` (+42/-1) — 6 new TestParseStructuredThinking tests

## How to Test

1. Run server tests: `cd server && uv run rut tests/test_agent.py -v` — expect 27 tests passing
2. Run full suite: `cd server && uv run rut tests/` — expect 401 tests passing
3. Build UI: `cd ui && npx vite build` — clean build
4. Start simulation and observe agent thinking events — should show structured SITUATION/OPTIONS/DECISION/RISK cards with color coding
5. Verify graceful degradation: when LLM output lacks structured tags, raw text tooltip is shown instead

## Reviewer Feedback Addressed (from PR #151)

- **Prompt bloat**: Compressed from 5 lines to 1 line
- **isChosenOption() false positives**: Replaced bidirectional `includes()` with word-boundary regex matching
- **Silent risk default**: Added `logger.debug()` warning for unrecognized risk values

## Changelog

- **Agent Reasoning Transparency Panel (Feature C)**: Structured reasoning output from LLM agents with visual card display
  - Compressed STRUCTURED_REASONING_PROMPT appended to rover and drone _build_context()
  - _parse_structured_thinking() parser with graceful fallback defaults
  - Risk-level logging for unrecognized values
  - ReasoningCard.vue with risk-based color coding and word-boundary option matching
  - AgentPane.vue integration with fallback to raw text tooltip
  - 6 unit tests for parser

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>