### PR TITLE
feat(ui): add obstacle visualization to WorldMap SVG

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,10 +17,16 @@
   - `_fallback_turn()` skips mountain-blocked directions when choosing random moves
   - Geyser eruption events broadcast via WebSocket for real-time UI updates
 * **models:** add `ObstacleInfo` pydantic model and `nearby_obstacles` field on `RoverComputed`
+* **ui:** add obstacle visualization to WorldMap SVG
+  - Mountains rendered as blue-grey triangles; geysers as circles colored by state (idle/warning/erupting)
+  - Erupting geysers animate with a pulse effect
+  - `OBSTACLE_COLORS` constant for consistent styling
+  - Screen positions pre-computed via `visibleObstacles` computed property for rendering performance
 
 ### Tests
 
 * **world:** add 15 obstacle tests covering generation, mountain blocking, geyser state machine, battery drain, snapshot filtering, origin protection, and deterministic seeding
+* **ui:** add 11 obstacle rendering tests covering mountain/geyser SVG output, color mapping, radius sizing, pulse animation class, mixed rendering, and empty state
 
 ### Bug Fixes
 

--- a/ui/src/components/WorldMap.vue
+++ b/ui/src/components/WorldMap.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
-import { TILE_SIZE, VIEWPORT_W, VIEWPORT_H, VEIN_COLORS, VEIN_SIZES, SOLAR_PANEL_COLOR, SOLAR_PANEL_DEPLETED_COLOR, agentColor, revealRadius } from '../constants.js'
+import { TILE_SIZE, VIEWPORT_W, VIEWPORT_H, VEIN_COLORS, VEIN_SIZES, SOLAR_PANEL_COLOR, SOLAR_PANEL_DEPLETED_COLOR, OBSTACLE_COLORS, agentColor, revealRadius } from '../constants.js'
 import { usePreferences } from '../composables/usePreferences.js'
 import { useRevealedSet } from '../composables/useRevealedSet.js'
 
@@ -356,6 +356,37 @@ function panelScreenY(p) {
   return (visibleH.value - 1 - (p.position[1] - camY.value)) * TILE_SIZE + 2
 }
 
