### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 
 # Local tool state
 .sisyphus/
+.claude/
 
 # OS files
 .DS_Store


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` to prevent Claude Code worktree directories from being tracked

## File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| Config | 1 (.gitignore) | 1 | 0 |

## Test plan
- [x] `.claude/worktrees/` no longer appears in `git status`

Co-Authored-By: agent-one team <agent-one@yanok.ai>