### PR TITLE
fix: correct SyntaxError in training_logger, improve logging, add tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,15 @@
 
 ### Bug Fixes
 
+* **training-logger:** fix critical `SyntaxError` in `_safe_json_str()` — `except TypeError, ValueError:` is invalid Python 3 syntax, changed to `except (TypeError, ValueError):` with `# fmt: skip` to prevent ruff from reverting
+* **agent:** upgrade training turn logging from `debug` to `warning` level for production observability
+
+### Tests
+
+* **training-logger:** add 7 new tests for `_safe_json_str` (4 tests) and `_build_turn_snapshot` (3 tests) — total training tests now 18
+
+### Bug Fixes
+
 * **ci:** fix 3 CI failures blocking all branches — remove broken `training_logger` import, fix `client` variable scoping in narrator streaming, apply `ruff format` to 5 unformatted files
 * **narrator:** fix `UnboundLocalError` in `_generate_text_streaming()` — remove dead duplicate code block, add proper `client = self._get_mistral()` in Mistral branch
 * **tests:** fix `test_generate_text_streaming_mistral_by_default` mock to use `AsyncMock` with `stream_async`

--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -1514,7 +1514,7 @@ class DroneLoop(BaseAgent):
             training_logger.log_turn(training_turn)
             training_logger.log_world_snapshot(self._world.get_tick(), get_snapshot())
         except Exception:
-            logger.debug("Training turn logging failed for %s", self.agent_id, exc_info=True)
+            logger.warning("Training turn logging failed for %s", self.agent_id, exc_info=True)
 
         # Auto-charge drone when at station
         drone = self._world.get_agents().get(self.agent_id)
@@ -1679,4 +1679,4 @@ class StationLoop(BaseAgent):
             training_logger.log_turn(training_turn)
             training_logger.log_world_snapshot(current_tick, get_snapshot())
         except Exception:
-            logger.debug("Training turn logging failed for station", exc_info=True)
+            logger.warning("Training turn logging failed for station", exc_info=True)

--- a/server/app/training_logger.py
+++ b/server/app/training_logger.py
@@ -487,7 +487,7 @@ def _safe_json_str(obj: Any) -> str:
 
     try:
         return json.dumps(obj, ensure_ascii=False, default=str)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):  # fmt: skip
         return "{}"
 
 

--- a/server/tests/test_training_logger.py
+++ b/server/tests/test_training_logger.py
@@ -224,3 +224,92 @@ class TestTrainingLoggerDB(CaseWithDB):
         # Meta should contain session_id
         self.assertEqual(record["meta"]["session_id"], sid)
         self.assertEqual(record["meta"]["agent_type"], "rover")
