### PR TITLE
fix(tests): add assertions to tests that verified nothing (#142)

### DIFF
--- a/server/tests/test_host.py
+++ b/server/tests/test_host.py
@@ -62,6 +62,8 @@ class TestHostInbox(unittest.TestCase):
         host = _make_host()
         # Should not raise, just log warning
         host.send_command("nonexistent", {"name": "recall", "payload": {}})
+        # Verify no inbox was created for the unknown agent
+        self.assertNotIn("nonexistent", host._inboxes)
 
     def test_drain_unknown_agent(self):
         host = _make_host()

--- a/server/tests/test_world.py
+++ b/server/tests/test_world.py
@@ -1000,6 +1000,8 @@ class TestMemory(unittest.TestCase):
     def test_record_memory_unknown_agent(self):
         # Should not raise
         record_memory("nonexistent", "noop")
+        # Verify no agent named "nonexistent" was added to world state
+        self.assertNotIn("nonexistent", world.state["agents"])
 
 
 class TestDirectionHint(unittest.TestCase):


### PR DESCRIPTION
## Summary

Add `assertNotIn` checks to two test methods that had zero assertions, giving false confidence in test coverage.

Closes #142

## Changes

### Changed
| File | +/- | What |
|------|-----|------|
| `server/tests/test_host.py` | +2 | Assert no inbox created for unknown agent |
| `server/tests/test_world.py` | +2 | Assert unknown agent not added to world state |

## File Impact
| Category | Files | Lines Added | Lines Removed |
|----------|-------|-------------|---------------|
| Tests | 2 | 4 | 0 |
| **Total** | **2** | **4** | **0** |

## Testing
- Both modified tests pass locally
- No formatting changes — pure assertion additions

## Context
PR #155 previously attempted this fix but was closed due to merge conflicts from bundled formatting changes. This PR cherry-picks only the 2 substantive assertion lines per reviewer recommendation.

Co-Authored-By: agent-one team <agent-one@yanok.ai>