+// Obstacle rendering — pre-compute screen positions for efficiency
+const visibleObstacles = computed(() => {
+  if (!props.worldState) return []
+  return (props.worldState.obstacles || [])
+    .filter((o) => {
+      const [wx, wy] = o.position
+      return (
+        wx >= camX.value &&
+        wx < camX.value + visibleW.value &&
+        wy >= camY.value &&
+        wy < camY.value + visibleH.value
+      )
+    })
+    .map((o) => {
+      const { sx, sy } = worldToScreen(o.position[0], o.position[1])
+      return { ...o, sx, sy }
+    })
+})
+
+function obstacleColor(o) {
+  if (o.kind === 'mountain') return OBSTACLE_COLORS.mountain
+  if (o.kind === 'geyser') return OBSTACLE_COLORS['geyser_' + (o.state || 'idle')] || OBSTACLE_COLORS.geyser_idle
+  return '#666'
+}
+
+function obstacleTooltip(o) {
+  if (o.kind === 'mountain') return `Ice Mountain at (${o.position[0]}, ${o.position[1]}) — impassable`
+  if (o.kind === 'geyser') return `Air Geyser at (${o.position[0]}, ${o.position[1]}) — ${o.state || 'idle'}`
+  return `${o.kind} at (${o.position[0]}, ${o.position[1]})`
+}
+
 // Drag-to-pan
 function onMouseDown(e) {
   dragging.value = true
@@ -685,6 +716,34 @@ defineExpose({ camX, camY, visibleW, visibleH, panCamera, navigateTo })
         >
           <title>{{ stoneTooltip(s) }}</title>
         </rect>
+      </template>
+
+      <!-- obstacles (mountains + geysers) -->
+      <template
+        v-for="(o, i) in visibleObstacles"
+        :key="'obs-' + i"
+      >
+        <!-- mountains: triangle -->
+        <polygon
+          v-if="o.kind === 'mountain'"
+          :points="`${o.sx},${o.sy - 7} ${o.sx - 7},${o.sy + 5} ${o.sx + 7},${o.sy + 5}`"
+          :fill="obstacleColor(o)"
+          opacity="0.85"
+        >
+          <title>{{ obstacleTooltip(o) }}</title>
+        </polygon>
+        <!-- geysers: circle with animation when erupting -->
+        <circle
+          v-else-if="o.kind === 'geyser'"
+          :cx="o.sx"
+          :cy="o.sy"
+          :r="o.state === 'erupting' ? 7 : o.state === 'warning' ? 5 : 4"
+          :fill="obstacleColor(o)"
+          :opacity="o.state === 'erupting' ? 0.95 : 0.7"
+          :class="{ 'geyser-pulse': o.state === 'erupting' }"
+        >
+          <title>{{ obstacleTooltip(o) }}</title>
+        </circle>
       </template>
 
       <!-- solar panels -->
@@ -1153,5 +1212,13 @@ defineExpose({ camX, camY, visibleW, visibleH, panCamera, navigateTo })
 @keyframes pulse-text {
   from { opacity: 0.7; }
   to { opacity: 1; }
+}
+
+@keyframes geyser-pulse-anim {
+  0%, 100% { r: 7; opacity: 0.95; }
+  50% { r: 9; opacity: 0.7; }
+}
+.geyser-pulse {
+  animation: geyser-pulse-anim 0.6s ease-in-out infinite;
 }
 </style>

--- a/ui/src/components/__tests__/WorldMapObstacles.test.js
+++ b/ui/src/components/__tests__/WorldMapObstacles.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { OBSTACLE_COLORS } from '../../constants.js'
+
+// Test OBSTACLE_COLORS constant
+describe('OBSTACLE_COLORS', () => {
+  it('has mountain color', () => {
+    expect(OBSTACLE_COLORS.mountain).toBe('#8899bb')
+  })
+
+  it('has geyser idle color', () => {
+    expect(OBSTACLE_COLORS.geyser_idle).toBe('#447788')
+  })
+
+  it('has geyser warning color', () => {
+    expect(OBSTACLE_COLORS.geyser_warning).toBe('#cc8844')
+  })
+
+  it('has geyser erupting color', () => {
+    expect(OBSTACLE_COLORS.geyser_erupting).toBe('#ee4444')
+  })
+})
+
+// Test WorldMap obstacle rendering
+// WorldMap requires complex props and composables; test via a lightweight wrapper
+describe('WorldMap obstacle rendering', () => {
+  // We test the rendering logic indirectly by checking SVG output
+  // with a minimal component that mirrors the obstacle template
+  const ObstacleTestWrapper = {
+    template: `
+      <svg>
+        <template v-for="(o, i) in obstacles" :key="'obs-' + i">
+          <polygon
+            v-if="o.kind === 'mountain'"
+            :points="trianglePoints(o)"
+            :fill="obstacleColor(o)"
+            class="mountain"
+          />
+          <circle
+            v-else-if="o.kind === 'geyser'"
+            :cx="o.sx"
+            :cy="o.sy"
+            :r="o.state === 'erupting' ? 7 : o.state === 'warning' ? 5 : 4"
+            :fill="obstacleColor(o)"
+            :class="{ 'geyser-pulse': o.state === 'erupting' }"
+            class="geyser"
+          />
+        </template>
+      </svg>
+    `,
+    props: ['obstacles'],
+    methods: {
+      trianglePoints(o) {
+        return `${o.sx},${o.sy - 7} ${o.sx - 7},${o.sy + 5} ${o.sx + 7},${o.sy + 5}`
+      },
+      obstacleColor(o) {
+        if (o.kind === 'mountain') return OBSTACLE_COLORS.mountain
+        if (o.kind === 'geyser') return OBSTACLE_COLORS['geyser_' + (o.state || 'idle')] || OBSTACLE_COLORS.geyser_idle
+        return '#666'
+      },
+    },
+  }
+
+  it('renders mountains as polygons', () => {
+    const wrapper = mount(ObstacleTestWrapper, {
+      props: {
+        obstacles: [
+          { kind: 'mountain', position: [5, 3], sx: 100, sy: 60 },
+        ],
+      },
+    })
+    const polygon = wrapper.find('polygon.mountain')
+    expect(polygon.exists()).toBe(true)
+    expect(polygon.attributes('fill')).toBe(OBSTACLE_COLORS.mountain)
+    expect(polygon.attributes('points')).toBe('100,53 93,65 107,65')
+  })
+
+  it('renders geysers as circles', () => {
+    const wrapper = mount(ObstacleTestWrapper, {
+      props: {
+        obstacles: [
+          { kind: 'geyser', state: 'idle', position: [2, 4], sx: 50, sy: 80 },
+        ],
+      },
+    })
+    const circle = wrapper.find('circle.geyser')
+    expect(circle.exists()).toBe(true)
+    expect(circle.attributes('fill')).toBe(OBSTACLE_COLORS.geyser_idle)
+    expect(circle.attributes('r')).toBe('4')
+  })
+
+  it('renders erupting geyser with larger radius and pulse class', () => {
+    const wrapper = mount(ObstacleTestWrapper, {
+      props: {
+        obstacles: [
+          { kind: 'geyser', state: 'erupting', position: [2, 4], sx: 50, sy: 80 },
+        ],
+      },
+    })
+    const circle = wrapper.find('circle.geyser')
+    expect(circle.attributes('r')).toBe('7')
+    expect(circle.classes()).toContain('geyser-pulse')
+  })
+
+  it('renders warning geyser with medium radius', () => {
+    const wrapper = mount(ObstacleTestWrapper, {
+      props: {
+        obstacles: [
+          { kind: 'geyser', state: 'warning', position: [2, 4], sx: 50, sy: 80 },
+        ],
+      },
+    })
+    const circle = wrapper.find('circle.geyser')
+    expect(circle.attributes('r')).toBe('5')
+    expect(circle.attributes('fill')).toBe(OBSTACLE_COLORS.geyser_warning)
+    expect(circle.classes()).not.toContain('geyser-pulse')
+  })
+
+  it('renders mixed mountains and geysers', () => {
+    const wrapper = mount(ObstacleTestWrapper, {
+      props: {
+        obstacles: [
+          { kind: 'mountain', position: [0, 0], sx: 10, sy: 10 },
+          { kind: 'geyser', state: 'idle', position: [1, 1], sx: 30, sy: 30 },
+          { kind: 'mountain', position: [2, 2], sx: 50, sy: 50 },
+          { kind: 'geyser', state: 'erupting', position: [3, 3], sx: 70, sy: 70 },
+        ],
+      },
+    })
+    expect(wrapper.findAll('polygon.mountain')).toHaveLength(2)
+    expect(wrapper.findAll('circle.geyser')).toHaveLength(2)
+  })
+
+  it('renders nothing when obstacles is empty', () => {
+    const wrapper = mount(ObstacleTestWrapper, {
+      props: { obstacles: [] },
+    })
+    expect(wrapper.findAll('polygon').length).toBe(0)
+    expect(wrapper.findAll('circle').length).toBe(0)
+  })
+
+  it('idle geyser does not have pulse class', () => {
+    const wrapper = mount(ObstacleTestWrapper, {
+      props: {
+        obstacles: [
+          { kind: 'geyser', state: 'idle', position: [0, 0], sx: 10, sy: 10 },
+        ],
+      },
+    })
+    expect(wrapper.find('circle.geyser').classes()).not.toContain('geyser-pulse')
+  })
+})

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -34,6 +34,13 @@ export const AGENT_COLORS = {
 export const SOLAR_PANEL_COLOR = '#f0c040'
 export const SOLAR_PANEL_DEPLETED_COLOR = '#555555'
 
+export const OBSTACLE_COLORS = {
+  mountain: '#8899bb',
+  geyser_idle: '#447788',
+  geyser_warning: '#cc8844',
+  geyser_erupting: '#ee4444',
+}
+
 export function agentColor(id) {
   return AGENT_COLORS[id] || '#6c6'
 }


### PR DESCRIPTION
## Summary

Adds frontend visualization for environmental hazards (ice mountains and air geysers) introduced in PR #220 (backend). Mountains render as blue-grey triangles; geysers render as circles colored by state (idle/warning/erupting) with a CSS pulse animation on eruption.

Part 2 of 2 for PR #106 re-implementation (see #220 for backend).

## Changes

### Added
| File | +/- | Description |
|------|-----|-------------|
| `ui/src/constants.js` | +7 | `OBSTACLE_COLORS` constant (mountain, geyser idle/warning/erupting) |
| `ui/src/components/__tests__/WorldMapObstacles.test.js` | +152 | 11 rendering tests for obstacle SVG output |

### Changed
| File | +/- | Description |
|------|-----|-------------|
| `ui/src/components/WorldMap.vue` | +68/−1 | `visibleObstacles` computed, obstacle SVG rendering (triangles + circles), geyser pulse CSS |
| `Changelog.md` | +6 | Frontend feature + test entries |

### File Impact
| Category | Files | Lines added | Lines removed |
|----------|-------|-------------|---------------|
| Core | 2 | 75 | 1 |
| Tests | 1 | 152 | 0 |
| Docs | 1 | 6 | 0 |
| **Total** | **4** | **233** | **1** |

## Changelog

* **ui:** add obstacle visualization to WorldMap SVG
  - Mountains rendered as blue-grey triangles; geysers as circles colored by state
  - Erupting geysers animate with CSS pulse effect
  - `OBSTACLE_COLORS` constant for consistent styling
  - Screen positions pre-computed via `visibleObstacles` computed for performance
* **ui:** add 11 obstacle rendering tests

## Testing
- `npm test` — 26/26 pass (15 existing + 11 new)
- `npm run build` — succeeds
- `eslint` — 0 errors, 0 warnings

Co-Authored-By: agent-one team <agent-one@yanok.ai>