### PR TITLE
fix: fix remaining charge_rover references to charge_agent (#68)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -76,6 +76,7 @@
 - **Agent Reasoning Transparency Panel (Feature C)**: Structured reasoning output from LLM agents with visual card display
 
 ### Fixed
+- **Charge event naming (#68)**: Fix remaining `charge_rover` reference in StationLoop.INTERESTING_EVENTS to `charge_agent`; fix narrator comment
 - **Broadcaster safety guards (#100)**: Guard `disconnect()` against double-disconnect `ValueError`, iterate copy in `send()` to prevent mutation-during-iteration, guard dead connection cleanup with membership check. 6 new unit tests.
 - **Infinite loop guard in `_random_free_pos` (#118)**: Replace unbounded `while True` with bounded random attempts (`CHUNK_SIZE²×2`), deterministic linear scan fallback, and last-resort origin return with warning log. Added 6 unit tests.
 - **Logging hygiene (#134, #135)**: Replace f-string formatting in `broadcast.py` logger calls with lazy `%s` formatting; replace bare `print()` in `db.py` with proper `logger.info()`/`logger.warning()` using lazy formatting

--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -1277,7 +1277,7 @@ class StationLoop(BaseAgent):
             "mission_success",
             "mission_failed",
             "mission_aborted",
-            "charge_rover",
+            "charge_agent",
             "deploy_solar_panel",
             "use_solar_battery",
         }

--- a/server/app/narrator.py
+++ b/server/app/narrator.py
@@ -34,7 +34,7 @@ INTERESTING_EVENTS = {
     # Station events
     "assign_mission": 3,  # mission assigned to rover
     "alert": 3,  # station broadcast alert
-    "charge_agent": 2,  # rover being charged
+    "charge_agent": 2,  # agent being charged
     # Agent internal
     "thinking": 1,  # agent reasoning (narrate sparingly)
     # Mission-level

--- a/server/tests/test_host.py
+++ b/server/tests/test_host.py
@@ -297,3 +297,5 @@ class TestHostStationLoop(unittest.TestCase):
         self.assertIn("dig", StationLoop.INTERESTING_EVENTS)
         self.assertIn("scan", StationLoop.INTERESTING_EVENTS)
         self.assertNotIn("move", StationLoop.INTERESTING_EVENTS)
+        self.assertIn("charge_agent", StationLoop.INTERESTING_EVENTS)
+        self.assertNotIn("charge_rover", StationLoop.INTERESTING_EVENTS)


### PR DESCRIPTION
## Summary

Fix the last remaining `charge_rover` references missed by prior merges. The core rename (broadcast events, narrator matching) was already merged via earlier PRs, but `StationLoop.INTERESTING_EVENTS` and a narrator comment still referenced the old name. Supersedes PR #79.

## Change Type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Semantic Diff

### Changed
- `server/app/agent.py` (+1/−1) — `StationLoop.INTERESTING_EVENTS`: `charge_rover` → `charge_agent`
- `server/app/narrator.py` (+1/−1) — Comment fix: "rover being charged" → "agent being charged"
- `server/tests/test_host.py` (+2/−0) — Regression test: assert `charge_agent` in and `charge_rover` not in `INTERESTING_EVENTS`
- `Changelog.md` (+1/−0) — Entry

### Removed
- None

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 4 |
| Files deleted | 0 |
| Lines added | +5 |
| Lines removed | -2 |

### Core Files Modified
- `server/app/agent.py` (+1/−1) — StationLoop event filter
- `server/app/narrator.py` (+1/−1) — Comment

### Tests
- `server/tests/test_host.py` (+2) — Regression test for charge event naming

## How to Test

1. `cd server && uv run rut tests/` — 413 tests pass
2. `grep -rn charge_rover server/app/` — only backward-compat alias in world.py remains

## Changelog

- **Charge event naming (#68)**: Fix remaining `charge_rover` in StationLoop.INTERESTING_EVENTS → `charge_agent`; fix narrator comment

Closes #68

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>