### PR TITLE
feat(power-allocation): add allocate_power station tool with budget events and UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,10 @@ Every PR description **must** follow the template in `.github/PULL_REQUEST_TEMPL
 - Node 24 LTS, uv package manager
 - Python 3.14+ (server), JavaScript/Vue 3 (UI) + FastAPI, Pydantic, Mistral AI SDK (server); Vue 3, Vite (UI) (181-goal-confidence-tracking)
 - SurrealDB (runtime), in-memory WORLD dict (simulation state) (181-goal-confidence-tracking)
+- Python 3.14+ + Pydantic v2 (BaseModel, Field, Literal, field_validator, TypeAdapter), FastAPI, mistralai (182-pydantic-refactor)
+- SurrealDB on port 4002 (unchanged by this refactor) (182-pydantic-refactor)
+- Python 3.14+ (server), JavaScript/Vue 3 (UI) + FastAPI, Pydantic v2, mistralai SDK, Vue 3, Vite (182-pydantic-refactor)
+- In-memory WORLD dict (simulation state), SurrealDB on port 4002 (unchanged) (182-pydantic-refactor)
 
 ## Recent Changes
 - 181-goal-confidence-tracking: Added Python 3.14+ (server), JavaScript/Vue 3 (UI) + FastAPI, Pydantic, Mistral AI SDK (server); Vue 3, Vite (UI)

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,17 @@
 
 ### Features
 
+* **power-allocation:** add `allocate_power(agent_id, amount)` tool to station agent — sets minimum battery threshold per agent, stored in `WORLD["power_budgets"]`
+* **power-allocation:** add `check_power_budgets()` tick-loop monitor — emits `PowerBudgetWarning` events when agent battery drops below allocated threshold (3-tick debounce)
+* **power-allocation:** add `EmergencyModeActivated`/`EmergencyModeDeactivated` events when total power demand exceeds `STATION_POWER_CAPACITY`
+* **power-allocation:** update station system prompt with POWER MANAGEMENT section — guides LLM on budget allocation strategy and event responses
+* **power-allocation:** add `PowerBudgetBar.vue` component (blue inline bar) and integrate in `AgentPane.vue` — conditionally displayed when budget is set
+* **power-allocation:** expose `power_budgets` and `emergency_mode` in `StationContext`, world snapshot, and `_build_world_summary()`
+
+### Tests
+
+* **power-allocation:** add 35 tests in `test_power_budget.py` (9 allocate_power, 8 warnings, 6 emergency mode, 12 context/prompt)
+
 * **goal-confidence:** add `goal_confidence` (float 0.0-1.0) to all agent states — initialized at 0.5 on mission assignment, updated deterministically after each action (+0.05 success, -0.05 failure, -0.08 fallback/hazard, +0.10 delivery), clamped to [0.0, 1.0], resets on mission reassignment
 * **goal-confidence:** expose `goal_confidence` in observation contexts (`observe_rover`, `observe_hauler`, `observe_station`) so LLM agents can introspect on their own confidence
 * **goal-confidence:** add `goal_confidence` to `RoverSummary` so station agent sees confidence of all field agents

--- a/server/app/agent.py
+++ b/server/app/agent.py
@@ -51,6 +51,7 @@ from .world import (
     update_tasks,
 )
 from .world import check_storm_tick, get_storm_info, update_goal_confidence
+from .world import record_memory
 from .world import is_obstacle_at
 from .station import StationAgent
 from .training_logger import training_logger
@@ -1919,7 +1920,7 @@ class RoverLoop(BaseAgent):
         t0 = time.monotonic()
         turn = await asyncio.to_thread(self._reasoner.run_turn)
         llm_ms = int((time.monotonic() - t0) * 1000)
-        next_tick()
+        _tick, _power_events = next_tick()
 
         # Advance storm lifecycle and broadcast any storm events
         storm_events = check_storm_tick()
@@ -1931,6 +1932,26 @@ class RoverLoop(BaseAgent):
                 payload=sevt["payload"],
             )
             await host.broadcast(storm_msg.to_dict())
+
+        # Broadcast power budget events (warnings + emergency mode transitions)
+        for pevt in _power_events:
+            ename = pevt["type"]
+            payload = {k: v for k, v in pevt.items() if k != "type"}
+            power_msg = make_message(source="world", type="event", name=ename, payload=payload)
+            await host.broadcast(power_msg.to_dict())
+            # Record warnings in station memory so station LLM sees them
+            if ename == "power_budget_warning":
+                record_memory(
+                    "station",
+                    f"PowerBudgetWarning: {pevt['agent_id']} battery {pevt['battery']:.0%} "
+                    f"below budget {pevt['budget']:.0%}",
+                )
+            elif ename == "emergency_mode_activated":
+                record_memory(
+                    "station", "EMERGENCY MODE ACTIVATED — total power demand exceeds capacity"
+                )
+            elif ename == "emergency_mode_deactivated":
+                record_memory("station", "Emergency mode deactivated — power demand normalized")
 
         geyser_events = update_geysers()
         messages = []
@@ -2274,7 +2295,7 @@ class DroneLoop(BaseAgent):
         _llm_ms = int((time.monotonic() - _t0) * 1000)
         _action_result = {}
         _action_ok = False
-        next_tick()
+        _tick, _power_events = next_tick()
         messages = []
 
         if turn["thinking"]:
@@ -2460,7 +2481,7 @@ class HaulerLoop(BaseAgent):
             return
 
         turn = await asyncio.to_thread(self._reasoner.run_turn)
-        next_tick()
+        _tick, _power_events = next_tick()
 
         messages = []
         if turn["thinking"]:

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -215,6 +215,8 @@ class StationContext(BaseModel):
     water_collected: int = 0
     gas_collected: int = 0
     station_resources: StationResources | None = None
+    power_budgets: dict[str, float] = {}
+    emergency_mode: bool = False
 
 
 # ── Hauler Context ──

--- a/server/app/station.py
+++ b/server/app/station.py
@@ -8,7 +8,7 @@ from mistralai import Mistral
 
 from .config import settings
 from .models import StationContext
-from .world import assign_mission, charge_agent
+from .world import allocate_power, assign_mission, charge_agent
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,35 @@ RECALL_AGENT_TOOL = {
     },
 }
 
-STATION_TOOLS = [ASSIGN_MISSION_TOOL, BROADCAST_ALERT_TOOL, CHARGE_AGENT_TOOL, RECALL_AGENT_TOOL]
+ALLOCATE_POWER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "allocate_power",
+        "description": "Set a power budget for an agent. Defines the minimum battery threshold to maintain. A PowerBudgetWarning event fires when the agent's battery drops below this level.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "The agent to set a power budget for (e.g. 'rover-mistral', 'drone-mistral').",
+                },
+                "amount": {
+                    "type": "number",
+                    "description": "Minimum battery threshold (0.0-1.0). Agent receives warnings below this level.",
+                },
+            },
+            "required": ["agent_id", "amount"],
+        },
+    },
+}
+
+STATION_TOOLS = [
+    ASSIGN_MISSION_TOOL,
+    BROADCAST_ALERT_TOOL,
+    CHARGE_AGENT_TOOL,
+    RECALL_AGENT_TOOL,
+    ALLOCATE_POWER_TOOL,
+]
 
 SYSTEM_PROMPT = (
     "You are the Mars base station. You coordinate the Mars mission.\n"
@@ -128,6 +156,13 @@ SYSTEM_PROMPT = (
     "- Assign haulers to patrol near rovers that are furthest from station.\n"
     "- When a rover's inventory is full (3 items), direct the hauler to collect from it.\n"
     "- This keeps rovers exploring instead of returning to station to deliver.\n"
+    "\n"
+    "POWER MANAGEMENT:\n"
+    "- Use allocate_power to set minimum battery thresholds for agents.\n"
+    "- Set budgets at mission start: 0.2-0.3 for rovers, 0.3-0.4 for drones.\n"
+    "- When you receive a PowerBudgetWarning, recall the affected agent or prioritize charging.\n"
+    "- When EmergencyModeActivated fires, recall all low-battery agents immediately.\n"
+    "- Adjust budgets based on mission progress and distance from station.\n"
 )
 
 
@@ -158,6 +193,13 @@ def _build_world_summary(context: StationContext):
             f"  {rover.id} ({label}): pos=({x},{y}) battery={rover.battery:.0%} "
             f'mission="{rover.mission.objective}" visited={rover.visited_count}'
         )
+    # Power budgets
+    power_budgets = getattr(context, "power_budgets", {})
+    if power_budgets:
+        budget_parts = [f"{aid}={bud:.0%}" for aid, bud in power_budgets.items()]
+        lines.append(f"Power budgets: {', '.join(budget_parts)}")
+    if getattr(context, "emergency_mode", False):
+        lines.append("*** EMERGENCY MODE ACTIVE — total power demand exceeds station capacity ***")
     lines.append(f"Veins on map: {len(context.stones)}")
     for s in context.stones:
         grade_str = f" grade={s.grade}" if s.grade != "unknown" else ""
@@ -185,6 +227,8 @@ def _parse_tool_calls(tool_calls):
             actions.append({"name": "charge_agent", "params": args})
         elif name == "recall_agent":
             actions.append({"name": "recall_agent", "params": args})
+        elif name == "allocate_power":
+            actions.append({"name": "allocate_power", "params": args})
     return actions
 
 
@@ -204,6 +248,8 @@ def execute_action(action):
             "agent_id": params["agent_id"],
             "reason": params.get("reason", "Emergency recall from station"),
         }
+    elif name == "allocate_power":
+        return allocate_power(params["agent_id"], params["amount"])
     return {"ok": False, "error": f"Unknown station action: {name}"}
 
 

--- a/server/app/world.py
+++ b/server/app/world.py
@@ -78,6 +78,8 @@ BATTERY_COST_ANALYZE = 3 / FUEL_CAPACITY_ROVER  # 3 fuel units
 BATTERY_COST_SCAN = 2 / FUEL_CAPACITY_DRONE  # 2 fuel units
 BATTERY_COST_NOTIFY = 2 / FUEL_CAPACITY_ROVER  # 2 fuel units (radio notification)
 CHARGE_RATE = 0.20
+STATION_POWER_CAPACITY = 1.0  # max aggregate power deficit the station can service per cycle
+POWER_WARN_COOLDOWN = 3  # ticks between repeated warnings for the same agent
 MAX_MOVE_DISTANCE = 3
 MAX_MOVE_DISTANCE_DRONE = 6
 MAX_MOVE_DISTANCE_HAULER = 2
@@ -749,6 +751,9 @@ def _build_initial_world():
             "gas_collected": 0,
         },
         "storm": storm_mod.make_storm_state(),
+        "power_budgets": {},
+        "emergency_mode": False,
+        "_power_warn_ticks": {},
     }
     return world
 
@@ -1010,10 +1015,12 @@ def reset_world():
 
 
 def next_tick():
-    """Increment and return the current tick number."""
+    """Increment and return the current tick number and any power budget events."""
     WORLD["tick"] += 1
     apply_structure_passive_effects()
-    return WORLD["tick"]
+    tick = WORLD["tick"]
+    power_events = check_power_budgets(tick)
+    return tick, power_events
 
 
 def update_geysers():
@@ -1911,8 +1918,113 @@ def charge_agent(agent_id):
     return result
 
 
+def _execute_allocate_power(agent_id, amount):
+    """Set a power budget (minimum battery threshold) for an agent."""
+    agent = WORLD["agents"].get(agent_id)
+    if agent is None:
+        return {"ok": False, "error": f"Unknown agent: {agent_id}"}
+    if agent.get("type") == "station":
+        return {"ok": False, "error": "Cannot set power budget for station"}
+    amount = max(0.0, min(1.0, amount))
+    previous = WORLD["power_budgets"].get(agent_id)
+    WORLD["power_budgets"][agent_id] = amount
+    logger.info("Power budget for %s set to %.0f%%", agent_id, amount * 100)
+    return {
+        "ok": True,
+        "agent_id": agent_id,
+        "amount": amount,
+        "previous": previous,
+    }
+
+
+def allocate_power(agent_id, amount):
+    """Station-initiated power budget allocation."""
+    result = _execute_allocate_power(agent_id, amount)
+    if result["ok"]:
+        record_memory("station", f"Set power budget for {agent_id} to {result['amount']:.0%}")
+    return result
+
+
 # Backward-compat alias
 charge_rover = charge_agent
+
+
+def check_power_budgets(tick):
+    """Check all power budgets and return event dicts for warnings/emergency transitions."""
+    events = []
+    budgets = WORLD.get("power_budgets", {})
+    if not budgets:
+        # If no budgets set but emergency mode was on, deactivate
+        if WORLD.get("emergency_mode"):
+            WORLD["emergency_mode"] = False
+            events.append(
+                {
+                    "type": "emergency_mode_deactivated",
+                    "total_demand": 0.0,
+                    "capacity": STATION_POWER_CAPACITY,
+                }
+            )
+        return events
+
+    warn_ticks = WORLD.setdefault("_power_warn_ticks", {})
+    total_demand = 0.0
+    agents_in_deficit = []
+
+    for agent_id, budget in budgets.items():
+        agent = WORLD["agents"].get(agent_id)
+        if agent is None:
+            continue
+        battery = agent.get("battery", 0.0)
+        deficit = max(0.0, budget - battery)
+        if deficit > 0:
+            total_demand += deficit
+            agents_in_deficit.append(
+                {
+                    "agent_id": agent_id,
+                    "battery": round(battery, 3),
+                    "budget": budget,
+                    "deficit": round(deficit, 3),
+                }
+            )
+            # Debounce: emit warning only if cooldown expired
+            last_warn = warn_ticks.get(agent_id, -POWER_WARN_COOLDOWN)
+            if tick - last_warn >= POWER_WARN_COOLDOWN:
+                warn_ticks[agent_id] = tick
+                events.append(
+                    {
+                        "type": "power_budget_warning",
+                        "agent_id": agent_id,
+                        "battery": round(battery, 3),
+                        "budget": budget,
+                        "deficit": round(deficit, 3),
+                    }
+                )
+
+    # Emergency mode transitions
+    was_emergency = WORLD.get("emergency_mode", False)
+    is_emergency = total_demand > STATION_POWER_CAPACITY
+
+    if is_emergency and not was_emergency:
+        WORLD["emergency_mode"] = True
+        events.append(
+            {
+                "type": "emergency_mode_activated",
+                "total_demand": round(total_demand, 3),
+                "capacity": STATION_POWER_CAPACITY,
+                "agents_in_deficit": agents_in_deficit,
+            }
+        )
+    elif not is_emergency and was_emergency:
+        WORLD["emergency_mode"] = False
+        events.append(
+            {
+                "type": "emergency_mode_deactivated",
+                "total_demand": round(total_demand, 3),
+                "capacity": STATION_POWER_CAPACITY,
+            }
+        )
+
+    return events
 
 
 # --- Agent setters (seal direct WORLD writes from other modules) ---
@@ -3255,6 +3367,8 @@ def observe_station():
         collected_quantity=mission.get("collected_quantity", 0),
         target_quantity=mission.get("target_quantity", TARGET_QUANTITY),
         station_resources=station_resources,
+        power_budgets=WORLD.get("power_budgets", {}),
+        emergency_mode=WORLD.get("emergency_mode", False),
     )
 
 
@@ -3330,6 +3444,8 @@ def get_snapshot():
         if tuple(item.get("position", [])) in revealed:
             visible_ground_items.append(item)
     snap["ground_items"] = visible_ground_items
+    # Strip internal power budget tracking (not for UI)
+    snap.pop("_power_warn_ticks", None)
     # Include agent messages for UI visibility
     snap["agent_messages"] = copy.deepcopy(AGENT_MESSAGES)
     # Ensure bounds are present

--- a/server/tests/test_power_budget.py
+++ b/server/tests/test_power_budget.py
@@ -1,0 +1,241 @@
+"""Tests for station power allocation and budget monitoring."""
+
+import pytest
+
+from app.world import (
+    WORLD,
+    allocate_power,
+    check_power_budgets,
+    reset_world,
+    STATION_POWER_CAPACITY,
+    POWER_WARN_COOLDOWN,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_world():
+    """Reset WORLD state before and after each test."""
+    reset_world()
+    yield
+    reset_world()
+
+
+# ── T006: allocate_power tool tests ──────────────────────────────────────────
+
+
+class TestAllocatePower:
+    """T006: allocate_power tool tests."""
+
+    def test_valid_allocation_sets_budget(self):
+        result = allocate_power("rover-mistral", 0.3)
+        assert result["ok"] is True
+        assert result["agent_id"] == "rover-mistral"
+        assert result["amount"] == 0.3
+        assert result["previous"] is None
+        assert WORLD["power_budgets"]["rover-mistral"] == 0.3
+
+    def test_update_overwrites_previous(self):
+        allocate_power("rover-mistral", 0.3)
+        result = allocate_power("rover-mistral", 0.5)
+        assert result["ok"] is True
+        assert result["previous"] == 0.3
+        assert result["amount"] == 0.5
+        assert WORLD["power_budgets"]["rover-mistral"] == 0.5
+
+    def test_invalid_agent_returns_error(self):
+        result = allocate_power("nonexistent-agent", 0.3)
+        assert result["ok"] is False
+        assert "Unknown agent" in result["error"]
+
+    def test_station_agent_returns_error(self):
+        result = allocate_power("station", 0.3)
+        assert result["ok"] is False
+        assert "station" in result["error"].lower()
+
+    def test_amount_clamped_above_one(self):
+        result = allocate_power("rover-mistral", 1.5)
+        assert result["ok"] is True
+        assert result["amount"] == 1.0
+        assert WORLD["power_budgets"]["rover-mistral"] == 1.0
+
+    def test_amount_clamped_below_zero(self):
+        result = allocate_power("rover-mistral", -0.5)
+        assert result["ok"] is True
+        assert result["amount"] == 0.0
+        assert WORLD["power_budgets"]["rover-mistral"] == 0.0
+
+    def test_boundary_zero(self):
+        result = allocate_power("rover-mistral", 0.0)
+        assert result["ok"] is True
+        assert result["amount"] == 0.0
+
+    def test_boundary_one(self):
+        result = allocate_power("rover-mistral", 1.0)
+        assert result["ok"] is True
+        assert result["amount"] == 1.0
+
+    def test_multiple_agents_independent(self):
+        allocate_power("rover-mistral", 0.3)
+        allocate_power("drone-mistral", 0.4)
+        assert WORLD["power_budgets"]["rover-mistral"] == 0.3
+        assert WORLD["power_budgets"]["drone-mistral"] == 0.4
+
+
+# ── T011: PowerBudgetWarning event tests ─────────────────────────────────────
+
+
+class TestPowerBudgetWarning:
+    """T011: PowerBudgetWarning event tests."""
+
+    def test_warning_emitted_when_battery_below_budget(self):
+        WORLD["power_budgets"]["rover-mistral"] = 0.3
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.2
+        events = check_power_budgets(tick=10)
+        warnings = [e for e in events if e["type"] == "power_budget_warning"]
+        assert len(warnings) == 1
+        assert warnings[0]["agent_id"] == "rover-mistral"
+        assert warnings[0]["battery"] == 0.2
+        assert warnings[0]["budget"] == 0.3
+        assert warnings[0]["deficit"] > 0
+
+    def test_no_warning_when_battery_meets_budget(self):
+        WORLD["power_budgets"]["rover-mistral"] = 0.3
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.5
+        events = check_power_budgets(tick=10)
+        warnings = [e for e in events if e["type"] == "power_budget_warning"]
+        assert len(warnings) == 0
+
+    def test_no_warning_when_battery_equals_budget(self):
+        WORLD["power_budgets"]["rover-mistral"] = 0.3
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.3
+        events = check_power_budgets(tick=10)
+        warnings = [e for e in events if e["type"] == "power_budget_warning"]
+        assert len(warnings) == 0
+
+    def test_debounce_suppresses_warning_within_cooldown(self):
+        WORLD["power_budgets"]["rover-mistral"] = 0.3
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.2
+        events1 = check_power_budgets(tick=10)
+        assert len([e for e in events1 if e["type"] == "power_budget_warning"]) == 1
+        # Within cooldown -- no warning
+        events2 = check_power_budgets(tick=11)
+        assert len([e for e in events2 if e["type"] == "power_budget_warning"]) == 0
+        events3 = check_power_budgets(tick=12)
+        assert len([e for e in events3 if e["type"] == "power_budget_warning"]) == 0
+
+    def test_warning_resumes_after_cooldown(self):
+        WORLD["power_budgets"]["rover-mistral"] = 0.3
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.2
+        check_power_budgets(tick=10)
+        # After cooldown
+        events = check_power_budgets(tick=10 + POWER_WARN_COOLDOWN)
+        warnings = [e for e in events if e["type"] == "power_budget_warning"]
+        assert len(warnings) == 1
+
+    def test_no_events_when_no_budgets_set(self):
+        events = check_power_budgets(tick=10)
+        assert len(events) == 0
+
+    def test_deficit_value_correct(self):
+        WORLD["power_budgets"]["rover-mistral"] = 0.5
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.2
+        events = check_power_budgets(tick=10)
+        warnings = [e for e in events if e["type"] == "power_budget_warning"]
+        assert len(warnings) == 1
+        assert warnings[0]["deficit"] == pytest.approx(0.3)
+
+    def test_multiple_agents_below_budget(self):
+        WORLD["power_budgets"]["rover-mistral"] = 0.5
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.2
+        WORLD["power_budgets"]["drone-mistral"] = 0.4
+        WORLD["agents"]["drone-mistral"]["battery"] = 0.1
+        events = check_power_budgets(tick=10)
+        warnings = [e for e in events if e["type"] == "power_budget_warning"]
+        warned_ids = {w["agent_id"] for w in warnings}
+        assert warned_ids == {"rover-mistral", "drone-mistral"}
+
+
+# ── T012: EmergencyMode event tests ──────────────────────────────────────────
+
+# Agents available for creating high-demand scenarios.
+_FIELD_AGENTS = [
+    "rover-mistral",
+    "rover-2",
+    "drone-mistral",
+    "hauler-mistral",
+    "rover-large",
+    "rover-medium",
+    "rover-codestral",
+]
+
+
+class TestEmergencyMode:
+    """T012: EmergencyMode event tests."""
+
+    def test_emergency_activated_when_demand_exceeds_capacity(self):
+        # Set high budgets for multiple agents with low batteries.
+        for agent_id in _FIELD_AGENTS:
+            WORLD["power_budgets"][agent_id] = 0.5
+            WORLD["agents"][agent_id]["battery"] = 0.1
+        # Total demand = 7 * 0.4 = 2.8 > STATION_POWER_CAPACITY (1.0)
+        events = check_power_budgets(tick=10)
+        activated = [e for e in events if e["type"] == "emergency_mode_activated"]
+        assert len(activated) == 1
+        assert activated[0]["total_demand"] > STATION_POWER_CAPACITY
+        assert WORLD["emergency_mode"] is True
+
+    def test_no_emergency_when_demand_within_capacity(self):
+        WORLD["power_budgets"]["rover-mistral"] = 0.3
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.2
+        # Demand = 0.1 < 1.0
+        events = check_power_budgets(tick=10)
+        activated = [e for e in events if e["type"] == "emergency_mode_activated"]
+        assert len(activated) == 0
+        assert WORLD["emergency_mode"] is False
+
+    def test_emergency_deactivated_when_demand_drops(self):
+        # First activate emergency mode.
+        for agent_id in _FIELD_AGENTS:
+            WORLD["power_budgets"][agent_id] = 0.5
+            WORLD["agents"][agent_id]["battery"] = 0.1
+        check_power_budgets(tick=10)
+        assert WORLD["emergency_mode"] is True
+
+        # Now charge agents to reduce demand below capacity.
+        for agent_id in _FIELD_AGENTS:
+            WORLD["agents"][agent_id]["battery"] = 0.8
+        events = check_power_budgets(tick=14)
+        deactivated = [e for e in events if e["type"] == "emergency_mode_deactivated"]
+        assert len(deactivated) == 1
+        assert WORLD["emergency_mode"] is False
+
+    def test_emergency_flag_toggled_in_world(self):
+        assert WORLD["emergency_mode"] is False
+        for agent_id in _FIELD_AGENTS:
+            WORLD["power_budgets"][agent_id] = 0.5
+            WORLD["agents"][agent_id]["battery"] = 0.1
+        check_power_budgets(tick=10)
+        assert WORLD["emergency_mode"] is True
+
+    def test_emergency_not_triggered_when_demand_equals_capacity(self):
+        # Carefully set up demand exactly equal to capacity.
+        # 2 agents with deficit 0.5 each => demand = 1.0 == STATION_POWER_CAPACITY.
+        WORLD["power_budgets"]["rover-mistral"] = 0.6
+        WORLD["agents"]["rover-mistral"]["battery"] = 0.1
+        WORLD["power_budgets"]["rover-2"] = 0.6
+        WORLD["agents"]["rover-2"]["battery"] = 0.1
+        # demand = 0.5 + 0.5 = 1.0, not strictly greater than 1.0
+        events = check_power_budgets(tick=10)
+        activated = [e for e in events if e["type"] == "emergency_mode_activated"]
+        assert len(activated) == 0
+        assert WORLD["emergency_mode"] is False
+
+    def test_emergency_activated_includes_agents_in_deficit(self):
+        for agent_id in _FIELD_AGENTS:
+            WORLD["power_budgets"][agent_id] = 0.5
+            WORLD["agents"][agent_id]["battery"] = 0.1
+        events = check_power_budgets(tick=10)
+        activated = [e for e in events if e["type"] == "emergency_mode_activated"]
+        assert "agents_in_deficit" in activated[0]
+        deficit_ids = {a["agent_id"] for a in activated[0]["agents_in_deficit"]}
+        assert deficit_ids == set(_FIELD_AGENTS)

--- a/server/tests/test_station.py
+++ b/server/tests/test_station.py
@@ -448,3 +448,88 @@ class TestStationContextFields(unittest.TestCase):
         )
         self.assertEqual(ctx.tick, 50)
         self.assertEqual(ctx.mission_status, "completed")
+
+
+class TestPowerManagementContext(unittest.TestCase):
+    """T017: Station prompt and context power management tests."""
+
+    def test_system_prompt_contains_power_management(self):
+        from app.station import SYSTEM_PROMPT
+
+        self.assertIn("POWER MANAGEMENT", SYSTEM_PROMPT)
+
+    def test_system_prompt_contains_allocate_power_guidance(self):
+        from app.station import SYSTEM_PROMPT
+
+        self.assertIn("allocate_power", SYSTEM_PROMPT)
+
+    def test_system_prompt_contains_emergency_mode_guidance(self):
+        from app.station import SYSTEM_PROMPT
+
+        self.assertIn("EmergencyModeActivated", SYSTEM_PROMPT)
+
+    def test_station_context_includes_power_budgets(self):
+        from app.world import observe_station, WORLD
+
+        WORLD["power_budgets"]["rover-mistral"] = 0.3
+        ctx = observe_station()
+        self.assertEqual(ctx.power_budgets, {"rover-mistral": 0.3})
+
+    def test_station_context_includes_empty_power_budgets(self):
+        from app.world import observe_station, WORLD
+
+        WORLD["power_budgets"].clear()
+        ctx = observe_station()
+        self.assertEqual(ctx.power_budgets, {})
+
+    def test_station_context_includes_emergency_mode_true(self):
+        from app.world import observe_station, WORLD
+
+        WORLD["emergency_mode"] = True
+        ctx = observe_station()
+        self.assertTrue(ctx.emergency_mode)
+
+    def test_station_context_includes_emergency_mode_false(self):
+        from app.world import observe_station, WORLD
+
+        WORLD["emergency_mode"] = False
+        ctx = observe_station()
+        self.assertFalse(ctx.emergency_mode)
+
+    def test_world_summary_shows_power_budgets(self):
+        ctx = _make_station_context(power_budgets={"rover-mistral": 0.3})
+        summary = _build_world_summary(ctx)
+        self.assertIn("Power budgets", summary)
+        self.assertIn("rover-mistral", summary)
+
+    def test_world_summary_shows_emergency_mode(self):
+        ctx = _make_station_context(emergency_mode=True)
+        summary = _build_world_summary(ctx)
+        self.assertIn("EMERGENCY MODE ACTIVE", summary)
+
+    def test_allocate_power_tool_in_station_tools(self):
+        from app.station import STATION_TOOLS
+
+        tool_names = [t["function"]["name"] for t in STATION_TOOLS]
+        self.assertIn("allocate_power", tool_names)
+
+    def test_allocate_power_tool_parsed(self):
+        tool_calls = [
+            _mock_tool_call("allocate_power", {"agent_id": "rover-mistral", "amount": 0.3}),
+        ]
+        actions = _parse_tool_calls(tool_calls)
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0]["name"], "allocate_power")
+        self.assertEqual(actions[0]["params"]["agent_id"], "rover-mistral")
+        self.assertEqual(actions[0]["params"]["amount"], 0.3)
+
+    def test_execute_allocate_power_action(self):
+        result = execute_action(
+            {
+                "name": "allocate_power",
+                "params": {"agent_id": "rover-mistral", "amount": 0.3},
+            }
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["agent_id"], "rover-mistral")
+        self.assertEqual(result["amount"], 0.3)

--- a/specs/182-pydantic-refactor/checklists/requirements.md
+++ b/specs/182-pydantic-refactor/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Pydantic Refactor — Discriminated Unions & Model Validators
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation on first iteration.
+- The Assumptions section mentions necessary technical migration (dataclass to BaseModel) which is acceptable as an implementation constraint, not a specification detail.
+- The spec deliberately uses clamping semantics (not rejection) for validators, documented as an assumption based on existing simulation behavior.

--- a/specs/182-pydantic-refactor/contracts/websocket-message-schema.md
+++ b/specs/182-pydantic-refactor/contracts/websocket-message-schema.md
@@ -1,0 +1,157 @@
+# WebSocket Message Schema Contract: Power Allocation Events
+
+**Feature**: Station Power Allocation Tool | **Date**: 2026-03-05
+
+## New Events Added to WebSocket `/ws` Endpoint
+
+All events follow the existing base message schema:
+```json
+{
+  "source": "string",
+  "type": "string",
+  "name": "string",
+  "payload": "object",
+  "id": "string (UUID v4)",
+  "ts": "number (Unix timestamp)",
+  "tick": "integer",
+  "correlation_id": "string|null"
+}
+```
+
+---
+
+### EventMessage: power_budget_warning
+
+Emitted when an agent's battery drops below its allocated power budget threshold.
+
+```json
+{
+  "source": "world",
+  "type": "event",
+  "name": "power_budget_warning",
+  "payload": {
+    "agent_id": "rover-mistral",
+    "battery": 0.22,
+    "budget": 0.30,
+    "deficit": 0.08
+  },
+  "tick": 45
+}
+```
+
+| payload key | type | description |
+|-------------|------|-------------|
+| agent_id | string | Agent whose battery is below budget |
+| battery | number (0-1) | Current battery level |
+| budget | number (0-1) | Allocated minimum threshold |
+| deficit | number (0-1) | budget - battery (positive when below) |
+
+**Frequency**: Max once per 3 ticks per agent (debounced).
+
+---
+
+### EventMessage: emergency_mode_activated
+
+Emitted when total power demand across all budgeted agents exceeds station capacity.
+
+```json
+{
+  "source": "world",
+  "type": "event",
+  "name": "emergency_mode_activated",
+  "payload": {
+    "total_demand": 1.35,
+    "capacity": 1.0,
+    "agents_in_deficit": [
+      {"agent_id": "rover-mistral", "battery": 0.10, "budget": 0.30, "deficit": 0.20},
+      {"agent_id": "drone-mistral", "battery": 0.05, "budget": 0.40, "deficit": 0.35},
+      {"agent_id": "rover-2", "battery": 0.00, "budget": 0.30, "deficit": 0.30},
+      {"agent_id": "hauler-mistral", "battery": 0.10, "budget": 0.25, "deficit": 0.15},
+      {"agent_id": "rover-large", "battery": 0.15, "budget": 0.30, "deficit": 0.15},
+      {"agent_id": "rover-4", "battery": 0.10, "budget": 0.30, "deficit": 0.20}
+    ]
+  },
+  "tick": 78
+}
+```
+
+| payload key | type | description |
+|-------------|------|-------------|
+| total_demand | number | Sum of all budget deficits |
+| capacity | number | Station power capacity (default 1.0) |
+| agents_in_deficit | array | List of agents with deficit details |
+
+---
+
+### EventMessage: emergency_mode_deactivated
+
+Emitted when total power demand drops back below capacity after emergency.
+
+```json
+{
+  "source": "world",
+  "type": "event",
+  "name": "emergency_mode_deactivated",
+  "payload": {
+    "total_demand": 0.75,
+    "capacity": 1.0
+  },
+  "tick": 92
+}
+```
+
+---
+
+### ActionMessage: allocate_power
+
+Emitted when station executes the allocate_power tool.
+
+```json
+{
+  "source": "station",
+  "type": "action",
+  "name": "allocate_power",
+  "payload": {
+    "ok": true,
+    "agent_id": "rover-mistral",
+    "amount": 0.30,
+    "previous": null
+  },
+  "tick": 5
+}
+```
+
+| payload key | type | description |
+|-------------|------|-------------|
+| ok | boolean | Whether allocation succeeded |
+| agent_id | string | Target agent |
+| amount | number (0-1) | Allocated minimum threshold |
+| previous | number or null | Previous budget (null if first allocation) |
+| error | string (optional) | Error message if ok=false |
+
+---
+
+### World State Snapshot Additions
+
+The periodic `state` event (`name: "state"`) payload gains:
+
+```json
+{
+  "power_budgets": {
+    "rover-mistral": 0.30,
+    "drone-mistral": 0.40
+  },
+  "emergency_mode": false
+}
+```
+
+UI consumers should read `power_budgets[agentId]` to display the PowerBudgetBar.
+
+---
+
+## Backward Compatibility
+
+- Existing events are unchanged
+- New events use the same base schema
+- UI consumers that don't handle `power_budget_warning`/`emergency_mode_activated` will simply ignore them
+- World state snapshot additions are additive (new keys, no removed/renamed keys)

--- a/specs/182-pydantic-refactor/data-model.md
+++ b/specs/182-pydantic-refactor/data-model.md
@@ -1,0 +1,164 @@
+# Data Model: Station Power Allocation Tool
+
+**Feature**: Station Power Allocation Tool (allocate_power) + Budget Events
+**Date**: 2026-03-05
+
+---
+
+## Entity: PowerBudget (new)
+
+Stored in `WORLD["power_budgets"]` as a flat dict.
+
+| Field | Type | Description | Validation |
+|-------|------|-------------|------------|
+| agent_id (key) | `str` | Target agent identifier | Must exist in `WORLD["agents"]` |
+| threshold (value) | `float` | Minimum battery level to maintain | Clamped to [0.0, 1.0] |
+
+**Example state**:
+```python
+WORLD["power_budgets"] = {
+    "rover-mistral": 0.3,
+    "drone-mistral": 0.4,
+    "hauler-mistral": 0.25,
+}
+```
+
+**State Transitions**:
+- Unset -> Set: Station calls `allocate_power(agent_id, amount)`
+- Set -> Updated: Station calls `allocate_power` again with different amount
+- Set -> Cleared: Mission ends or world reset
+
+---
+
+## Constant: STATION_POWER_CAPACITY (new)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| STATION_POWER_CAPACITY | `float` | `1.0` | Max aggregate power deficit the station can service per cycle |
+
+Scalable by future upgrades (e.g., `power_mk2`).
+
+---
+
+## Event: PowerBudgetWarning (new)
+
+Emitted when an agent's battery drops below its allocated power budget.
+
+| Field | Type | Value |
+|-------|------|-------|
+| source | `str` | `"world"` |
+| type | `str` | `"event"` |
+| name | `str` | `"power_budget_warning"` |
+| payload.agent_id | `str` | Agent whose battery is below budget |
+| payload.battery | `float` | Current battery level |
+| payload.budget | `float` | Allocated minimum threshold |
+| payload.deficit | `float` | `budget - battery` (positive when below) |
+| tick | `int` | Current simulation tick |
+
+**Trigger**: `agent.battery < power_budgets[agent_id]`
+**Debounce**: Max once per 3 ticks per agent.
+
+---
+
+## Event: EmergencyModeActivated (new)
+
+Emitted when total power demand exceeds station capacity.
+
+| Field | Type | Value |
+|-------|------|-------|
+| source | `str` | `"world"` |
+| type | `str` | `"event"` |
+| name | `str` | `"emergency_mode_activated"` |
+| payload.total_demand | `float` | Sum of all budget deficits |
+| payload.capacity | `float` | Station power capacity |
+| payload.agents_in_deficit | `list[dict]` | `[{agent_id, battery, budget, deficit}]` |
+| tick | `int` | Current simulation tick |
+
+**Trigger**: `sum(max(0, budget - battery) for budgeted agents) > STATION_POWER_CAPACITY`
+**Latch**: Emitted on activation; EmergencyModeDeactivated emitted when condition clears.
+
+---
+
+## Event: EmergencyModeDeactivated (new)
+
+Emitted when total power demand drops back below station capacity after emergency.
+
+| Field | Type | Value |
+|-------|------|-------|
+| source | `str` | `"world"` |
+| type | `str` | `"event"` |
+| name | `str` | `"emergency_mode_deactivated"` |
+| payload.total_demand | `float` | Current total demand |
+| payload.capacity | `float` | Station power capacity |
+| tick | `int` | Current simulation tick |
+
+---
+
+## Updated Entity: WORLD (additions only)
+
+| New Field | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `power_budgets` | `dict[str, float]` | `{}` | Per-agent power budget thresholds |
+| `emergency_mode` | `bool` | `False` | Whether emergency mode is active |
+| `_power_warn_ticks` | `dict[str, int]` | `{}` | Internal debounce: last warning tick per agent |
+
+---
+
+## Updated Entity: StationContext (Pydantic model in station.py)
+
+| New Field | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `power_budgets` | `dict[str, float]` | `{}` | Current power allocations visible to station LLM |
+| `emergency_mode` | `bool` | `False` | Whether emergency mode is active |
+
+---
+
+## Tool Schema: ALLOCATE_POWER_TOOL (new)
+
+```python
+ALLOCATE_POWER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "allocate_power",
+        "description": (
+            "Set a power budget for an agent. Defines the minimum battery "
+            "threshold to maintain. A PowerBudgetWarning event fires when "
+            "the agent's battery drops below this level."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "The agent to set a power budget for (e.g. 'rover-mistral', 'drone-mistral').",
+                },
+                "amount": {
+                    "type": "number",
+                    "description": "Minimum battery threshold (0.0-1.0). Agent receives warnings below this level.",
+                },
+            },
+            "required": ["agent_id", "amount"],
+        },
+    },
+}
+```
+
+---
+
+## Relationships
+
+```
+Station --[calls]--> allocate_power(agent_id, amount)
+  |
+  v
+WORLD["power_budgets"][agent_id] = amount
+  |
+  v (each tick)
+check_power_budgets()
+  |
+  +--> agent.battery < budget? --> PowerBudgetWarning
+  |
+  +--> total_demand > capacity? --> EmergencyModeActivated
+  |
+  +--> previously emergency, now resolved? --> EmergencyModeDeactivated
+```

--- a/specs/182-pydantic-refactor/plan.md
+++ b/specs/182-pydantic-refactor/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Station Power Allocation Tool (allocate_power) + Budget Events
+
+**Branch**: `182-pydantic-refactor` | **Date**: 2026-03-05 | **Spec**: `/specs/182-pydantic-refactor/spec.md`
+**Input**: Feature specification + user description of power allocation scope
+
+## Summary
+
+Add `allocate_power(agent_id, amount)` tool to the station agent, enabling fine-grained power budget management. The tool sets a minimum battery threshold per agent. The simulation tick loop monitors budgets and emits `PowerBudgetWarning` events when agents drop below their threshold, and `EmergencyModeActivated` when total demand exceeds station capacity. The station system prompt is updated with power management guidance, and the UI gains a `PowerBudgetBar` indicator in AgentPane.
+
+## Technical Context
+
+**Language/Version**: Python 3.14+ (server), JavaScript/Vue 3 (UI)
+**Primary Dependencies**: FastAPI, Pydantic v2, mistralai SDK, Vue 3, Vite
+**Storage**: In-memory WORLD dict (simulation state), SurrealDB on port 4002 (unchanged)
+**Testing**: pytest with in-memory SurrealDB (server), manual verification (UI)
+**Target Platform**: Linux/macOS server, modern browser (desktop/tablet/mobile)
+**Project Type**: Web application (FastAPI backend + Vue 3 SPA)
+**Performance Goals**: No measurable latency impact; budget check runs O(n) per tick where n = budgeted agents (max ~9)
+**Constraints**: Must not break existing station tools or charge mechanics; backward-compatible world state
+**Scale/Scope**: 4 server files + 2 UI files changed, ~200 lines added
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution is not yet configured (template placeholders). No gates to evaluate. Proceeding.
+
+**Post-Phase 1 Re-check**: Constitution still unconfigured. No violations to report.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/182-pydantic-refactor/
+├── plan.md              # This file
+├── research.md          # Phase 0: 7 research decisions
+├── data-model.md        # Phase 1: entities, events, tool schema
+├── quickstart.md        # Phase 1: verification guide
+├── contracts/
+│   └── websocket-message-schema.md  # Phase 1: new WS events
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (changes)
+
+```text
+server/app/
+├── station.py           # ALLOCATE_POWER_TOOL, _execute_allocate_power(), system prompt update, StationContext fields
+├── world.py             # STATION_POWER_CAPACITY, WORLD init, check_power_budgets(), allocate_power()
+├── host.py              # route_station_actions() allocate_power case, budget event broadcasting
+└── tests/
+    ├── test_station.py  # allocate_power tool tests
+    └── test_power_budget.py  # PowerBudgetWarning, EmergencyMode tests (new)
+
+ui/src/
+├── components/
+│   ├── PowerBudgetBar.vue   # New component (mirrors BatteryBar.vue)
+│   └── AgentPane.vue        # Add PowerBudgetBar to agent-row-2
+└── (no new composables needed — uses existing worldState from useWebSocket)
+```
+
+**Structure Decision**: Web application (Option 2 pattern). Backend changes in `server/app/`, frontend changes in `ui/src/components/`. No new directories created.
+
+## Design Decisions
+
+### D1: Power Budget as Minimum Threshold (not charge cap)
+
+`allocate_power(agent_id, amount)` sets a minimum battery threshold. When `agent.battery < amount`, a `PowerBudgetWarning` fires. Charging is NOT capped — station can always charge to 1.0. The budget is for monitoring and prioritization, not enforcement.
+
+**Why**: Simpler, backward-compatible with existing charge mechanics, and more useful for the LLM (warnings inform strategic decisions rather than artificial limits).
+
+### D2: Budget Check in Tick Loop
+
+`check_power_budgets()` is called from `next_tick()` in `world.py`, alongside existing `apply_structure_passive_effects()`. Returns a list of events to broadcast.
+
+**Why**: Natural extension point. Budget violations are detected every tick regardless of agent actions.
+
+### D3: EmergencyMode as Aggregate Demand Signal
+
+Emergency mode activates when `sum(deficits) > STATION_POWER_CAPACITY`. This is a station-level crisis distinct from individual `PowerBudgetWarning` events.
+
+**Why**: Gives the LLM a clear signal to change strategy (e.g., recall all agents, prioritize critical missions).
+
+### D4: Debounced Warnings (3-tick cooldown)
+
+`PowerBudgetWarning` is emitted max once per 3 ticks per agent to avoid flooding the station's context and the WebSocket channel.
+
+**Why**: Without debouncing, an agent with low battery would generate a warning every tick, bloating station memory and UI timeline.
+
+### D5: UI PowerBudgetBar (conditional)
+
+Displayed only when `worldState.power_budgets[agentId]` exists. Uses the same visual pattern as `BatteryBar.vue` (3rem inline bar, color-coded).
+
+**Why**: Zero visual change until station starts using allocate_power. Consistent with existing design system.
+
+## Implementation Order
+
+1. **world.py** — WORLD state additions + `check_power_budgets()` + `_execute_allocate_power()`
+2. **station.py** — ALLOCATE_POWER_TOOL + system prompt + StationContext fields
+3. **host.py** — Route allocate_power action + broadcast budget events from tick
+4. **tests** — Unit tests for allocate_power, budget warnings, emergency mode
+5. **PowerBudgetBar.vue** — New UI component
+6. **AgentPane.vue** — Integrate PowerBudgetBar
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Station LLM ignores allocate_power tool | Low — feature is opt-in | System prompt explicitly guides usage; tool is included in tools array |
+| PowerBudgetWarning floods station memory | Medium — context overflow | 3-tick debounce; memory cap already enforced (8 entries) |
+| EmergencyMode triggers too aggressively | Low | STATION_POWER_CAPACITY = 1.0 is generous; tunable constant |
+| UI breaks on missing power_budgets field | Low | Conditional rendering; field defaults to empty dict |
+
+## Complexity Tracking
+
+No constitution violations to justify. Feature is additive with minimal complexity.

--- a/specs/182-pydantic-refactor/quickstart.md
+++ b/specs/182-pydantic-refactor/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart: Station Power Allocation Tool
+
+**Branch**: `182-pydantic-refactor`
+
+## Prerequisites
+
+- Python 3.14+, Node 24+, uv, SurrealDB running on port 4002
+- `MISTRAL_API_KEY` set in `server/.env`
+
+## Setup
+
+```bash
+git checkout 182-pydantic-refactor
+cd server && uv sync
+cd ../ui && npm install
+```
+
+## Run
+
+```bash
+# Terminal 1: Server
+cd server && ./run
+
+# Terminal 2: UI
+cd ui && npm run dev
+```
+
+Open `http://localhost:4089`.
+
+## Verify Feature
+
+1. **Power allocation tool**: Start simulation and observe station behavior
+   ```bash
+   cd server && uv run pytest tests/ -v -k "allocate_power"
+   ```
+
+2. **PowerBudgetWarning events**: Verify warnings fire when agents drop below budget
+   ```bash
+   cd server && uv run pytest tests/ -v -k "power_budget_warning"
+   ```
+
+3. **EmergencyMode events**: Verify emergency mode activates under high demand
+   ```bash
+   cd server && uv run pytest tests/ -v -k "emergency_mode"
+   ```
+
+4. **Full Regression**: Run all tests
+   ```bash
+   cd server && uv run pytest tests/ -v
+   ```
+
+5. **Runtime Verification**: In the simulation UI, observe:
+   - Station uses `allocate_power` tool to set budgets for agents
+   - PowerBudgetBar appears in AgentPane for agents with set budgets
+   - PowerBudgetWarning events appear in the timeline when agents drop below budget
+   - EmergencyModeActivated appears when total demand exceeds capacity
+
+## Key Files Changed
+
+| File | Change |
+|------|--------|
+| `server/app/station.py` | Added `ALLOCATE_POWER_TOOL`, `_execute_allocate_power()`, updated system prompt with POWER MANAGEMENT section, added `power_budgets`/`emergency_mode` to StationContext |
+| `server/app/world.py` | Added `STATION_POWER_CAPACITY` constant, `power_budgets`/`emergency_mode`/`_power_warn_ticks` to WORLD init, `check_power_budgets()` function, `allocate_power()` execution logic |
+| `server/app/host.py` | Added `allocate_power` case to `route_station_actions()`, broadcast PowerBudgetWarning/EmergencyMode events from tick loop |
+| `ui/src/components/PowerBudgetBar.vue` | New component: inline bar showing power budget threshold (mirrors BatteryBar pattern) |
+| `ui/src/components/AgentPane.vue` | Added PowerBudgetBar in agent-row-2, conditionally displayed when budget is set |

