### PR TITLE
fix(deps): patch glob CLI advisory

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mars-ui",
-      "version": "0.4.0",
+      "version": "0.7.0",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/space-grotesk": "^5.2.8",
@@ -3066,9 +3066,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmmirror.com/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Summary
- run npm audit fix for ui lockfile
- updates transitive glob to patched version range

## Security
- addresses Dependabot alert #1 (GHSA-5j98-mcp5-4vw2)

## Validation
- npm audit now reports 0 vulnerabilities in ui