### PR TITLE
fix(ci): start SurrealDB during pytest runs

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -74,6 +74,16 @@ async def rut_session_teardown():
         _surreal_log_file = None
 
 
+def pytest_sessionstart(session):
+    """Pytest hook: start test SurrealDB once per test session."""
+    asyncio.run(rut_session_setup())
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Pytest hook: stop test SurrealDB once per test session."""
+    asyncio.run(rut_session_teardown())
+
+
 class CaseWithDB(unittest.IsolatedAsyncioTestCase):
     """Base test case with real SurrealDB, calling handlers directly."""
 


### PR DESCRIPTION
## Why
After replacing rut with pytest, test session setup for in-memory SurrealDB was no longer invoked, causing ConnectionRefusedError on localhost:8009 in CI.

## What
- add pytest session hooks in server/tests/conftest.py
  - pytest_sessionstart -> start in-memory SurrealDB
  - pytest_sessionfinish -> teardown SurrealDB

## Validation
- uv run pytest tests/test_training_logger.py tests/test_elapsed_time.py -q
- result: 37 passed