--- a/specs/182-pydantic-refactor/research.md
+++ b/specs/182-pydantic-refactor/research.md
@@ -1,0 +1,91 @@
+# Research: Station Power Allocation Tool (allocate_power) + Budget Events
+
+**Feature**: Station Power Allocation Tool
+**Date**: 2026-03-05
+**Branch**: `182-pydantic-refactor`
+
+---
+
+## R1: How does the existing charge mechanism work?
+
+**Decision**: Extend the existing charge system with budget-aware monitoring, not replace it.
+
+**Rationale**: The current `_execute_charge()` in `world.py:1869-1895` adds `CHARGE_RATE = 0.20` (20%) per call, with optional `charge_mk2` upgrade doubling it. Charging requires co-location with station. The mechanism is clean and well-tested. Power allocation should layer on top: `allocate_power` sets a budget threshold, and the tick loop monitors agents against their budgets to emit warnings.
+
+**Alternatives Considered**:
+- **Replace charge system entirely**: Rejected. Existing charge flow is stable, tested, and backward-compatible.
+- **Make allocate_power control charge rate**: Rejected. A threshold-based budget (minimum battery to maintain) is more intuitive for the LLM and aligns with ROADMAP language.
+
+---
+
+## R2: Where should power budgets be stored in world state?
+
+**Decision**: Add `WORLD["power_budgets"]` as a top-level dict `{agent_id: float}` where the float is the minimum battery threshold (0.0-1.0).
+
+**Rationale**: WORLD dict is the single source of truth. Power budgets are a station-level concept that applies across agents. A flat dict keyed by agent_id mirrors the existing `WORLD["agents"]` pattern. Storing as a minimum threshold aligns with event semantics: PowerBudgetWarning fires when battery drops below the allocated minimum.
+
+**Alternatives Considered**:
+- **Store inside each agent's state dict**: Rejected. Power budgets are a station concern, not an agent concern.
+- **Nested structure with allocation history**: Rejected. Over-engineering for current scope.
+- **Absolute power units (e.g., 100 fuel units)**: Rejected. System uses 0.0-1.0 fractions everywhere.
+
+---
+
+## R3: How should PowerBudgetWarning events be emitted?
+
+**Decision**: Add `check_power_budgets()` function in `world.py`, called from the tick loop. Emit when `agent.battery < power_budgets[agent_id]`. Debounce warnings to avoid spam (max once per 3 ticks per agent).
+
+**Rationale**: The tick loop (`next_tick()`) already calls `apply_structure_passive_effects()`. Adding a budget check here is natural. Events emit via standard `make_message()` -> broadcast pipeline. Include agent_id, current battery, allocated threshold, and deficit amount.
+
+**Alternatives Considered**:
+- **Check only during charge operations**: Rejected. Warnings should fire whenever battery drops below threshold, not just at charge time.
+- **Check in agent reasoning loop**: Rejected. Power budget monitoring is a station/world responsibility.
+
+---
+
+## R4: How should EmergencyModeActivated be triggered?
+
+**Decision**: Define `STATION_POWER_CAPACITY = 1.0`. Calculate total demand as `sum(max(0, budget - agent.battery) for each budgeted agent)`. Emit EmergencyModeActivated when `total_demand > STATION_POWER_CAPACITY`.
+
+**Rationale**: Introducing a finite station capacity creates meaningful resource management decisions for the LLM. The capacity can scale with upgrades. EmergencyMode represents a systemic crisis (distinct from single-agent PowerBudgetWarning).
+
+**Alternatives Considered**:
+- **Trigger on agent count threshold**: Rejected. Doesn't capture actual power demand dynamics.
+- **Trigger when N agents have battery < 20%**: Rejected. Arbitrary, ignores allocated budgets.
+- **No station capacity, emit when any budget is violated**: Rejected. EmergencyMode should be systemic, not single-agent.
+
+---
+
+## R5: How should the station system prompt be updated?
+
+**Decision**: Add a "POWER MANAGEMENT" section to the station system prompt describing the allocate_power tool semantics, budget monitoring, and recommended strategies.
+
+**Rationale**: Existing prompt has structured sections (AGENT TYPES, RESOURCES, DRONE COORDINATION, HAULER COORDINATION). A parallel POWER MANAGEMENT section follows the pattern. The LLM needs guidance on when to allocate power (mission start, after storms), threshold recommendations, and how to respond to budget events.
+
+**Alternatives Considered**:
+- **Rely solely on tool description**: Rejected. Tool descriptions are terse; system prompt provides strategic guidance.
+- **Add to existing RESOURCES section**: Rejected. Power management is a distinct operational concern.
+
+---
+
+## R6: How should the UI display power budgets?
+
+**Decision**: Add a `PowerBudgetBar` component (based on `BatteryBar.vue`) in `AgentPane.vue` agent-row-2. Display conditionally when a power budget is set.
+
+**Rationale**: `BatteryBar.vue` is a clean 3rem-wide inline bar with dynamic color coding and CSS transitions. Duplicating this pattern for power budget maintains visual consistency. Show only when `power_budget` is set (backward compatible).
+
+**Alternatives Considered**:
+- **Overlay on BatteryBar**: Rejected. Mixing concepts in one bar is confusing.
+- **Text-only display**: Rejected. Visual bars are more scannable in compact AgentPane layout.
+
+---
+
+## R7: Should charge operations enforce budgets?
+
+**Decision**: No. The budget is a MINIMUM threshold for warnings, not a charge cap. `charge_agent` continues to charge to 1.0 regardless of budget.
+
+**Rationale**: The allocate_power tool sets the floor (minimum desired battery), not the ceiling. The station should always be able to charge agents fully. The budget is for prioritization via warnings, not enforcement. This avoids confusing the LLM with artificial charge limits.
+
+**Alternatives Considered**:
+- **Cap charging at budget level**: Rejected. Would prevent full charges and confuse the LLM.
+- **Scale charge rate by budget proportion**: Rejected. Adds complexity without clear benefit.

