### PR TITLE
docs: update ROADMAP.md milestone checkboxes to reflect current state (#74)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Documentation
+
+* **roadmap:** update ROADMAP.md milestone checkboxes to reflect current implementation state ([#74](https://github.com/mhack-agent-one/agent-one/issues/74))
+  - M0: mark protocol types and BaseAgent as done
+  - M2: split station tools (charge_agent ✅, broadcast_alert ✅, allocate_power ❌), fix tool names
+  - M3: mark all Drone items as done, correct tool names (`scan`, `move`, `notify`)
+  - M4: mark voice commands as done (Voxtral STT)
+  - M5: mark pre-seeded world, UI polish, LLM fallback, cancel as done
+  - Stretch Voice: mark all three items done (TTS, STT, narrator voices)
+  - Stretch Visual UI: add reasoning panel, comm visualization, landing page
+  - Dependencies: update Python 3.12+ → 3.14+, pip → uv, add Node.js 24+, ElevenLabs, SurrealDB
+
 ## [0.4.0](https://github.com/mhack-agent-one/agent-one/compare/v0.3.0...v0.4.0) (2026-03-01)
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,8 @@ Mars Mission — Multi-Agent LLM Simulation (Mistral Hackathon)
 ## Milestone 0: Scaffold (pre-hackathon)
 
 - [x] Init repo, venv, project structure
-- [ ] Copy/adapt protocol types from Snowball (subset only)
-- [ ] Copy/adapt BaseAgent class (tool framework, streaming, emit helpers)
+- [x] Copy/adapt protocol types from Snowball (subset only)
+- [x] Copy/adapt BaseAgent class (tool framework, streaming, emit helpers)
 - [x] Decide UI approach (terminal with textual/rich? web? both?) → web (Vue 3 + Vite)
 
 ## Milestone 1: Rover picks up a stone (first simulation)
@@ -31,11 +31,12 @@ Mars Mission — Multi-Agent LLM Simulation (Mistral Hackathon)
 **Goal:** base station agent monitors and supports the rover.
 
 - [x] Station agent: power management, telemetry monitoring
-- [x] Station tools: `charge_rover(agent_id)` — charge co-located rovers
-- [ ] Station tools: `allocate_power(agent, amount)`, `broadcast_alert(message)`
+- [x] Station tools: `charge_agent(agent_id)` — charge co-located rovers
+- [x] Station tools: `broadcast_alert(message)` — broadcast messages to all agents
+- [ ] Station tools: `allocate_power(agent, amount)` — fine-grained power allocation
 - [ ] Station emits PowerBudgetWarning, EmergencyModeActivated actions
 - [ ] Goal confidence tracking: updates after each drill, visible in UI
-- [x] Mission completion: deliver target stones to station -> mission success
+- [x] Mission completion: deliver target stones to station → mission success
 
 **Done when:** station monitors rover, manages power, mission completes. (Partial — charging and mission completion done)
 
@@ -43,14 +44,14 @@ Mars Mission — Multi-Agent LLM Simulation (Mistral Hackathon)
 
 **Goal:** two field agents running concurrently, communicating through the coordinator.
 
-- [ ] Drone agent: system prompt, scan tools
-- [ ] Drone tools: `scan_area(zones)`, `map_route(from, to)`
-- [ ] Drone emits Action with probabilistic rock map
-- [ ] Coordinator: route Actions from drone -> rover
-- [ ] Rover receives drone findings, uses them in reasoning
-- [ ] All agents active simultaneously
+- [x] Drone agent: system prompt, scan tools
+- [x] Drone tools: `scan` (concentration map), `move` (tile navigation), `notify` (radio to station)
+- [x] Drone emits Action with probabilistic rock map
+- [x] Coordinator: route Actions from drone → rover (via broadcast + notify)
+- [x] Rover receives drone findings, uses them in reasoning
+- [x] All agents active simultaneously
 
-**Done when:** drone scans, rover uses scan data to pick a rock, all streamed live.
+**Done when:** drone scans, rover uses scan data to pick a rock, all streamed live. ✅
 
 ## Milestone 4: External Events + Human-in-the-loop
 
@@ -60,7 +61,7 @@ Mars Mission — Multi-Agent LLM Simulation (Mistral Hackathon)
 - [ ] Events broadcast to agents with updated world state
 - [ ] Agents react to events (rover reassesses, drone adjusts scan priority)
 - [ ] Rover emits UiRequest::Confirm before high-risk moves
-- [ ] Human can steer agents with free-text input
+- [x] Human can steer agents with voice commands (Voxtral STT → LLM parsing → action)
 
 **Done when:** storm arrives, rover asks human "cross hazard zone?", human decides, agents adapt.
 
@@ -69,34 +70,41 @@ Mars Mission — Multi-Agent LLM Simulation (Mistral Hackathon)
 **Goal:** reliable, impressive 5-minute demo.
 
 - [ ] Scripted event timeline (timed storms, terrain shifts, escalations)
-- [ ] Pre-seeded world state tuned for dramatic demo arc
-- [ ] UI polish: clear layout, streaming visible, tool calls visible
+- [x] Pre-seeded world state tuned for dramatic demo arc (`world_seed` config)
+- [x] UI polish: clear layout, streaming visible, tool calls visible (landing page, i18n, responsive)
 - [ ] Dry run end-to-end 3+ times
-- [ ] Handle LLM flakiness: fallback prompts, retry on empty responses
-- [ ] Cancel works mid-response
+- [x] Handle LLM flakiness: fallback prompts, retry on empty responses (`_fallback_turn()`)
+- [x] Cancel works mid-response (`abort_mission()` + task cancellation)
 
 **Done when:** you can run the demo 3 times in a row and it looks good every time.
 
 ## Stretch: Voice (ElevenLabs prize)
 
-- [ ] TTS reads incoming alerts aloud
-- [ ] STT for human commands -> coordinator
-- [ ] Agent "personality" voices (rover = calm, station = urgent)
+- [x] TTS reads incoming alerts aloud (ElevenLabs dual-narrator dialogue)
+- [x] STT for human commands → coordinator (Voxtral via `/api/voice-command`)
+- [x] Agent "personality" voices (Commander Rex = male, Dr. Nova = female narrators)
 
 ## Stretch: Visual UI
 
 - [x] Web UI with grid map (Vue 3 + Vite, proxied to FastAPI)
 - [x] Agent positions on map, animated movement (SVG with pulsing dots)
 - [x] Stone markers on map (diamond shapes, colored by type)
-- [ ] Goal confidence bars
+- [ ] Goal confidence bars (UI not implemented)
 - [x] Event log timeline (per-agent panes + global event log)
+- [x] Agent reasoning transparency panel
+- [x] Communication visualization on map
+- [x] Landing page with i18n (10 locales) and Three.js Mars globe
 
 ## Dependencies
 
 | What | Where |
 |------|-------|
-| Mistral API key | MISTRAL_API_KEY env var |
-| Python 3.12+ | venv |
-| mistralai SDK | pip install |
+| Mistral API key | `MISTRAL_API_KEY` env var |
+| ElevenLabs API key | `ELEVENLABS_API_KEY` env var (optional — voice narration) |
+| Python 3.14+ | `uv sync` |
+| Node.js 24+ | `npm ci` |
+| mistralai SDK | `uv sync` (in pyproject.toml) |
+| elevenlabs SDK | `uv sync` (optional) |
+| SurrealDB | port 4002 (dev) |
 | Snowball protocol subset | copied/adapted from snowball repo |
-| BaseAgent class | copied/adapted from agents/mistral_base.py |
+| BaseAgent class | copied/adapted from agents/mistral\_base.py |


### PR DESCRIPTION
## Summary

Update all ROADMAP.md milestone checkboxes to accurately reflect the current implementation state. Fixes #74.

## Change Type

- [x] `docs` — Documentation only

## Semantic Diff

### Added
- New Stretch Visual UI items: reasoning panel, comm visualization, landing page
- New dependency entries: ElevenLabs, Node.js 24+, SurrealDB

### Changed
- `ROADMAP.md` — Updated 20+ checkbox states across all milestones, corrected tool names (charge_rover→charge_agent, scan_area→scan), updated Python 3.12+→3.14+, pip→uv
- `Changelog.md` — Added Unreleased section documenting all roadmap changes

### Removed
- None

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 2 |
| Files deleted | 0 |
| Lines added | +47 |
| Lines removed | -25 |

### Core Files Modified
- `ROADMAP.md` — milestone checkboxes, tool names, dependency table
- `Changelog.md` — unreleased docs entry

### Tests
- N/A (documentation-only change; CI path filter skips server/ui jobs)

## How to Test

1. Review ROADMAP.md against actual codebase (protocol.py, base_agent.py, agent.py, station.py, narrator.py, voice.py, UI components)
2. Verify dependency versions match pyproject.toml and package.json
3. CI passes (docs-only — no server/ui jobs triggered)

## Changelog

**Documentation**
- Update ROADMAP.md milestone checkboxes to reflect current implementation state (#74)
  - M0: mark protocol types and BaseAgent as done
  - M2: split station tools, fix tool names
  - M3: mark Drone fully done, correct tool names
  - M4: mark voice commands done (Voxtral STT)
  - M5: mark pre-seeded world, UI polish, LLM fallback, cancel
  - Stretch Voice: all items done
  - Stretch Visual UI: add reasoning panel, comm viz, landing page
  - Dependencies: Python 3.14+, uv, Node.js 24+, ElevenLabs, SurrealDB

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>