+
+
+class TestSafeJsonStr(unittest.TestCase):
+    """Unit tests for _safe_json_str helper."""
+
+    def test_serializes_dict(self):
+        from app.training_logger import _safe_json_str
+
+        result = _safe_json_str({"key": "value", "num": 42})
+        self.assertIn('"key"', result)
+        self.assertIn("42", result)
+
+    def test_handles_non_serializable(self):
+        from app.training_logger import _safe_json_str
+
+        result = _safe_json_str({"obj": object()})
+        self.assertIn("obj", result)
+
+    def test_empty_dict(self):
+        from app.training_logger import _safe_json_str
+
+        self.assertEqual(_safe_json_str({}), "{}")
+
+    def test_serializes_nested(self):
+        from app.training_logger import _safe_json_str
+
+        result = _safe_json_str({"a": [1, 2, {"b": True}]})
+        self.assertIn('"a"', result)
+        self.assertIn("true", result)
+
+
+class TestBuildTurnSnapshot(unittest.TestCase):
+    """Unit tests for _build_turn_snapshot helper."""
+
+    def test_basic_snapshot(self):
+        from unittest.mock import MagicMock
+
+        from app.agent import _build_turn_snapshot
+
+        world = MagicMock()
+        world.get_agents.return_value = {"station": {"position": [5, 5]}}
+        world.get_mission.return_value = {
+            "status": "running",
+            "collected": 10,
+            "target_quantity": 100,
+        }
+
+        agent_state = {
+            "position": [3, 4],
+            "battery": 0.75,
+            "inventory": [{"type": "basalt", "grade": "A", "quantity": 1}],
+            "memory": ["moved east", "dug rock"],
+            "tasks": ["collect basalt"],
+        }
+
+        snap = _build_turn_snapshot(agent_state, world)
+        self.assertEqual(snap.agent_position, [3, 4])
+        self.assertAlmostEqual(snap.agent_battery, 0.75)
+        self.assertEqual(snap.distance_to_station, 3)
+        self.assertEqual(snap.mission_status, "running")
+        self.assertEqual(snap.collected_quantity, 10)
+
+    def test_missing_fields_default_safely(self):
+        from unittest.mock import MagicMock
+
+        from app.agent import _build_turn_snapshot
+
+        world = MagicMock()
+        world.get_agents.return_value = {}
+        world.get_mission.return_value = {}
+
+        snap = _build_turn_snapshot({}, world)
+        self.assertEqual(snap.agent_position, [0, 0])
+        self.assertEqual(snap.agent_battery, 0)
+        self.assertEqual(snap.distance_to_station, 0)
+
+    def test_invalid_position_type(self):
+        from unittest.mock import MagicMock
+
+        from app.agent import _build_turn_snapshot
+
+        world = MagicMock()
+        world.get_agents.return_value = {"station": {"position": "invalid"}}
+        world.get_mission.return_value = None
+
+        agent_state = {"position": "not-a-list", "battery": "not-a-number"}
+        snap = _build_turn_snapshot(agent_state, world)
+        self.assertEqual(snap.agent_position, [0, 0])
+        self.assertEqual(snap.agent_battery, 0)


### PR DESCRIPTION
## Summary

Fixes a **critical SyntaxError** on main introduced by PR #212 (squash-merged without the fix commit). The `except TypeError, ValueError:` syntax in `training_logger.py` is Python 2 — it crashes the server on import under Python 3.14.

## Changes

### Bug Fixes
- **training_logger.py**: `except TypeError, ValueError:` → `except (TypeError, ValueError):  # fmt: skip`
  - `# fmt: skip` prevents ruff v0.15.4 from reverting the fix (known quirk when `target-version` is unset)
- **agent.py**: Upgraded training turn logging from `logger.debug` → `logger.warning` (2 locations) for production observability

### Tests
- **test_training_logger.py**: Added 7 new unit tests:
  - `TestSafeJsonStr` (4 tests): dict, nested, empty, non-serializable
  - `TestBuildTurnSnapshot` (3 tests): basic, missing fields, invalid types

## File Impact

| Category | Files | Lines (+/-) |
|----------|-------|-------------|
| Core     | 2     | +3 / -3     |
| Tests    | 1     | +89 / -0    |
| Docs     | 1     | +9 / -0     |
| **Total**| **4** | **+101 / -3** |

### Changed
- `server/app/training_logger.py` — fix except clause syntax
- `server/app/agent.py` — upgrade log level

### Added
- `server/tests/test_training_logger.py` — 7 new test methods

### Docs
- `Changelog.md` — entry for this fix

## Testing
- All 18 training tests pass
- `ruff check` and `ruff format --check` pass
- Import verification: `python -c "import app.training_logger"` succeeds

## Changelog

### Bug Fixes
- **training-logger:** fix critical SyntaxError in `_safe_json_str()` (Python 2 except syntax)
- **agent:** upgrade training turn logging from debug to warning

### Tests
- **training-logger:** add 7 new tests for `_safe_json_str` and `_build_turn_snapshot`

Co-Authored-By: agent-one team <agent-one@yanok.ai>