--- a/specs/182-pydantic-refactor/spec.md
+++ b/specs/182-pydantic-refactor/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Pydantic Refactor — Discriminated Unions & Model Validators
+
+**Feature Branch**: `182-pydantic-refactor`
+**Created**: 2026-03-05
+**Status**: Draft
+**Input**: User description: "Pydantic Refactor — Discriminated Unions & Model Validators"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Typed Message Protocol (Priority: P1)
+
+As a developer working on the simulation, I want all protocol messages to use discriminated union types so that I can statically verify message correctness and catch protocol errors at parse time rather than at runtime.
+
+**Why this priority**: Message types are the communication backbone of the entire agent system. Every agent, the host, and the broadcaster create and consume messages. Typing these correctly eliminates the largest class of runtime protocol errors and unlocks IDE autocompletion for payload fields.
+
+**Independent Test**: Can be fully tested by constructing messages of each type and verifying that invalid type/name combinations are rejected at model creation time. Delivers immediate value through parse-time validation and IDE support.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message with type "event" and name "move", **When** the message is constructed, **Then** it is validated as a valid EventMessage with the correct payload structure.
+2. **Given** a message with an unknown type value, **When** parsed into the union type, **Then** a validation error is raised immediately.
+3. **Given** a valid message dict from WebSocket, **When** deserialized, **Then** the correct discriminated subtype is returned automatically based on the type field.
+4. **Given** existing code that creates messages via `make_message()`, **When** the refactor is applied, **Then** all existing call sites still produce valid typed messages without behavior changes.
+
+---
+
+### User Story 2 - Model Validators for World State Consistency (Priority: P2)
+
+As a developer, I want model validators on agent state and world models so that invalid state (e.g., negative battery, out-of-bounds positions) is caught immediately when models are constructed rather than causing silent corruption downstream.
+
+**Why this priority**: Without validators, invalid state propagates silently through the system — a battery of -0.3 or a position of [-5, 200] on a 30x30 grid would not be caught until it causes a visible bug. Validators provide a safety net at the model boundary.
+
+**Independent Test**: Can be tested by constructing models with boundary and invalid values and verifying that validators clamp or reject appropriately. Delivers value through early error detection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a battery value of 1.5, **When** constructing an agent state model, **Then** the value is clamped to 1.0.
+2. **Given** a battery value of -0.2, **When** constructing an agent state model, **Then** the value is clamped to 0.0.
+3. **Given** a position of [-1, 50] on a 30x30 grid, **When** constructing a model that validates position, **Then** the position is clamped to valid grid bounds [0, 29].
+4. **Given** a goal_confidence of 2.0, **When** constructing an agent state model, **Then** the value is clamped to 1.0.
+5. **Given** valid values within all bounds, **When** constructing any model, **Then** the model is created without modification (no false positives).
+
+---
+
+### User Story 3 - Typed ResourceDeposit Model (Priority: P3)
+
+As a developer, I want resource deposits to use the existing ResourceType enum in a typed ResourceDeposit model so that resource handling is consistent and type-safe across the codebase.
+
+**Why this priority**: The ResourceType enum already exists but resource deposits in the world state use plain dicts with string type fields. Wrapping these in a typed model ensures consistency and prevents typos in resource type strings.
+
+**Independent Test**: Can be tested by constructing ResourceDeposit models with valid and invalid resource types and verifying enum enforcement. Delivers value through consistent resource typing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource deposit with type "basalt_vein", **When** constructed as a ResourceDeposit, **Then** the type field is a valid ResourceType enum member.
+2. **Given** a resource deposit with type "unknown_mineral", **When** constructed as a ResourceDeposit, **Then** a validation error is raised.
+3. **Given** existing stone and ice deposit data in the world state, **When** the refactor is applied, **Then** all existing deposits are representable with the new typed model.
+
+---
+
+### User Story 4 - Updated Call Sites (Priority: P4)
+
+As a developer, I want all message creation and consumption call sites in agent.py, host.py, and station.py to use the new typed models so that the entire message pipeline is type-safe end-to-end.
+
+**Why this priority**: The typed models only deliver full value when all producers and consumers use them. This story ensures no call site is left using raw dicts for message construction.
+
+**Independent Test**: Can be tested by running the full test suite after updating call sites — all existing tests must pass, confirming behavioral equivalence. Additionally, static type checking should report zero type errors in the updated files.
+
+**Acceptance Scenarios**:
+
+1. **Given** a rover agent producing a "move" action message, **When** the call site uses the typed model, **Then** the message is constructed with payload validation.
+2. **Given** the host broadcasting a message, **When** it receives a typed message, **Then** serialization to dict for WebSocket works identically to the current behavior.
+3. **Given** the station agent handling an event, **When** the event is deserialized, **Then** the correct typed message subclass is returned.
+4. **Given** the entire test suite, **When** run after all call site updates, **Then** all tests pass with zero regressions.
+
+---
+
+### Edge Cases
+
+- What happens when a message has a valid type but an unexpected payload shape? Validators should reject with a clear error.
+- What happens when legacy/persisted messages (e.g., in training logs) are loaded with the new types? The system should handle missing fields gracefully with defaults.
+- What happens when a new message type is added in the future? The discriminated union should be easily extensible by adding a new subclass.
+- What happens when battery is exactly 0.0 or 1.0? Boundary values must be accepted, not rejected.
+- What happens when position is at grid edges (0 or grid_size-1)? These are valid and must pass validation.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST define discriminated union types for all protocol message categories (event, action, command, tool, stream) using a type discriminator field.
+- **FR-002**: The system MUST validate message payloads against the expected schema for each message type at construction time.
+- **FR-003**: The system MUST provide model validators for battery values, clamping to the [0.0, 1.0] range.
+- **FR-004**: The system MUST provide model validators for goal_confidence values, clamping to the [0.0, 1.0] range.
+- **FR-005**: The system MUST provide model validators for position coordinates, clamping to valid grid bounds.
+- **FR-006**: The system MUST use the existing ResourceType enum in a typed ResourceDeposit model for all resource deposit representations.
+- **FR-007**: All message creation call sites in agent.py, host.py, and station.py MUST use typed message models instead of raw dict construction.
+- **FR-008**: The system MUST maintain full backward compatibility — all existing tests must pass without modification after the refactor.
+- **FR-009**: The system MUST support serialization of typed messages to plain dicts for WebSocket broadcast compatibility.
+- **FR-010**: The system MUST support deserialization of plain dicts back into the correct discriminated union subtype.
+
+### Key Entities
+
+- **Message**: The base protocol unit with fields: id, ts, source, type, name, payload, tick, correlation_id. Discriminated by the `type` field into subtypes (EventMessage, ActionMessage, CommandMessage, ToolMessage, StreamMessage).
+- **AgentState**: Per-agent state with validated fields: position (grid-bounded), battery (0.0-1.0), goal_confidence (0.0-1.0), inventory, mission, memory.
+- **ResourceDeposit**: A typed resource occurrence in the world, combining position, quantity, and a ResourceType enum value.
+- **ResourceType**: Existing enum with values: basalt_vein, ice, water, gas.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of protocol message types are covered by discriminated union subtypes — no message is constructed as an untyped dict.
+- **SC-002**: All agent state models include validators for numeric bounds (battery, goal_confidence) and spatial bounds (position) — zero invalid states can be constructed.
+- **SC-003**: All existing tests pass after the refactor with zero regressions — the change is purely additive in safety, not behavioral.
+- **SC-004**: All resource deposits in the world state use the typed ResourceDeposit model with ResourceType enum enforcement.
+- **SC-005**: New tests achieve at least 90% coverage of the new validator and discriminated union logic.
+- **SC-006**: Invalid message construction (wrong type, out-of-bounds values) is caught at model creation time, not at runtime consumption.
+
+## Assumptions
+
+- The existing `@dataclass Message` in protocol.py will be migrated to a Pydantic BaseModel to enable discriminated unions and validators. This is a necessary prerequisite since dataclasses do not support discriminator features.
+- Position validators will use the grid dimensions from the world configuration (currently 30x30) as the bounds reference.
+- Battery and goal_confidence validators will use clamping behavior (silently adjust to valid range) rather than rejection behavior (raise error), since the simulation already produces boundary-adjacent values during normal operation.
+- The `make_message()` factory function will be updated to return typed message instances, but a `.model_dump()` method will preserve WebSocket serialization compatibility.
+- Training log compatibility: existing training data files with old message formats will not be retroactively migrated; the new models will accept legacy formats via default field values.

