### PR TITLE
feat: simulation timer, session duration tracking, and control button verification

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,30 @@
 * All landing page SVG icons use `aria-hidden="true"` for accessibility — decorative icons must not confuse screen readers.
 * All CSS animations include `@media (prefers-reduced-motion: reduce)` rules to respect user accessibility preferences.
 
+## [0.6.0] — Simulation Timer, Duration Tracking & Control Verification (2026-03-01)
+
+### Features
+
+* **server:** add elapsed time tracking to simulation snapshots — `elapsed_seconds` field in world snapshot, synced to UI every tick
+* **server:** implement pause-aware elapsed time — `Host.paused` converted to `@property` with automatic pause/resume timestamp tracking
+* **server:** store `duration_seconds` in SurrealDB `training_session` table on session finalization (success, failure, or abort)
+* **server:** auto-finalize training sessions on `mission_success`, `mission_failed`, and abort events with full `SessionResult`
+* **server:** idempotent session finalization — `end_session()` guard prevents double-finalize errors
+* **ui:** pass `:paused` prop to StatsBar for timer pause synchronization
+
+### Tests
+
+* **test_elapsed_time:** 19 new tests covering pause property, elapsed seconds calculation, start() resets, snapshot integration, session finalization, duration persistence, broadcast hooks, and end_session idempotency
+
+### Control Buttons Verified
+
+* RESET, PAUSE, ABORT, and Voice ON/OFF — all verified working end-to-end via existing code paths (no changes needed)
+
+### Errors Identified & Prevented
+
+* **Lost uncommitted changes:** Server-side changes from previous session were never committed and lost during branch operations. Lesson: always commit work-in-progress before switching branches.
+* **Feature branch drift:** `feature/simulation-timer-controls` fell 8 commits behind `main` — rebased to avoid merge conflicts.
+
 ## [Unreleased]
 
 ### Features

--- a/server/app/host.py
+++ b/server/app/host.py
@@ -17,6 +17,7 @@ from .station import StationAgent, execute_action as station_execute_action
 from .world import abort_mission as world_abort_mission
 from .world import get_snapshot
 from .world import observe_station
+from .world import set_elapsed_provider
 from .config import settings
 from .training_logger import training_logger
 from .training_models import SessionConfig, SessionResult
@@ -34,8 +35,34 @@ class Host:
         self._station = StationAgent()
         self._station_loop = None
         self._agent_tasks: list[asyncio.Task] = []
-        self.paused = False
+        self._paused = False
         self._session_start_time: float = 0.0
+        self._total_paused_duration: float = 0.0
+        self._pause_start_time: float | None = None
+
+    @property
+    def paused(self) -> bool:
+        return self._paused
+
+    @paused.setter
+    def paused(self, value: bool):
+        """Set paused state with automatic pause duration tracking."""
+        if value and not self._paused:
+            self._pause_start_time = time.monotonic()
+        elif not value and self._paused and self._pause_start_time is not None:
+            self._total_paused_duration += time.monotonic() - self._pause_start_time
+            self._pause_start_time = None
+        self._paused = value
+
+    def get_elapsed_seconds(self) -> float:
+        """Return wall-clock seconds since start, excluding paused time."""
+        if not self._session_start_time:
+            return 0.0
+        raw = time.monotonic() - self._session_start_time
+        paused_so_far = self._total_paused_duration
+        if self._paused and self._pause_start_time is not None:
+            paused_so_far += time.monotonic() - self._pause_start_time
+        return max(0.0, raw - paused_so_far)
 
     # ── Agent registration ──
 
@@ -81,6 +108,18 @@ class Host:
         from .world import world as default_world
 
         training_logger.maybe_log_broadcast_event(msg_dict, default_world.get_tick())
+        # Finalize training session on mission end events
+        event_name = msg_dict.get("name", "")
+        if event_name in ("mission_success", "mission_failed"):
+            payload = msg_dict.get("payload", {})
+            status = "success" if event_name == "mission_success" else "failed"
+            result = SessionResult(
+                total_ticks=default_world.get_tick(),
+                basalt_collected=payload.get("collected_quantity", 0),
+                basalt_delivered=payload.get("collected_quantity", 0),
+                duration_seconds=self.get_elapsed_seconds(),
+            )
+            training_logger.end_session(result, status=status)
         # Feed interesting events to station loop for periodic evaluation
         if self._station_loop is not None:
             from .agent import StationLoop
@@ -93,8 +132,10 @@ class Host:
 
     async def start(self):
         """Launch all registered agent loops."""
-        self.paused = False
+        self._paused = False
         self._session_start_time = time.monotonic()
