### PR TITLE
perf: double agent action speed

### DIFF
--- a/server/app/config.py
+++ b/server/app/config.py
@@ -34,8 +34,8 @@ class Settings(BaseSettings):
 
     # Simulation timing
     agent_turn_interval_seconds: float = Field(default=0.5, gt=0)
-    llm_turn_interval_seconds: float = Field(default=6.0, gt=0)
-    drone_turn_interval_seconds: float = Field(default=5.0, gt=0)
+    llm_turn_interval_seconds: float = Field(default=3.0, gt=0)
+    drone_turn_interval_seconds: float = Field(default=2.5, gt=0)
 
     # World generation seed (empty = random)
     world_seed: str = ""

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -12,7 +12,7 @@ class TestDroneTurnIntervalSetting(unittest.TestCase):
 
     def test_default_value(self):
         s = Settings(mistral_api_key="test")
-        self.assertEqual(s.drone_turn_interval_seconds, 5.0)
+        self.assertEqual(s.drone_turn_interval_seconds, 2.5)
 
     def test_custom_value(self):
         s = Settings(mistral_api_key="test", drone_turn_interval_seconds=10.0)


### PR DESCRIPTION
## Summary
Double agent action speed: rover 6s→3s, drone 5s→2.5s. With 2 active LLM agents this gives ~44 Mistral calls/min, within rate limits.

## Changes
| File | Change |
|------|--------|
| `server/app/config.py` | llm_turn_interval 6→3s, drone_turn_interval 5→2.5s |
| `server/tests/test_config.py` | Update default assertion 5.0→2.5 |

Co-Authored-By: agent-one team <agent-one@yanok.ai>