### PR TITLE
feat: re-enable rover-2 on HuggingFace Qwen3-32B for multi-rover cooperation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@
 * **ui:** deposit events shown in EventLog with 📦 icon and toast notifications
 * **agent:** rover prompt now explains auto-delivery and shows delivered/target progress
 * **world:** task planner prioritizes "Return to station" when inventory is full
+* **agent:** re-enable rover-2 powered by HuggingFace Inference API (Qwen/Qwen3-32B) — separate LLM provider from rover-mistral to avoid Mistral rate limits
+* **config:** upgrade default HuggingFace model from Qwen2.5-72B to Qwen3-32B
 
 ### Bug Fixes
 

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -29,8 +29,8 @@ class Settings(BaseSettings):
     hugging_face_read: str = ""
     hugging_face_write: str = ""
     llm_provider: str = "mistral"  # "mistral" or "huggingface"
-    huggingface_model: str = "Qwen/Qwen2.5-72B-Instruct"
-    huggingface_narration_model: str = "Qwen/Qwen2.5-72B-Instruct"
+    huggingface_model: str = "Qwen/Qwen3-32B"
+    huggingface_narration_model: str = "Qwen/Qwen3-32B"
 
     # Simulation timing
     agent_turn_interval_seconds: float = Field(default=0.5, gt=0)
@@ -40,8 +40,8 @@ class Settings(BaseSettings):
     # World generation seed (empty = random)
     world_seed: str = ""
 
-    # Active agents (comma-separated; rover-2 available but inactive to reduce API load)
-    active_agents: str = "rover-mistral,drone-mistral,station-loop"
+    # Active agents (comma-separated)
+    active_agents: str = "rover-mistral,rover-2,drone-mistral,station-loop"
 
     # ElevenLabs narration
     elevenlabs_api_key: str = ""

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -42,7 +42,7 @@ AGENT_MAP = {
     "rover-mistral": lambda: RoverMistralLoop(
         agent_id="rover-mistral", interval=settings.llm_turn_interval_seconds
     ),
-    "rover-2": lambda: RoverMistralLoop(
+    "rover-2": lambda: RoverHuggingFaceLoop(
         agent_id="rover-2", interval=settings.llm_turn_interval_seconds
     ),
     "drone-mistral": lambda: DroneMistralLoop(interval=settings.drone_turn_interval_seconds),

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -477,6 +477,7 @@ def _build_initial_world():
                 "memory": [],
             },
             "rover-mistral": _make_rover(0, 0),
+            "rover-2": _make_rover(0, 0),
             "drone-mistral": _make_drone(0, 0),
         },
         "stones": [],


### PR DESCRIPTION
## Summary

Re-enable rover-2 using HuggingFace Inference API with Qwen/Qwen3-32B as the LLM provider, enabling two rovers to operate simultaneously without shared rate limits (Mistral for rover-mistral, HuggingFace for rover-2).

## Change Type

- [x] `feat` — New feature

## Semantic Diff

### Added
- `server/app/world.py` — Re-added `rover-2` agent to `_build_initial_world()` at position (0,0)
- `Changelog.md` — Two entries in [Unreleased]: rover-2 re-enablement & Qwen3-32B upgrade

### Changed
- `server/app/config.py` — Updated `huggingface_model` from `Qwen/Qwen2.5-72B-Instruct` → `Qwen/Qwen3-32B`, updated `huggingface_narration_model` similarly, re-added `rover-2` to `active_agents`
- `server/app/main.py` — Switched rover-2 factory from `RoverMistralLoop` → `RoverHuggingFaceLoop` in `AGENT_MAP`

### Removed
- N/A

## File Impact

| Metric | Count |
|--------|-------|
| Files added | 0 |
| Files modified | 4 |
| Files deleted | 0 |
| Lines added | +8 |
| Lines removed | -5 |

### Core Files Modified
- `server/app/config.py` — HuggingFace model names + active_agents list
- `server/app/main.py` — rover-2 agent factory mapping
- `server/app/world.py` — rover-2 initial world state

### Tests
- No test files added or modified (existing 590 tests all pass, including 37 HuggingFace-specific tests)

## How to Test

1. Set `HUGGING_FACE_READ` env var with a valid HuggingFace API token
2. Run `cd server && uv run rut tests/` — all 590 tests should pass
3. Start the server (`./run`) and observe both `rover-mistral` and `rover-2` agents spawning in the simulation
4. Check WebSocket events for `rover-2` actions powered by Qwen3-32B

## Changelog

### [Unreleased]
- Re-enabled rover-2 with HuggingFace Inference API (Qwen/Qwen3-32B) for multi-rover cooperation without shared rate limits
- Upgraded HuggingFace model from Qwen2.5-72B-Instruct to Qwen3-32B for better tool-calling support

---

Co-Authored-By: agent-one team <agent-one@yanok.ai>