### PR TITLE
feat(station): enable command issuing via recall routing

### DIFF
--- a/server/app/host.py
+++ b/server/app/host.py
@@ -218,6 +218,22 @@ class Host:
                     },
                 )
 
+            # Route recall command to target agent inbox
+            if action["name"] == "recall_agent" and action_result.get("ok"):
+                target_id = action["params"]["agent_id"]
+                self.send_command(
+                    target_id,
+                    {
+                        "name": "recall",
+                        "payload": {
+                            "reason": action["params"].get(
+                                "reason", "Emergency recall from station"
+                            ),
+                        },
+                        "id": correlation_id or "",
+                    },
+                )
+
             # Broadcast to UI
             if action["name"] == "broadcast_alert":
                 msg = make_message(

--- a/server/app/station.py
+++ b/server/app/station.py
@@ -70,7 +70,29 @@ CHARGE_AGENT_TOOL = {
     },
 }
 
-STATION_TOOLS = [ASSIGN_MISSION_TOOL, BROADCAST_ALERT_TOOL, CHARGE_AGENT_TOOL]
+RECALL_AGENT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "recall_agent",
+        "description": "Issue an emergency recall command so an agent returns to station immediately.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "The agent to recall (e.g. 'rover-mistral', 'drone-mistral', 'hauler-mistral').",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Short reason for the recall command.",
+                },
+            },
+            "required": ["agent_id"],
+        },
+    },
+}
+
+STATION_TOOLS = [ASSIGN_MISSION_TOOL, BROADCAST_ALERT_TOOL, CHARGE_AGENT_TOOL, RECALL_AGENT_TOOL]
 
 SYSTEM_PROMPT = (
     "You are the Mars base station. You coordinate the Mars mission.\n"
@@ -95,6 +117,7 @@ SYSTEM_PROMPT = (
     "Keep responses short (1-2 sentences of reasoning, then act).\n"
     "Always assign missions to all available agents when defining the initial mission.\n"
     "When an agent arrives at the station with low battery, charge it.\n"
+    "If an agent is critically low, stuck, or in danger, issue a recall command.\n"
     "\n"
     "DRONE COORDINATION:\n"
     "- When you have multiple drones, send each to a DIFFERENT sector of the map.\n"
@@ -160,6 +183,8 @@ def _parse_tool_calls(tool_calls):
             actions.append({"name": "broadcast_alert", "params": args})
         elif name == "charge_agent":
             actions.append({"name": "charge_agent", "params": args})
+        elif name == "recall_agent":
+            actions.append({"name": "recall_agent", "params": args})
     return actions
 
 
@@ -173,6 +198,12 @@ def execute_action(action):
         return charge_agent(params["agent_id"])
     elif name == "broadcast_alert":
         return {"ok": True, "message": params["message"]}
+    elif name == "recall_agent":
+        return {
+            "ok": True,
+            "agent_id": params["agent_id"],
+            "reason": params.get("reason", "Emergency recall from station"),
+        }
     return {"ok": False, "error": f"Unknown station action: {name}"}
 
 

--- a/server/tests/test_host.py
+++ b/server/tests/test_host.py
@@ -148,6 +148,35 @@ class TestHostStationRouting(unittest.TestCase):
                 # Verify broadcast was called
                 mock_bc.send.assert_called()
 
+    def test_route_station_actions_recall_agent(self):
+        host = _make_host()
+        host.register(_dummy("rover-mock"))
+
+        result = {
+            "thinking": None,
+            "actions": [
+                {
+                    "name": "recall_agent",
+                    "params": {"agent_id": "rover-mock", "reason": "Storm incoming"},
+                },
+            ],
+        }
+
+        with patch("app.host.station_execute_action") as mock_exec:
+            mock_exec.return_value = {
+                "ok": True,
+                "agent_id": "rover-mock",
+                "reason": "Storm incoming",
+            }
+            with patch("app.host.broadcaster") as mock_bc:
+                mock_bc.send = AsyncMock()
+                asyncio.run(host.route_station_actions(result))
+
+        commands = host.drain_inbox("rover-mock")
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0]["name"], "recall")
+        self.assertEqual(commands[0]["payload"]["reason"], "Storm incoming")
+
 
 class TestHostAbortMission(unittest.TestCase):
     def setUp(self):

--- a/server/tests/test_station.py
+++ b/server/tests/test_station.py
@@ -250,6 +250,14 @@ class TestParseToolCalls(unittest.TestCase):
         self.assertEqual(actions[0]["name"], "charge_agent")
         self.assertEqual(actions[0]["params"]["agent_id"], "rover-mistral")
 
+    def test_recall_agent_parsed(self):
+        tool_calls = [_mock_tool_call("recall_agent", {"agent_id": "rover-mistral", "reason": "Storm"})]
+        actions = _parse_tool_calls(tool_calls)
+
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0]["name"], "recall_agent")
+        self.assertEqual(actions[0]["params"]["agent_id"], "rover-mistral")
+
     def test_multiple_tool_calls_parsed(self):
         tool_calls = [
             _mock_tool_call("assign_mission", {"agent_id": "rover-mistral", "objective": "Go"}),
@@ -292,6 +300,16 @@ class TestExecuteAction(unittest.TestCase):
             }
         )
         self.assertTrue(result["ok"])
+
+    def test_recall_agent(self):
+        result = execute_action(
+            {
+                "name": "recall_agent",
+                "params": {"agent_id": "rover-mistral", "reason": "Battery critical"},
+            }
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["agent_id"], "rover-mistral")
 
     def test_unknown_action(self):
         result = execute_action(

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -430,7 +430,7 @@ wheels = [
 
 [[package]]
 name = "mars"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "elevenlabs" },


### PR DESCRIPTION
## Summary
- add recall_agent station tool
- parse and execute station recall_agent actions
- route recall actions through Host into target agent inbox (recall command)
- add tests for station tool parsing/execution and host routing

## Validation
- uv run pytest tests/test_station.py tests/test_host.py -q
- result: 50 passed