### PR TITLE
fix: increase agent intervals to avoid 429 rate limits

### DIFF
--- a/server/app/config.py
+++ b/server/app/config.py
@@ -34,8 +34,8 @@ class Settings(BaseSettings):
 
     # Simulation timing
     agent_turn_interval_seconds: float = Field(default=0.5, gt=0)
-    llm_turn_interval_seconds: float = Field(default=3.0, gt=0)
-    drone_turn_interval_seconds: float = Field(default=2.5, gt=0)
+    llm_turn_interval_seconds: float = Field(default=4.0, gt=0)
+    drone_turn_interval_seconds: float = Field(default=3.5, gt=0)
 
     # World generation seed (empty = random)
     world_seed: str = ""

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -12,7 +12,7 @@ class TestDroneTurnIntervalSetting(unittest.TestCase):
 
     def test_default_value(self):
         s = Settings(mistral_api_key="test")
-        self.assertEqual(s.drone_turn_interval_seconds, 2.5)
+        self.assertEqual(s.drone_turn_interval_seconds, 3.5)
 
     def test_custom_value(self):
         s = Settings(mistral_api_key="test", drone_turn_interval_seconds=10.0)


### PR DESCRIPTION
## Summary
Previous 3s/2.5s intervals caused ~42% of Mistral API calls to hit 429 rate limits. Adjusted to 4s/3.5s (~32 calls/min) for reliable operation.

## Changes
| File | Change |
|------|--------|
| `server/app/config.py` | llm_turn_interval 3→4s, drone_turn_interval 2.5→3.5s |
| `server/tests/test_config.py` | Update default assertion |

Co-Authored-By: agent-one team <agent-one@yanok.ai>