### PR TITLE
fix: replace f-string logging and print() with lazy logger (#134, #135)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 ### Added
 - **Agent Reasoning Transparency Panel (Feature C)**: Structured reasoning output from LLM agents with visual card display
+
+### Fixed
+- **Logging hygiene (#134, #135)**: Replace f-string formatting in `broadcast.py` logger calls with lazy `%s` formatting; replace bare `print()` in `db.py` with proper `logger.info()`/`logger.warning()` using lazy formatting
   - Compressed `STRUCTURED_REASONING_PROMPT` appended to rover and drone `_build_context()` — agents output SITUATION/OPTIONS/DECISION/RISK fields
   - `_parse_structured_thinking()` parser extracts structured fields with graceful fallback defaults
   - Risk-level logging: unrecognized risk values logged at DEBUG before defaulting to "low"

--- a/server/app/broadcast.py
+++ b/server/app/broadcast.py
@@ -19,11 +19,11 @@ class Broadcaster:
     async def connect(self, ws: WebSocket):
         await ws.accept()
         self._connections.append(ws)
-        logger.info(f"Client connected ({len(self._connections)} total)")
+        logger.info("Client connected (%d total)", len(self._connections))
 
     def disconnect(self, ws: WebSocket):
         self._connections.remove(ws)
-        logger.info(f"Client disconnected ({len(self._connections)} total)")
+        logger.info("Client disconnected (%d total)", len(self._connections))
 
     async def send(self, event: dict):
         """Broadcast an event dict to all connected clients."""

--- a/server/app/db.py
+++ b/server/app/db.py
@@ -9,11 +9,14 @@ RecordID notes:
 
 from __future__ import annotations
 
+import logging
 from typing import Generator
 
 from surrealdb import Surreal
 
 from .config import settings
+
+logger = logging.getLogger(__name__)
 
 
 def _create_connection() -> Surreal:
@@ -28,22 +31,22 @@ def init_db():
     """Verify DB connection on startup, with retries for Railway cold starts."""
     import time as _time
 
-    print(f"Connecting to SurrealDB: {settings.surreal_url}")
-    print(f"Namespace: {settings.surreal_ns}, Database: {settings.surreal_db}")
+    logger.info("Connecting to SurrealDB: %s", settings.surreal_url)
+    logger.info("Namespace: %s, Database: %s", settings.surreal_ns, settings.surreal_db)
 
     max_attempts = 10
     for attempt in range(1, max_attempts + 1):
         try:
             client = _create_connection()
             client.close()
-            print("SurrealDB connection verified")
+            logger.info("SurrealDB connection verified")
             return
         except Exception as exc:
             if attempt == max_attempts:
                 raise RuntimeError(
                     f"Failed to connect to SurrealDB after {max_attempts} attempts"
                 ) from exc
-            print(f"SurrealDB not ready (attempt {attempt}/{max_attempts}): {exc}")
+            logger.warning("SurrealDB not ready (attempt %d/%d): %s", attempt, max_attempts, exc)
             _time.sleep(2)
 
 


### PR DESCRIPTION
## Summary

Replace f-string formatting in logger calls with lazy `%s` formatting and bare `print()` with proper structured logging. Cherry-picked core fixes from PR #149 per reviewer advice (dropped ruff formatting hunks already merged via #185).

## Change Type

- [x] `fix` — Bug fix

## Semantic Diff

### Added
- None

### Changed
- `server/app/broadcast.py` (+2/−2) — f-string → lazy `%s` formatting in `logger.info()` calls
- `server/app/db.py` (+7/−4) — `print()` → `logger.info()`/`logger.warning()` with lazy formatting; added `import logging` and `logger`
- `Changelog.md` (+3/−0) — Logging hygiene entry

### Removed
- None

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 3 |
| Files deleted | 0 |
| Lines added | +12 |
| Lines removed | -6 |

### Core Files Modified
- `server/app/broadcast.py` (+2/−2) — Lazy logger formatting
- `server/app/db.py` (+7/−4) — print() → structured logger

### Tests
- No test changes needed (logging is behavior-transparent)
- Full suite: 401 tests passing

## How to Test

1. Run `cd server && uv run rut tests/` — 401 tests pass
2. Start server with `DEBUG` log level — verify SurrealDB connection messages appear via logger instead of stdout
3. Connect WebSocket client — verify connect/disconnect messages use lazy formatting

## Changelog

- **Logging hygiene (#134, #135)**: Replace f-string formatting in `broadcast.py` logger calls with lazy `%s` formatting; replace bare `print()` in `db.py` with proper `logger.info()`/`logger.warning()` using lazy formatting

Closes #134
Closes #135

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>