### PR TITLE
fix(ui): tone down HowItWorks timeline animation line

### DIFF
--- a/ui/src/components/landing/HowItWorks.vue
+++ b/ui/src/components/landing/HowItWorks.vue
@@ -282,26 +282,26 @@ const { sectionRef, visible } = useRevealOnScroll()
   position: relative;
 }
 
-/* Connecting gradient line — animated flow */
+/* Connecting gradient line — subtle animated flow */
 .timeline::before {
   content: '';
   position: absolute;
   top: 31px; /* center of 64px circle */
   left: 32px;
   right: 32px;
-  height: 2px;
+  height: 1px;
   background: linear-gradient(
     90deg,
-    var(--mars-sunset),
-    var(--accent-cyan),
-    var(--mars-sunset),
-    var(--accent-cyan)
+    rgba(255, 107, 53, 0.25),
+    rgba(0, 212, 255, 0.15),
+    rgba(255, 107, 53, 0.25),
+    rgba(0, 212, 255, 0.15)
   );
   background-size: 200% 100%;
   z-index: 1;
   opacity: 0;
   transition: opacity 0.8s ease 0.3s;
-  animation: timeline-flow 4s linear infinite;
+  animation: timeline-flow 8s linear infinite;
 }
 
 /* ─── Step ─── */
@@ -551,17 +551,17 @@ const { sectionRef, visible } = useRevealOnScroll()
     bottom: 0;
     left: 31px; /* center of 64px circle */
     right: auto;
-    width: 2px;
+    width: 1px;
     height: 100%;
     background: linear-gradient(
       180deg,
-      var(--mars-sunset),
-      var(--accent-cyan),
-      var(--mars-sunset),
-      var(--accent-cyan)
+      rgba(255, 107, 53, 0.25),
+      rgba(0, 212, 255, 0.15),
+      rgba(255, 107, 53, 0.25),
+      rgba(0, 212, 255, 0.15)
     );
     background-size: 100% 200%;
-    animation: timeline-flow-vertical 4s linear infinite;
+    animation: timeline-flow-vertical 8s linear infinite;
   }
 
   .timeline__step {


### PR DESCRIPTION
## Summary

Reduce the animated timeline connecting line in HowItWorks section — it was too pronounced and visually competed with the step content.

## Change Type

- [x] `fix` — Bug fix
- [x] `style` — Formatting, linting (no logic change)

## Semantic Diff

### Changed
- `ui/src/components/landing/HowItWorks.vue` — Timeline line toned down: 2px→1px, solid colors→75-85% transparent rgba, 4s→8s animation speed. Both desktop (horizontal) and mobile (vertical) orientations updated.

### Removed
- None

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 1 |
| Files deleted | 0 |
| Lines added | +13 |
| Lines removed | -13 |

### Core Files Modified
- `ui/src/components/landing/HowItWorks.vue` (+13/-13)

### Tests
- None (CSS-only change)

## How to Test

1. `cd ui && npm run dev`
2. Open `http://localhost:4089` — scroll to "How It Works" section
3. Verify the connecting line between steps is a subtle, faint gradient — not a bright animated stripe
4. Resize to ≤768px — verify the vertical line is equally subtle
5. `npm run build` — verify build passes

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>