### PR TITLE
fix(ci): resolve eslint errors and flaky storm test

### DIFF
--- a/server/tests/test_coverage_expansion.py
+++ b/server/tests/test_coverage_expansion.py
@@ -610,17 +610,21 @@ class TestStormBatteryEffects(_WorldSaveRestore):
         """Moving during a storm costs more battery than in clear weather."""
         rover = WORLD["agents"]["rover-mistral"]
 
-        # Clear weather move
+        # Use origin area (guaranteed obstacle-free)
+        rover["position"] = [0, 0]
         rover["battery"] = 1.0
-        execute_action("rover-mistral", "move", {"direction": "east"})
+        WORLD["storm"] = storm_mod.make_storm_state()  # clear weather
+        result_clear = execute_action("rover-mistral", "move", {"direction": "east"})
         clear_cost = 1.0 - rover["battery"]
+        self.assertTrue(result_clear.get("ok", False), f"Clear move failed: {result_clear}")
 
         # Reset position for storm move
-        rover["position"] = [5, 5]
+        rover["position"] = [0, 0]
         rover["battery"] = 1.0
         self._activate_storm(intensity=0.6)
-        execute_action("rover-mistral", "move", {"direction": "east"})
+        result_storm = execute_action("rover-mistral", "move", {"direction": "east"})
         storm_cost = 1.0 - rover["battery"]
+        self.assertTrue(result_storm.get("ok", False), f"Storm move failed: {result_storm}")
 
         self.assertGreater(storm_cost, clear_cost)
 

--- a/ui/src/pages/ReplayPage.vue
+++ b/ui/src/pages/ReplayPage.vue
@@ -1,11 +1,8 @@
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import WorldMap from '../components/WorldMap.vue'
 import MiniMap from '../components/MiniMap.vue'
 import { VIEWPORT_W, VIEWPORT_H, agentColor } from '../constants.js'
-
-const router = useRouter()
 
 // ── Session picker state ──
 const sessions = ref([])


### PR DESCRIPTION
## Summary
- Remove unused `watch` import and `router` variable from ReplayPage.vue (eslint no-unused-vars errors)
- Fix `test_storm_move_costs_more_battery` — use origin area [0,0] which is guaranteed obstacle-free, preventing intermittent failures from world-gen obstacles at [5,5]

## File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| UI | 1 (ReplayPage.vue) | 2 | 4 |
| Tests | 1 (test_coverage_expansion.py) | 7 | 4 |

## Test plan
- [x] `cd ui && npx eslint .` — 0 errors (879 warnings, all style)
- [x] `cd ui && npm run build` — builds successfully
- [x] `cd server && uv run pytest tests/ -v` — 876 passed, 3 skipped, 0 failures
- [x] `cd server && uv run ruff check app/ tests/` — clean

Co-Authored-By: agent-one team <agent-one@yanok.ai>