### PR TITLE
fix(ui): preserve event log and simulation state on WebSocket reconnect (#72)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - **Agent Reasoning Transparency Panel (Feature C)**: Structured reasoning output from LLM agents with visual card display
 
 ### Fixed
+- **WebSocket reconnect (#72)**: Event log and simulation state are no longer reset on reconnect — only on initial page load. Simulation reset and event clearing now guarded by `isFirstConnect` flag in both `useWebSocket.js` and `App.vue`
 - **Logging hygiene (#134, #135)**: Replace f-string formatting in `broadcast.py` logger calls with lazy `%s` formatting; replace bare `print()` in `db.py` with proper `logger.info()`/`logger.warning()` using lazy formatting
   - Compressed `STRUCTURED_REASONING_PROMPT` appended to rover and drone `_build_context()` — agents output SITUATION/OPTIONS/DECISION/RISK fields
   - `_parse_structured_thinking()` parser extracts structured fields with graceful fallback defaults

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -37,9 +37,11 @@ const mobileAgents = computed(() => {
 })
 
 
-async function onWsConnect() {
+async function onWsConnect(isFirst) {
   paused.value = false
-  fetch('/api/simulation/reset', { method: 'POST' })
+  if (isFirst) {
+    fetch('/api/simulation/reset', { method: 'POST' })
+  }
   try {
     const res = await fetch('/api/narration/status')
     if (res.ok) {

--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -8,6 +8,7 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
   const narrationChunk = ref(null)
   let ws = null
   let eventUid = 0
+  let isFirstConnect = true
 
   const agentEvents = computed(() => {
     const byAgent = {}
@@ -34,9 +35,13 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
 
     ws.onopen = () => {
       connected.value = true
-      events.value = []
+      if (isFirstConnect) {
+        events.value = []
+      }
+      const first = isFirstConnect
+      isFirstConnect = false
       worldState.value = null
-      if (onConnect) onConnect()
+      if (onConnect) onConnect(first)
     }
 
     ws.onmessage = (msg) => {


### PR DESCRIPTION
## Summary

Guard both event clearing and simulation reset behind an isFirstConnect flag so WebSocket reconnects no longer destroy simulation progress.

Supersedes #87 — this PR applies the same isFirstConnect fix plus additionally guards the /api/simulation/reset call in App.vue onWsConnect(), which was the root cause of issue #72.

## Change Type

- [x] fix — Bug fix

## Semantic Diff

### Changed
- ui/src/composables/useWebSocket.js — add isFirstConnect flag; only clear events on first connect; pass first arg to onConnect callback (+8/-1)
- ui/src/App.vue — guard /api/simulation/reset call with isFirst parameter (+4/-2)
- Changelog.md — add fix entry (+1)

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 3 |
| Files deleted | 0 |
| Lines added | +12 |
| Lines removed | -4 |

## Changelog

- WebSocket reconnect (#72): Event log and simulation state no longer reset on reconnect — only on initial page load

Closes #72
Supersedes #87

Co-Authored-By: agent-one team <agent-one@yanok.ai>