+        self._total_paused_duration = 0.0
+        self._pause_start_time = None
         self._narrator.reset()
         self._narrator.start()
 
@@ -112,12 +153,15 @@ class Host:
 
         # Station assigns initial missions to all agents
         asyncio.create_task(self.station_startup())
+        # Register elapsed time provider for world snapshots
+        set_elapsed_provider(self.get_elapsed_seconds)
 
     def stop(self):
         """Cancel all running agent loops and narrator."""
         self._narrator.stop()
         # End training session
-        elapsed = time.monotonic() - self._session_start_time if self._session_start_time else 0.0
+        elapsed = self.get_elapsed_seconds()
+        set_elapsed_provider(None)
         result = SessionResult(
             duration_seconds=elapsed,
         )
@@ -229,6 +273,16 @@ class Host:
             name="mission_aborted",
             payload=result,
         )
+        # Finalize training session as aborted
+        from .world import world as default_world
+
+        abort_result = SessionResult(
+            total_ticks=default_world.get_tick(),
+            basalt_collected=result.get("collected_quantity", 0),
+            basalt_delivered=result.get("collected_quantity", 0),
+            duration_seconds=self.get_elapsed_seconds(),
+        )
+        training_logger.end_session(abort_result, status="aborted")
         await broadcaster.send(msg.to_dict())
         await self._narrator.feed(msg.to_dict())
         return {"ok": True, **result}