--- a/specs/182-pydantic-refactor/tasks.md
+++ b/specs/182-pydantic-refactor/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: Station Power Allocation Tool (allocate_power) + Budget Events
+
+**Input**: Design documents from `/specs/182-pydantic-refactor/`
+**Prerequisites**: plan.md, data-model.md, research.md, contracts/websocket-message-schema.md, quickstart.md
+
+**Tests**: Included — the CLAUDE.md requires complete test coverage before PR.
+
+**Organization**: Tasks grouped by user story derived from feature scope.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project initialization needed. This feature extends an existing codebase. Phase 1 covers WORLD state initialization changes that all stories depend on.
+
+- [X] T001 Add `power_budgets`, `emergency_mode`, and `_power_warn_ticks` fields to WORLD dict initialization in `server/app/world.py`
+- [X] T002 Add `STATION_POWER_CAPACITY = 1.0` and `POWER_WARN_COOLDOWN = 3` constants in `server/app/world.py`
+- [X] T003 [P] Add `power_budgets: dict[str, float] = {}` and `emergency_mode: bool = False` fields to the `StationContext` Pydantic model in `server/app/models.py`
+
+**Checkpoint**: WORLD state and StationContext have power budget fields. No behavioral changes yet.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core execution logic that US2 (events) and US3 (routing) depend on.
+
+- [X] T004 Implement `_execute_allocate_power(agent_id: str, amount: float) -> dict` in `server/app/world.py`
+- [X] T005 Implement `allocate_power(agent_id: str, amount: float) -> dict` public wrapper in `server/app/world.py`
+
+**Checkpoint**: Foundation ready — allocate_power execution works in isolation.
+
+---
+
+## Phase 3: User Story 1 - allocate_power Tool (Priority: P1)
+
+### Tests for User Story 1
+
+- [X] T006 [P] [US1] Create test file `server/tests/test_power_budget.py` with TestAllocatePower class (9 tests)
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Define `ALLOCATE_POWER_TOOL` dict in `server/app/station.py`
+- [X] T008 [US1] Add `ALLOCATE_POWER_TOOL` to the `STATION_TOOLS` list in `server/app/station.py`
+- [X] T009 [US1] Add `allocate_power` case to `execute_action()` and `_parse_tool_calls()` in `server/app/station.py`
+- [X] T010 [US1] Verified `allocate_power` handled by generic broadcast in `route_station_actions()` in `server/app/host.py`
+
+**Checkpoint**: Station LLM can call allocate_power. Budget stored in WORLD. Broadcast via WebSocket.
+
+---
+
+## Phase 4: User Story 2 - Budget Warning & Emergency Events (Priority: P2)
+
+### Tests for User Story 2
+
+- [X] T011 [P] [US2] TestPowerBudgetWarning class in `server/tests/test_power_budget.py` (8 tests)
+- [X] T012 [P] [US2] TestEmergencyMode class in `server/tests/test_power_budget.py` (6 tests)
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Implement `check_power_budgets(tick: int) -> list[dict]` in `server/app/world.py`
+- [X] T014 [US2] Call `check_power_budgets(tick)` from `next_tick()` in `server/app/world.py`, updated all 3 callers in `agent.py`
+- [X] T015 [US2] Broadcast power budget events from rover tick loop in `server/app/agent.py`
+- [X] T016 [US2] Add PowerBudgetWarning/EmergencyMode events to station memory via `record_memory()` in `server/app/agent.py`
+
+**Checkpoint**: Budget monitoring active. Warnings and emergency events fire and reach UI + station LLM.
+
+---
+
+## Phase 5: User Story 3 - Station System Prompt & Context (Priority: P3)
+
+### Tests for User Story 3
+
+- [X] T017 [P] [US3] TestPowerManagementContext class in `server/tests/test_station.py` (12 tests)
+
+### Implementation for User Story 3
+
+- [X] T018 [US3] Add "POWER MANAGEMENT" section to the station system prompt in `server/app/station.py`
+- [X] T019 [US3] Populate `power_budgets` and `emergency_mode` in StationContext builder (`observe_station()` in `server/app/world.py`) and `_build_world_summary()` in `server/app/station.py`
+
+**Checkpoint**: Station LLM has full power management context and guidance.
+
+---
+
+## Phase 6: User Story 4 - UI Power Budget Indicator (Priority: P4)
+
+### Implementation for User Story 4
+
+- [X] T020 [P] [US4] Create `ui/src/components/PowerBudgetBar.vue` — inline bar with blue fill, "B:" label prefix
+- [X] T021 [US4] Update `ui/src/components/AgentPane.vue` and `ui/src/components/AgentPanes.vue` with PowerBudgetBar integration
+- [X] T022 [US4] Strip `_power_warn_ticks` from `get_snapshot()` in `server/app/world.py` (power_budgets/emergency_mode already included via deepcopy)
+
+**Checkpoint**: UI shows power budget status for all budgeted agents.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Regression testing, formatting, documentation.
+
+- [X] T023 Run full test suite — 738 passed, 0 failed
+- [X] T024 [P] Run ruff format + ruff check — all clean
+- [X] T025 [P] Update `Changelog.md` with power allocation feature entry
+- [X] T026 Run quickstart.md validation steps — 738 passed, 0 failed, ruff clean
+
+---

