### PR TITLE
fix(ui): preserve event log and simulation state on WebSocket reconnect (#72)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -74,7 +74,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **WebSocket reconnect (#72)**: Event log and simulation state are no longer reset on reconnect — only on initial page load. Simulation reset and event clearing now guarded by `isFirstConnect` flag in both `useWebSocket.js` and `App.vue`
+- **WebSocket reconnect (#72)**: Event log and simulation state are no longer reset on reconnect — only on initial page load. Simulation reset and event clearing now guarded by `isFirstConnect` flag in `useWebSocket.js` and `SimulationPage.vue`
 
 ### Added
 - **Agent Reasoning Transparency Panel (Feature C)**: Structured reasoning output from LLM agents with visual card display

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6,10 +6,15 @@
   "packages": {
     "": {
       "name": "mars-ui",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "vue": "^3.5.18"
+        "@fontsource/space-grotesk": "^5.2.8",
+        "gsap": "^3.13.0",
+        "three": "^0.176.0",
+        "vue": "^3.5.18",
+        "vue-i18n": "^11.1.0",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
@@ -768,6 +773,15 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmmirror.com/@fontsource/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -837,6 +851,50 @@
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
         "mlly": "^1.8.0"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmmirror.com/@intlify/core-base/-/core-base-11.2.8.tgz",
+      "integrity": "sha512-nBq6Y1tVkjIUsLsdOjDSJj4AsjvD0UG3zsg9Fyc+OivwlA/oMHSKooUy9tpKj0HqZ+NWFifweHavdljlBLTwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "11.2.8",
+        "@intlify/shared": "11.2.8"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmmirror.com/@intlify/message-compiler/-/message-compiler-11.2.8.tgz",
+      "integrity": "sha512-A5n33doOjmHsBtCN421386cG1tWp5rpOjOYPNsnpjIJbQ4POF0QY2ezhZR9kr0boKwaHjbOifvyQvHj2UTrDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.2.8",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmmirror.com/@intlify/shared/-/shared-11.2.8.tgz",
+      "integrity": "sha512-l6e4NZyUgv8VyXXH4DbuucFOBmxLF56C/mqh2tvApbzl2Hrhi1aTDcuv5TKdxzfHYmpO3UB0Cz04fgDT9vszfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1687,6 +1745,12 @@
         "@vue/shared": "3.5.29"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmmirror.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.29",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.29.tgz",
@@ -2409,6 +2473,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gsap": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmmirror.com/gsap/-/gsap-3.14.2.tgz",
+      "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -3098,6 +3168,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/three": {
+      "version": "0.176.0",
+      "resolved": "https://registry.npmmirror.com/three/-/three-0.176.0.tgz",
+      "integrity": "sha512-PWRKYWQo23ojf9oZSlRGH8K09q7nRSWx6LY/HF/UUrMdYgN9i1e2OwJYHoQjwc6HF/4lvvYLC5YC1X8UJL2ZpA==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -3387,6 +3463,41 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmmirror.com/vue-i18n/-/vue-i18n-11.2.8.tgz",
+      "integrity": "sha512-vJ123v/PXCZntd6Qj5Jumy7UBmIuE92VrtdX+AXr+1WzdBHojiBxnAxdfctUFL+/JIN+VQH4BhsfTtiGsvVObg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.2.8",
+        "@intlify/shared": "11.2.8",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmmirror.com/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/which": {

--- a/ui/src/composables/useWebSocket.js
+++ b/ui/src/composables/useWebSocket.js
@@ -10,6 +10,7 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
   const RECONNECT_MAX = 30000
   let ws = null
   let eventUid = 0
+  let isFirstConnect = true
 
   const agentEvents = computed(() => {
     const byAgent = {}
@@ -36,9 +37,13 @@ export function useWebSocket({ onConnect, onEvent } = {}) {
 
     ws.onopen = () => {
       connected.value = true
-      events.value = []
-      worldState.value = null
-      if (onConnect) onConnect()
+      const first = isFirstConnect
+      isFirstConnect = false
+      if (first) {
+        events.value = []
+        worldState.value = null
+      }
+      if (onConnect) onConnect(first)
       reconnectDelay = 2000  // reset backoff on successful connection
     }
 

--- a/ui/src/pages/SimulationPage.vue
+++ b/ui/src/pages/SimulationPage.vue
@@ -37,9 +37,11 @@ const mobileAgents = computed(() => {
 })
 
 
-async function onWsConnect() {
+async function onWsConnect(isFirst) {
   paused.value = false
-  fetch('/api/simulation/reset', { method: 'POST' }).catch(() => {})
+  if (isFirst) {
+    fetch('/api/simulation/reset', { method: 'POST' }).catch(() => {})
+  }
   try {
     const res = await fetch('/api/narration/status')
     if (res.ok) {


### PR DESCRIPTION
## Summary

Add `isFirstConnect` flag to `useWebSocket.js` so event log and world state are only cleared on initial connection, not on WebSocket reconnects. Guard the `/api/simulation/reset` call in `SimulationPage.vue` with the `isFirst` parameter so the simulation is not reset on reconnect.

Also fixes out-of-sync `package-lock.json` (missing landing-page deps).

Closes #72
Supersedes #87, #200, #205

## Semantic Diff

| Category | Files | Lines Added | Lines Removed |
|----------|-------|-------------|---------------|
| UI | 2 | 13 | 5 |
| Docs | 1 | 1 | 1 |
| Config | 1 | 113 | 2 |
| **Total** | **4** | **127** | **8** |

### Changed
- `ui/src/composables/useWebSocket.js` (+8 / -3) — Add isFirstConnect flag, guard event clearing
- `ui/src/pages/SimulationPage.vue` (+4 / -2) — Guard simulation reset with isFirst flag
- `Changelog.md` (+1 / -1) — Update entry
- `ui/package-lock.json` (+113 / -2) — Sync with package.json

## Changelog
- **WebSocket reconnect state preservation (#72)**: Event log, world state, and simulation are no longer reset on reconnect — only on initial page load

Co-Authored-By: agent-one team <agent-one@yanok.ai>