--- a/server/app/training_logger.py
+++ b/server/app/training_logger.py
@@ -33,6 +33,7 @@ _SCHEMA_QUERIES = [
     "DEFINE FIELD IF NOT EXISTS config ON training_session TYPE object FLEXIBLE",
     "DEFINE FIELD IF NOT EXISTS result ON training_session TYPE option<object> FLEXIBLE",
     "DEFINE FIELD IF NOT EXISTS tags ON training_session TYPE array DEFAULT []",
+    "DEFINE FIELD IF NOT EXISTS duration_seconds ON training_session TYPE option<float>",
     "DEFINE INDEX IF NOT EXISTS idx_session_status ON training_session FIELDS status",
     "DEFINE TABLE IF NOT EXISTS training_turn SCHEMAFULL",
     "DEFINE FIELD IF NOT EXISTS session_id ON training_turn TYPE string",
@@ -170,11 +171,13 @@ class TrainingLogger:
             try:
                 db.query(
                     f"UPDATE training_session:`{self._session_id}` SET "
-                    "ended_at = $ended_at, status = $status, result = $result",
+                    "ended_at = $ended_at, status = $status, result = $result, "
+                    "duration_seconds = $duration_seconds",
                     {
                         "ended_at": datetime.now(timezone.utc),
                         "status": status,
                         "result": result.model_dump(),
+                        "duration_seconds": result.duration_seconds,
                     },
                 )
                 logger.info("Training session ended: %s (status=%s)", self._session_id, status)
@@ -182,6 +185,8 @@ class TrainingLogger:
                 db.close()
         except Exception:
             logger.exception("Failed to end training session %s", self._session_id)
+        finally:
+            self._session_id = None  # Prevent double-end
 
     def log_turn(self, turn: TrainingTurn) -> None:
         """Log an agent decision cycle."""

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -1,9 +1,12 @@
 """In-memory world state for the Mars simulation."""
 
+from __future__ import annotations
+
 import copy
 import hashlib
 import logging
 import random
+from collections.abc import Callable
 
 from .config import settings
 from . import storm as storm_mod
@@ -12,6 +15,18 @@ from .models import AgentMission, InventoryItem, StoneInfo, ObstacleInfo
 from .models import RoverSummary, StationContext
 
 logger = logging.getLogger(__name__)
+
+# ── Elapsed time provider ──
+# Injected by Host.start() so get_snapshot() can include elapsed_seconds
+# without needing a direct reference to the Host instance.
+_elapsed_provider: Callable[[], float] | None = None
+
+
+def set_elapsed_provider(provider: Callable[[], float] | None):
+    """Set (or clear) the callback that returns elapsed seconds for snapshots."""
+    global _elapsed_provider
+    _elapsed_provider = provider
+
 
 # ENGINE vs AGENT RESPONSIBILITY — DO NOT BREAK THIS CONTRACT:
 # - Engine (world.py): enforces physics — battery drain, movement cost, pickup limits,
@@ -1927,6 +1942,8 @@ def get_snapshot():
         snap["bounds"] = {"min_x": 0, "max_x": GRID_W - 1, "min_y": 0, "max_y": GRID_H - 1}
     # Add storm info for UI
     snap["storm"] = storm_mod.get_storm_info(WORLD)
+    # Add elapsed time from host (if available)
+    snap["elapsed_seconds"] = _elapsed_provider() if _elapsed_provider else 0.0
     return snap
 
 

--- a/server/tests/test_elapsed_time.py
+++ b/server/tests/test_elapsed_time.py
@@ -1,0 +1,280 @@
+"""Tests for elapsed time tracking and session duration persistence."""
+
+import asyncio
+import time
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.host import Host
+from app.narrator import Narrator
+from app.training_logger import TrainingLogger
+from app.training_models import SessionConfig, SessionResult
+from app.world import get_snapshot, set_elapsed_provider
+from tests.conftest import CaseWithDB
+
+
+def _make_host():
+    """Create a Host with a mocked narrator for testing."""
+    narrator = MagicMock(spec=Narrator)
+    narrator.feed = AsyncMock()
+    narrator.reset = MagicMock()
+    narrator.start = MagicMock()
+    narrator.stop = MagicMock()
+    return Host(narrator=narrator)
+
+
+# ── Host.paused property ──
+
+
+class TestHostPausedProperty(unittest.TestCase):
+    """Test that paused property setter tracks pause duration."""
+
+    def test_paused_default_false(self):
+        host = _make_host()
+        self.assertFalse(host.paused)
+
+    def test_set_paused_true(self):
+        host = _make_host()
+        host.paused = True
+        self.assertTrue(host.paused)
+        self.assertIsNotNone(host._pause_start_time)
+
+    def test_set_paused_false_after_true(self):
+        host = _make_host()
+        host.paused = True
+        self.assertIsNotNone(host._pause_start_time)
+        host.paused = False
+        self.assertFalse(host.paused)
+        self.assertIsNone(host._pause_start_time)
+        self.assertGreater(host._total_paused_duration, 0.0)
+
+    def test_setting_paused_true_twice_no_double_track(self):
+        """Setting paused=True when already paused should not reset the pause start."""
+        host = _make_host()
+        host.paused = True
+        first_start = host._pause_start_time
+        host.paused = True  # no-op since already paused
+        self.assertEqual(host._pause_start_time, first_start)
+
+    def test_setting_paused_false_twice_no_double_add(self):
+        """Setting paused=False when already unpaused should not add zero duration."""
+        host = _make_host()
+        host.paused = True
+        host.paused = False
+        dur1 = host._total_paused_duration
+        host.paused = False  # no-op since already unpaused
+        self.assertEqual(host._total_paused_duration, dur1)
+
+
+# ── Host.get_elapsed_seconds ──
+
+
+class TestHostElapsedSeconds(unittest.TestCase):
+    """Test elapsed time calculation excluding pause duration."""
+
+    def test_zero_before_start(self):
+        host = _make_host()
+        self.assertEqual(host.get_elapsed_seconds(), 0.0)
+
+    def test_positive_after_start(self):
+        host = _make_host()
+        host._session_start_time = time.monotonic() - 5.0
+        elapsed = host.get_elapsed_seconds()
+        self.assertGreaterEqual(elapsed, 4.5)  # Allow small timing variance
+        self.assertLessEqual(elapsed, 6.0)
+
+    def test_excludes_paused_time(self):
+        host = _make_host()
+        host._session_start_time = time.monotonic() - 10.0
+        host._total_paused_duration = 3.0
+        elapsed = host.get_elapsed_seconds()
+        self.assertGreaterEqual(elapsed, 6.5)
+        self.assertLessEqual(elapsed, 8.0)
+
+    def test_excludes_current_pause(self):
+        """While paused, current pause time is also excluded."""
+        host = _make_host()
+        host._session_start_time = time.monotonic() - 10.0
+        host._paused = True
+        host._pause_start_time = time.monotonic() - 5.0
+        elapsed = host.get_elapsed_seconds()
+        # Should be ~5s (10s total - 5s paused)
+        self.assertGreaterEqual(elapsed, 4.0)
+        self.assertLessEqual(elapsed, 6.0)
+
+
+# ── Host.start() resets pause tracking ──
+
+
+class TestHostStartResetsPauseTracking(unittest.TestCase):
+    def test_start_resets_pause_fields(self):
+        host = _make_host()
+        host._total_paused_duration = 42.0
+        host._pause_start_time = time.monotonic()
+        host._paused = True
+
+        with patch("app.host.broadcaster") as mock_bc:
+            mock_bc.send = AsyncMock()
+            with patch.object(host, "station_startup", new_callable=AsyncMock):
+                loop = asyncio.new_event_loop()
+                try:
+                    loop.run_until_complete(host.start())
+                    loop.run_until_complete(asyncio.sleep(0.05))
+                finally:
+                    host.stop()
+                    loop.close()
+
+        self.assertFalse(host._paused)
+        # start() sets _session_start_time to a fresh value
+        self.assertIsNone(host._pause_start_time)
+
+
+# ── get_snapshot() includes elapsed_seconds ──
+
+
+class TestGetSnapshotElapsedSeconds(unittest.TestCase):
+    def tearDown(self):
+        set_elapsed_provider(None)
+
+    def test_default_zero_when_no_provider(self):
+        set_elapsed_provider(None)
+        snap = get_snapshot()
+        self.assertEqual(snap["elapsed_seconds"], 0.0)
+
+    def test_uses_provider_when_set(self):
+        set_elapsed_provider(lambda: 42.5)
+        snap = get_snapshot()
+        self.assertAlmostEqual(snap["elapsed_seconds"], 42.5)
+
+
+# ── TrainingLogger.end_session idempotency ──
+
+
+class TestEndSessionIdempotency(CaseWithDB):
+    def _make_logger(self):
+        tl = TrainingLogger()
+        tl._enabled = True
+        tl.init_schema()
+        return tl
+
+    async def test_end_session_clears_session_id(self):
+        tl = self._make_logger()
+        tl.start_session(SessionConfig())
+        self.assertIsNotNone(tl.session_id)
+
+        result = SessionResult(duration_seconds=10.0)
+        tl.end_session(result, status="success")
+        self.assertIsNone(tl.session_id)
+
+    async def test_end_session_twice_no_crash(self):
+        """Calling end_session twice should not raise (idempotent)."""
+        tl = self._make_logger()
+        tl.start_session(SessionConfig())
+
+        result = SessionResult(duration_seconds=5.0)
+        tl.end_session(result, status="success")
+        # Second call should be a no-op (session_id is None now)
+        tl.end_session(result, status="success")
+        self.assertIsNone(tl.session_id)
+
+
+# ── Session duration_seconds persistence ──
+
+
+class TestSessionDurationPersistence(CaseWithDB):
+    def _make_logger(self):
+        tl = TrainingLogger()
+        tl._enabled = True
+        tl.init_schema()
+        return tl
+
+    async def test_duration_seconds_stored(self):
+        tl = self._make_logger()
+        sid = tl.start_session(SessionConfig())
+
+        result = SessionResult(duration_seconds=123.45)
+        tl.end_session(result, status="success")
+
+        session = tl.get_session(sid)
+        self.assertIsNotNone(session)
+        self.assertAlmostEqual(session["duration_seconds"], 123.45, places=1)
+
+    async def test_duration_seconds_in_result(self):
+        tl = self._make_logger()
+        sid = tl.start_session(SessionConfig())
+
+        result = SessionResult(total_ticks=10, duration_seconds=60.0)
+        tl.end_session(result, status="success")
+
+        session = tl.get_session(sid)
+        self.assertAlmostEqual(session["result"]["duration_seconds"], 60.0, places=1)
+
+
+# ── Host.broadcast finalizes session on mission events ──
+
+
+class TestBroadcastFinalizesSession(unittest.TestCase):
+    def test_mission_success_ends_session(self):
+        host = _make_host()
+        host._session_start_time = time.monotonic() - 30.0
+
+        with patch("app.host.training_logger") as mock_tl:
+            mock_tl.maybe_log_broadcast_event = MagicMock()
+            mock_tl.end_session = MagicMock()
+
+            with patch("app.host.broadcaster") as mock_bc:
+                mock_bc.send = AsyncMock()
+                msg = {
+                    "name": "mission_success",
+                    "source": "world",
+                    "type": "event",
+                    "payload": {"collected_quantity": 300},
+                }
+                asyncio.run(host.broadcast(msg))
+
+            mock_tl.end_session.assert_called_once()
+            call_args = mock_tl.end_session.call_args
+            result = call_args[0][0]
+            self.assertIsInstance(result, SessionResult)
+            self.assertEqual(call_args[1]["status"], "success")
+            self.assertGreater(result.duration_seconds, 0.0)
+
+    def test_mission_failed_ends_session(self):
+        host = _make_host()
+        host._session_start_time = time.monotonic() - 15.0
+
+        with patch("app.host.training_logger") as mock_tl:
+            mock_tl.maybe_log_broadcast_event = MagicMock()
+            mock_tl.end_session = MagicMock()
+
+            with patch("app.host.broadcaster") as mock_bc:
+                mock_bc.send = AsyncMock()
+                msg = {
+                    "name": "mission_failed",
+                    "source": "world",
+                    "type": "event",
+                    "payload": {},
+                }
+                asyncio.run(host.broadcast(msg))
+
+            mock_tl.end_session.assert_called_once()
+            self.assertEqual(mock_tl.end_session.call_args[1]["status"], "failed")
+
+    def test_regular_event_does_not_end_session(self):
+        host = _make_host()
+
+        with patch("app.host.training_logger") as mock_tl:
+            mock_tl.maybe_log_broadcast_event = MagicMock()
+            mock_tl.end_session = MagicMock()
+
+            with patch("app.host.broadcaster") as mock_bc:
+                mock_bc.send = AsyncMock()
+                msg = {
+                    "name": "state",
+                    "source": "world",
+                    "type": "event",
+                    "payload": {},
+                }
+                asyncio.run(host.broadcast(msg))
+
+            mock_tl.end_session.assert_not_called()

--- a/ui/src/pages/SimulationPage.vue
+++ b/ui/src/pages/SimulationPage.vue
@@ -216,6 +216,7 @@ useKeyboard({
       :world-state="worldState"
       :agent-ids="agentIds"
       :event-count="events.length"
+      :paused="paused"
     />
 
     <div class="top-row">


### PR DESCRIPTION
## Summary

Add elapsed time tracking to simulation snapshots, persist run duration in the training_session database table, and verify all control buttons (RESET, PAUSE, ABORT, Voice ON/OFF) work correctly end-to-end.

## Change Type

- [x] `feat` — New feature
- [x] `test` — Adding or updating tests

## Semantic Diff

### Added
- `server/tests/test_elapsed_time.py` — 19 tests covering elapsed time calculation, pause tracking, snapshot integration, session finalization, duration persistence, broadcast hooks, and end_session idempotency

### Changed
- `server/app/host.py` — Convert `paused` to `@property` with pause/resume timestamp tracking; add `get_elapsed_seconds()` method; register elapsed provider on `start()`/`stop()`; auto-finalize training sessions on `mission_success`/`mission_failed` in `broadcast()`; finalize on `abort_mission()`
- `server/app/world.py` — Add `_elapsed_provider` callback, `set_elapsed_provider()` function, and `elapsed_seconds` field in `get_snapshot()`
- `server/app/training_logger.py` — Add `duration_seconds` schema field; update `end_session()` query to persist duration; add idempotency guard (`self._session_id = None` in `finally`)
- `ui/src/pages/SimulationPage.vue` — Pass `:paused="paused"` prop to StatsBar for timer synchronization
- `Changelog.md` — Add v0.6.0 entry

### Removed
- (none)

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 1 |
| Files modified | 5 |
| Files deleted | 0 |
| Lines added | +385 |
| Lines removed | -4 |

### Core Files Modified
- `server/app/host.py` (+57 / -3) — Pause-aware elapsed time tracking, session finalization hooks
- `server/app/world.py` (+17 / -0) — Elapsed provider callback + snapshot field
- `server/app/training_logger.py` (+6 / -1) — Duration persistence + idempotency guard
- `ui/src/pages/SimulationPage.vue` (+1 / -0) — Paused prop binding

### Tests
- `server/tests/test_elapsed_time.py` (+280 / -0) — 19 new tests

## How to Test

1. `cd server && uv sync && uv run rut tests/` — all 565 tests pass
2. `cd ui && npm install && npm run build` — UI builds cleanly
3. Start simulation → verify MM:SS timer appears in StatsBar
4. Click PAUSE → timer stops; click PAUSE again → timer resumes (no lost time)
5. Let simulation finish → check SurrealDB `training_session` table has `duration_seconds > 0`
6. Click ABORT → verify session finalized with result "aborted" and duration stored
7. Click RESET → verify simulation resets cleanly, timer back to 00:00

## Changelog

### [0.6.0] — Simulation Timer, Duration Tracking & Control Verification (2026-03-01)

#### Features
* **server:** add elapsed time tracking to simulation snapshots — `elapsed_seconds` field in world snapshot, synced to UI every tick
* **server:** implement pause-aware elapsed time — `Host.paused` converted to `@property` with automatic pause/resume timestamp tracking
* **server:** store `duration_seconds` in SurrealDB `training_session` table on session finalization (success, failure, or abort)
* **server:** auto-finalize training sessions on `mission_success`, `mission_failed`, and abort events with full `SessionResult`
* **server:** idempotent session finalization — `end_session()` guard prevents double-finalize errors
* **ui:** pass `:paused` prop to StatsBar for timer pause synchronization

#### Tests
* **test_elapsed_time:** 19 new tests

#### Control Buttons Verified
* RESET, PAUSE, ABORT, and Voice ON/OFF — all verified working end-to-end

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>