--- a/ui/src/components/AgentPane.vue
+++ b/ui/src/components/AgentPane.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import BatteryBar from './BatteryBar.vue'
 import ConfidenceBar from './ConfidenceBar.vue'
+import PowerBudgetBar from './PowerBudgetBar.vue'
 import ReasoningCard from './ReasoningCard.vue'
 
 const props = defineProps({
@@ -48,6 +49,10 @@ const props = defineProps({
   goalConfidence: {
     type: Number,
     default: 0,
+  },
+  powerBudget: {
+    type: Number,
+    default: null,
   },
 })
 
@@ -116,6 +121,9 @@ function eventText(e) {
         &middot; <BatteryBar :level="batteryLevel" />
         <template v-if="goalConfidence > 0">
           &middot; <ConfidenceBar :level="goalConfidence" />
+        </template>
+        <template v-if="powerBudget != null">
+          &middot; <PowerBudgetBar :level="powerBudget" />
         </template>
       </div>
     </div>

--- a/ui/src/components/AgentPanes.vue
+++ b/ui/src/components/AgentPanes.vue
@@ -73,6 +73,13 @@ function goalConfidence(id) {
   return a ? (a.goal_confidence ?? 0) : 0
 }
 
+function powerBudget(id) {
+  if (!props.worldState) return null
+  const budgets = props.worldState.power_budgets
+  if (!budgets) return null
+  return budgets[id] ?? null
+}
+
 </script>
 
 <template>
@@ -105,6 +112,7 @@ function goalConfidence(id) {
         :color="agentColor(id)"
         :message-count="messageCount(id)"
         :goal-confidence="goalConfidence(id)"
+        :power-budget="powerBudget(id)"
         @select-agent="emit('select-agent', $event)"
       />
     </template>

--- a/ui/src/components/PowerBudgetBar.vue
+++ b/ui/src/components/PowerBudgetBar.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  level: {
+    type: Number,
+    default: 0,
+  },
+})
+
+const pct = computed(() => Math.max(0, Math.min(100, Math.round(props.level * 100))))
+</script>
+
+<template>
+  <span class="budget-bar" :title="'Power budget: min ' + pct + '%'">
+    <span class="budget-track">
+      <span
+        class="budget-fill"
+        :style="{ width: pct + '%' }"
+      />
+    </span>
+    <span class="budget-label">B:{{ pct }}%</span>
+  </span>
+</template>
+
+<style scoped>
+.budget-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.budget-track {
+  display: inline-block;
+  width: 3rem;
+  height: 0.5rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  overflow: hidden;
+}
+
+.budget-fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background: var(--accent-blue);
+  transition: width 0.3s ease;
+}
+
+.budget-label {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  min-width: 2.8em;
+  text-align: right;
+}
+</style>


### PR DESCRIPTION
## Summary

- Add `allocate_power(agent_id, amount)` tool to station agent for fine-grained power budget management
- Emit `PowerBudgetWarning` events (3-tick debounce) when agents drop below budget threshold
- Emit `EmergencyModeActivated`/`Deactivated` events when total demand exceeds `STATION_POWER_CAPACITY`
- Update station system prompt with POWER MANAGEMENT guidance section
- Add `PowerBudgetBar.vue` UI component (blue inline bar, conditional display in AgentPane)

## Semantic Diff

### File Impact

| Category | Files | Lines Added | Lines Removed |
|----------|-------|-------------|---------------|
| Core     | 6     | 206         | 7             |
| Tests    | 2     | 326         | 0             |
| Specs    | 8     | 868         | 0             |
| UI       | 3     | 73          | 0             |
| **Total**| **19**| **1474**    | **7**         |

### Added
- `server/tests/test_power_budget.py` — 23 tests for allocate_power, budget warnings, emergency mode
- `ui/src/components/PowerBudgetBar.vue` — inline bar component (blue fill, "B:" label)
- `specs/182-pydantic-refactor/` — plan, research, data-model, contracts, quickstart, tasks, spec, checklist

### Changed
- `server/app/world.py` — `STATION_POWER_CAPACITY`, `POWER_WARN_COOLDOWN` constants; WORLD init; `_execute_allocate_power()`, `allocate_power()`, `check_power_budgets()`; `next_tick()` returns tuple; `observe_station()` populates new fields; `get_snapshot()` strips internals
- `server/app/station.py` — `ALLOCATE_POWER_TOOL`; `STATION_TOOLS` updated; `execute_action()` + `_parse_tool_calls()` handle allocate_power; POWER MANAGEMENT prompt section; `_build_world_summary()` shows budgets
- `server/app/agent.py` — `next_tick()` callers updated for tuple return; power event broadcasting + station memory
- `server/app/models.py` — `StationContext` gains `power_budgets` and `emergency_mode`
- `server/tests/test_station.py` — 12 new tests for power management context/prompt
- `ui/src/components/AgentPane.vue` — PowerBudgetBar import, prop, conditional rendering
- `ui/src/components/AgentPanes.vue` — `powerBudget()` function, prop binding
- `Changelog.md` — power-allocation feature entries
- `CLAUDE.md` — agent context update (auto-generated)

## Changelog

* **power-allocation:** add `allocate_power(agent_id, amount)` tool to station agent
* **power-allocation:** add `check_power_budgets()` tick-loop monitor with 3-tick debounce
* **power-allocation:** add `EmergencyModeActivated`/`Deactivated` events
* **power-allocation:** update station system prompt with POWER MANAGEMENT section
* **power-allocation:** add `PowerBudgetBar.vue` and integrate in `AgentPane.vue`
* **power-allocation:** 35 new tests (738 total passing, 0 regressions)

## Test plan

- [x] 738 tests passing (`uv run pytest tests/ -v`)
- [x] Ruff format + check clean
- [x] allocate_power sets/updates/rejects budgets correctly (9 tests)
- [x] PowerBudgetWarning fires with debounce (8 tests)
- [x] EmergencyMode activates/deactivates correctly (6 tests)
- [x] Station prompt + context include power management (12 tests)
- [x] PowerBudgetBar conditionally rendered in AgentPane

Co-Authored-By: agent-one team <agent-one@yanok.ai>