### PR TITLE
chore: fix unused router params and add eslint argsIgnorePattern

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -7,4 +7,9 @@ export default [
   { languageOptions: { globals: globals.browser } },
   js.configs.recommended,
   ...pluginVue.configs['flat/recommended'],
+  {
+    rules: {
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
+  },
 ]

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -19,7 +19,7 @@ const router = createRouter({
       component: () => import('../pages/ReplayPage.vue'),
     },
   ],
-  scrollBehavior(to, from, savedPosition) {
+  scrollBehavior(_to, _from, savedPosition) {
     if (savedPosition) return savedPosition
     return { top: 0 }
   },


### PR DESCRIPTION
## Summary
- Rename `to`/`from` to `_to`/`_from` in router `scrollBehavior` — fixes TypeScript unused-var diagnostics
- Add `argsIgnorePattern: '^_'` to eslint config — underscore-prefixed params are now allowed project-wide, matching common JS convention

## File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| Config | 1 (eslint.config.js) | 5 | 0 |
| Core | 1 (router/index.js) | 1 | 1 |

## Test plan
- [x] `cd ui && npx eslint .` — 0 errors
- [x] `cd ui && npm run build` — builds successfully

Co-Authored-By: agent-one team <agent-one@yanok.ai>