### PR TITLE
test: add 38 comprehensive upgrade system contract tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,8 @@ Every PR description **must** follow the template in `.github/PULL_REQUEST_TEMPL
 - In-memory (conversation_id on reasoner instance, cleared on simulation reset) (184-agents-api-threads)
 - Python 3.14+ (server), JavaScript/Vue 3 (UI) + FastAPI, mistralai SDK, Vue 3, Vite (185-rover-peer-messaging)
 - In-memory (AGENT_MESSAGES global list in world.py) (185-rover-peer-messaging)
+- Python 3.14+ + FastAPI (app), unittest (tests), app.world module (190-upgrade-system-tests)
+- In-memory WORLD dict (no database needed for these tests) (190-upgrade-system-tests)
 
 ## Recent Changes
 - 181-goal-confidence-tracking: Added Python 3.14+ (server), JavaScript/Vue 3 (UI) + FastAPI, Pydantic, Mistral AI SDK (server); Vue 3, Vite (UI)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Tests
+
+* **upgrade-system-tests:** add 38 comprehensive tests in `test_upgrade_contract.py` closing the validation gap on base and building upgrade systems:
+  - 6 base upgrade success path tests (all 4 types succeed, exact resource deduction, return value structure)
+  - 5 base upgrade effect verification tests (charge_mk2 doubles charge rate, extended_fuel +100 capacity, enhanced_scanner +1 radius, repair_bay auto-repair at station, repair_bay inactive no-op)
+  - 11 base upgrade failure tests (wrong position, insufficient water/gas independently, unknown name, max level per type for all 4 upgrades, drone/hauler blocked, missing param)
+  - 8 building upgrade bonus tests (refinery/solar_panel/accumulator at levels 2 and 3, accumulator interval clamp at 1, upgrade isolation between structures)
+  - 3 building upgrade failure tests (drone/hauler blocked, return value structure)
+  - 3 multi-level progression tests (extended_fuel level 2 = +200, enhanced_scanner level 2 = +2 radius, building re-upgrade preserves base_contents)
+  - 2 integration tests (full upgrade flow via execute_action, upgrade during active storm)
+
 ### Documentation
 
 * **docs:** refresh SPEC.md for v0.8.0 — comprehensive documentation of all features added since initial release: Agents API backend, goal confidence tracking, human-in-the-loop, peer messaging, hauler agent, narrator system, training data pipeline, storm system, resource economy, base upgrades, voice commands, and full API endpoint reference

--- a/server/tests/test_upgrade_contract.py
+++ b/server/tests/test_upgrade_contract.py
@@ -1,0 +1,561 @@
+"""Comprehensive upgrade system contract tests.
+
+Covers base upgrades (charge_mk2, extended_fuel, enhanced_scanner, repair_bay),
+building upgrades (refinery, solar_panel_structure, accumulator), multi-level
+progression, and integration flows.
+"""
+
+import copy
+import unittest
+
+from app import storm as storm_mod
+from app.world import (
+    CHARGE_RATE,
+    FUEL_CAPACITY_ROVER,
+    ROVER_REVEAL_RADIUS,
+    STRUCTURE_TYPES,
+    UPGRADES,
+    WORLD,
+    _apply_upgrade_bonuses,
+    _effective_fuel_capacity,
+    _execute_charge,
+    _execute_upgrade_base,
+    _get_upgrade_level,
+    _reveal_radius_for,
+    check_mission_status,
+    execute_action,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _WorldSaveRestore(unittest.TestCase):
+    """Base class that saves and restores WORLD state around each test."""
+
+    def setUp(self):
+        self._saved_world = {
+            "station_upgrades": copy.deepcopy(WORLD.get("station_upgrades", {})),
+            "station_resources": copy.deepcopy(
+                WORLD.get("station_resources", {"water": 0, "gas": 0, "parts": []})
+            ),
+            "structures": copy.deepcopy(WORLD.get("structures", [])),
+            "stones": copy.deepcopy(WORLD.get("stones", [])),
+            "ground_items": copy.deepcopy(WORLD.get("ground_items", [])),
+            "delivered_items": copy.deepcopy(WORLD.get("delivered_items", [])),
+            "storm": copy.deepcopy(WORLD.get("storm", storm_mod.make_storm_state())),
+            "base_effects": copy.deepcopy(WORLD.get("base_effects", {})),
+        }
+        self._saved_rover = copy.deepcopy(WORLD["agents"]["rover-mistral"])
+        self._saved_hauler = copy.deepcopy(WORLD["agents"]["hauler-mistral"])
+        self._saved_station = copy.deepcopy(WORLD["agents"]["station"])
+
+        # Clean slate
+        WORLD["station_upgrades"] = {}
+        WORLD["station_resources"] = {"water": 0, "gas": 0, "parts": []}
+        WORLD["structures"] = []
+        WORLD["stones"] = []
+        WORLD["ground_items"] = []
+        WORLD["delivered_items"] = []
+        WORLD["storm"] = storm_mod.make_storm_state()
+        WORLD["base_effects"] = {}
+
+        # Reset rover to station position
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["position"] = [0, 0]
+        rover["battery"] = 1.0
+        rover["inventory"] = []
+        rover["memory"] = []
+
+        # Reset hauler
+        hauler = WORLD["agents"]["hauler-mistral"]
+        hauler["position"] = [5, 5]
+        hauler["battery"] = 1.0
+        hauler["inventory"] = []
+        hauler["memory"] = []
+
+        # Reset station position
+        WORLD["agents"]["station"]["position"] = [0, 0]
+
+    def tearDown(self):
+        WORLD["agents"]["rover-mistral"] = self._saved_rover
+        WORLD["agents"]["hauler-mistral"] = self._saved_hauler
+        WORLD["agents"]["station"] = self._saved_station
+
+        for key, val in self._saved_world.items():
+            WORLD[key] = val
+
+
+def _make_structure(stype="solar_panel_structure", pos=(5, 6), active=True, upgrade_level=1):
+    """Create a structure dict with contents from STRUCTURE_TYPES templates."""
+    contents = {}
+    for template in STRUCTURE_TYPES:
+        if template["type"] == stype:
+            contents = dict(template["contents"])
+            break
+    return {
+        "type": stype,
+        "category": "building",
+        "position": list(pos),
+        "explored": True,
+        "active": active,
+        "upgrade_level": upgrade_level,
+        "description": f"Test {stype}",
+        "contents": contents,
+    }
+
+
+# ---------------------------------------------------------------------------
+# US1: Base Upgrade Contract Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBaseUpgradeSuccess(_WorldSaveRestore):
+    """Tests that each base upgrade type succeeds with correct prerequisites."""
+
+    def _setup_resources(self, water=100, gas=100):
+        WORLD["station_resources"] = {"water": water, "gas": gas, "parts": []}
+
+    def test_charge_mk2_succeeds(self):
+        self._setup_resources()
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "charge_mk2"})
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["new_level"], 1)
+        self.assertEqual(result["cost"], {"water": 50, "gas": 20})
+
+    def test_extended_fuel_succeeds(self):
+        self._setup_resources()
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "extended_fuel"})
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["new_level"], 1)
+        self.assertEqual(result["cost"], {"water": 30, "gas": 10})
+
+    def test_enhanced_scanner_succeeds(self):
+        self._setup_resources()
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "enhanced_scanner"})
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["new_level"], 1)
+        self.assertEqual(result["cost"], {"water": 20, "gas": 15})
+
+    def test_repair_bay_succeeds(self):
+        self._setup_resources()
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "repair_bay"})
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["new_level"], 1)
+        self.assertEqual(result["cost"], {"water": 40, "gas": 30})
+
+    def test_resource_deduction_exact(self):
+        """Each upgrade type deducts exactly the water/gas amounts from UPGRADES config."""
+        for upgrade_name, cfg in UPGRADES.items():
+            WORLD["station_upgrades"] = {}
+            WORLD["station_resources"] = {"water": 200, "gas": 200, "parts": []}
+            rover = WORLD["agents"]["rover-mistral"]
+            _execute_upgrade_base("rover-mistral", rover, {"upgrade": upgrade_name})
+            self.assertEqual(
+                WORLD["station_resources"]["water"],
+                200 - cfg["water"],
+                f"{upgrade_name}: water deduction mismatch",
+            )
+            self.assertEqual(
+                WORLD["station_resources"]["gas"],
+                200 - cfg["gas"],
+                f"{upgrade_name}: gas deduction mismatch",
+            )
+
+    def test_return_value_structure(self):
+        """Successful upgrade returns dict with expected keys."""
+        self._setup_resources()
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "charge_mk2"})
+        for key in ("ok", "upgrade", "new_level", "cost", "description"):
+            self.assertIn(key, result, f"Missing key: {key}")
+        self.assertIsInstance(result["cost"], dict)
+        self.assertIn("water", result["cost"])
+        self.assertIn("gas", result["cost"])
+
+
+class TestBaseUpgradeEffects(_WorldSaveRestore):
+    """Tests that each upgrade type's gameplay effect is correctly applied."""
+
+    def test_charge_mk2_doubles_charge_rate(self):
+        """With charge_mk2 active, charge rate is 2x the base CHARGE_RATE."""
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["battery"] = 0.1
+
+        # Charge without upgrade
+        WORLD["station_upgrades"] = {}
+        result_before = _execute_charge("rover-mistral", rover)
+        self.assertTrue(result_before["ok"])
+        rate_without = result_before["charge_rate"]
+
+        # Reset battery for second charge
+        rover["battery"] = 0.1
+        WORLD["station_upgrades"] = {"charge_mk2": 1}
+        result_after = _execute_charge("rover-mistral", rover)
+        self.assertTrue(result_after["ok"])
+        rate_with = result_after["charge_rate"]
+
+        self.assertAlmostEqual(rate_with, rate_without * 2, places=6)
+        self.assertAlmostEqual(rate_with, CHARGE_RATE * 2, places=6)
+
+    def test_extended_fuel_adds_100_capacity(self):
+        """With extended_fuel at level 1, rover fuel capacity increases by 100."""
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["type"] = "rover"
+        WORLD["station_upgrades"] = {}
+        base_capacity = _effective_fuel_capacity(rover)
+        self.assertEqual(base_capacity, FUEL_CAPACITY_ROVER)
+
+        WORLD["station_upgrades"] = {"extended_fuel": 1}
+        upgraded_capacity = _effective_fuel_capacity(rover)
+        self.assertEqual(upgraded_capacity, FUEL_CAPACITY_ROVER + 100)
+
+    def test_enhanced_scanner_adds_1_radius(self):
+        """With enhanced_scanner at level 1, rover reveal radius increases by 1."""
+        rover = WORLD["agents"]["rover-mistral"]
+        WORLD["station_upgrades"] = {}
+        base_radius = _reveal_radius_for(rover)
+        self.assertEqual(base_radius, ROVER_REVEAL_RADIUS)
+
+        WORLD["station_upgrades"] = {"enhanced_scanner": 1}
+        upgraded_radius = _reveal_radius_for(rover)
+        self.assertEqual(upgraded_radius, ROVER_REVEAL_RADIUS + 1)
+
+    def test_repair_bay_auto_repairs_at_station(self):
+        """With repair_bay active, rover at station gets battery set to 1.0 during tick."""
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["battery"] = 0.5
+        rover["position"] = [0, 0]
+        WORLD["agents"]["station"]["position"] = [0, 0]
+        WORLD["station_upgrades"] = {"repair_bay": 1}
+
+        # check_mission_status iterates agents and applies repair_bay
+        check_mission_status()
+        self.assertEqual(rover["battery"], 1.0)
+
+    def test_repair_bay_inactive_does_not_repair(self):
+        """Without repair_bay, rover battery is not auto-set to 1.0."""
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["battery"] = 0.5
+        rover["position"] = [0, 0]
+        WORLD["agents"]["station"]["position"] = [0, 0]
+        WORLD["station_upgrades"] = {}
+
+        check_mission_status()
+        # Battery should NOT be changed to 1.0 by repair_bay
+        self.assertLessEqual(rover["battery"], 0.5)
+
+
+class TestBaseUpgradeFailures(_WorldSaveRestore):
+    """Tests failure cases for base upgrades."""
+
+    def test_wrong_position(self):
+        """Upgrade fails when rover is not at station."""
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["position"] = [5, 5]
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "charge_mk2"})
+        self.assertFalse(result["ok"])
+        self.assertIn("station", result["error"].lower())
+
+    def test_insufficient_water_only(self):
+        """Upgrade fails when water is insufficient but gas is sufficient."""
+        WORLD["station_resources"] = {"water": 0, "gas": 100, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "charge_mk2"})
+        self.assertFalse(result["ok"])
+        self.assertIn("water", result["error"].lower())
+
+    def test_insufficient_gas_only(self):
+        """Upgrade fails when gas is insufficient but water is sufficient."""
+        WORLD["station_resources"] = {"water": 100, "gas": 0, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "charge_mk2"})
+        self.assertFalse(result["ok"])
+        self.assertIn("gas", result["error"].lower())
+
+    def test_unknown_upgrade_name(self):
+        """Upgrade fails for an unrecognized upgrade name."""
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "warp_drive"})
+        self.assertFalse(result["ok"])
+        self.assertIn("unknown", result["error"].lower())
+
+    def test_max_level_charge_mk2(self):
+        """charge_mk2 (max_level=1) cannot be upgraded past level 1."""
+        WORLD["station_upgrades"] = {"charge_mk2": 1}
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "charge_mk2"})
+        self.assertFalse(result["ok"])
+        self.assertIn("max level", result["error"].lower())
+
+    def test_max_level_extended_fuel(self):
+        """extended_fuel (max_level=2) cannot be upgraded past level 2."""
+        WORLD["station_upgrades"] = {"extended_fuel": 2}
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "extended_fuel"})
+        self.assertFalse(result["ok"])
+        self.assertIn("max level", result["error"].lower())
+
+    def test_max_level_enhanced_scanner(self):
+        """enhanced_scanner (max_level=2) cannot be upgraded past level 2."""
+        WORLD["station_upgrades"] = {"enhanced_scanner": 2}
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "enhanced_scanner"})
+        self.assertFalse(result["ok"])
+        self.assertIn("max level", result["error"].lower())
+
+    def test_max_level_repair_bay(self):
+        """repair_bay (max_level=1) cannot be upgraded past level 1."""
+        WORLD["station_upgrades"] = {"repair_bay": 1}
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "repair_bay"})
+        self.assertFalse(result["ok"])
+        self.assertIn("max level", result["error"].lower())
+
+    def test_drone_cannot_upgrade_base(self):
+        """Drones are blocked from using upgrade_base action."""
+        result = execute_action("drone-mistral", "upgrade_base", {"upgrade": "charge_mk2"})
+        self.assertFalse(result["ok"])
+        self.assertIn("drone", result["error"].lower())
+
+    def test_hauler_cannot_upgrade_base(self):
+        """Haulers are blocked from using upgrade_base action."""
+        result = execute_action("hauler-mistral", "upgrade_base", {"upgrade": "charge_mk2"})
+        self.assertFalse(result["ok"])
+        self.assertIn("hauler", result["error"].lower())
+
+    def test_missing_upgrade_param(self):
+        """Upgrade fails when no upgrade name is provided."""
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        result = _execute_upgrade_base("rover-mistral", rover, {})
+        self.assertFalse(result["ok"])
+        self.assertIn("unknown", result["error"].lower())
+
+
+# ---------------------------------------------------------------------------
+# US2: Building Upgrade Contract Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildingUpgradeBonuses(unittest.TestCase):
+    """Tests bonus calculations at each level for each structure type."""
+
+    def test_refinery_level2_bonus(self):
+        """Refinery at level 2: processing_capacity = int(round(50 * 1.5)) = 75."""
+        structure = _make_structure("refinery")
+        structure["upgrade_level"] = 2
+        _apply_upgrade_bonuses(structure)
+        self.assertEqual(structure["contents"]["processing_capacity"], int(round(50 * 1.5)))
+
+    def test_refinery_level3_bonus(self):
+        """Refinery at level 3: processing_capacity = int(round(50 * 2.25)) = 112."""
+        structure = _make_structure("refinery")
+        structure["upgrade_level"] = 3
+        _apply_upgrade_bonuses(structure)
+        self.assertEqual(structure["contents"]["processing_capacity"], int(round(50 * 2.25)))
+
+    def test_solar_panel_level2_bonus(self):
+        """Solar panel at level 2: charge_rate * 1.5, charge_radius + 1."""
+        structure = _make_structure("solar_panel_structure")
+        structure["upgrade_level"] = 2
+        _apply_upgrade_bonuses(structure)
+        self.assertAlmostEqual(structure["contents"]["charge_rate"], round(0.01 * 1.5, 5), places=5)
+        self.assertEqual(structure["contents"]["charge_radius"], 2)
+
+    def test_solar_panel_level3_bonus(self):
+        """Solar panel at level 3: charge_rate * 2.25, charge_radius + 2."""
+        structure = _make_structure("solar_panel_structure")
+        structure["upgrade_level"] = 3
+        _apply_upgrade_bonuses(structure)
+        self.assertAlmostEqual(
+            structure["contents"]["charge_rate"], round(0.01 * 2.25, 5), places=5
+        )
+        self.assertEqual(structure["contents"]["charge_radius"], 3)
+
+    def test_accumulator_level2_bonus(self):
+        """Accumulator at level 2: recharge_rate * 1.5, recharge_interval 5-1=4."""
+        structure = _make_structure("accumulator")
+        structure["upgrade_level"] = 2
+        _apply_upgrade_bonuses(structure)
+        self.assertAlmostEqual(
+            structure["contents"]["recharge_rate"], round(0.01 * 1.5, 5), places=5
+        )
+        self.assertEqual(structure["contents"]["recharge_interval"], 4)
+
+    def test_accumulator_level3_bonus(self):
+        """Accumulator at level 3: recharge_rate * 2.25, recharge_interval 5-2=3."""
+        structure = _make_structure("accumulator")
+        structure["upgrade_level"] = 3
+        _apply_upgrade_bonuses(structure)
+        self.assertAlmostEqual(
+            structure["contents"]["recharge_rate"], round(0.01 * 2.25, 5), places=5
+        )
+        self.assertEqual(structure["contents"]["recharge_interval"], 3)
+
+    def test_accumulator_interval_clamp_at_1(self):
+        """Accumulator with base interval=1 at level 3: max(1, 1-2) = 1."""
+        structure = _make_structure("accumulator")
+        structure["contents"]["recharge_interval"] = 1
+        structure["upgrade_level"] = 3
+        _apply_upgrade_bonuses(structure)
+        self.assertEqual(structure["contents"]["recharge_interval"], 1)
+
+    def test_upgrade_one_structure_does_not_affect_other(self):
+        """Upgrading one structure leaves other structures unchanged."""
+        refinery = _make_structure("refinery", pos=(5, 6))
+        solar = _make_structure("solar_panel_structure", pos=(7, 8))
+        original_solar_contents = dict(solar["contents"])
+
+        refinery["upgrade_level"] = 2
+        _apply_upgrade_bonuses(refinery)
+
+        # Solar panel should be unchanged
+        self.assertEqual(solar["contents"], original_solar_contents)
+
+
+class TestBuildingUpgradeFailures(_WorldSaveRestore):
+    """Tests failure cases for building upgrades."""
+
+    def test_drone_cannot_upgrade_building(self):
+        """Drones are blocked from using upgrade_building action."""
+        WORLD["structures"] = [_make_structure(pos=(5, 6))]
+        result = execute_action("drone-mistral", "upgrade_building", {})
+        self.assertFalse(result["ok"])
+        self.assertIn("drone", result["error"].lower())
+
+    def test_hauler_cannot_upgrade_building(self):
+        """Haulers are blocked from using upgrade_building action."""
+        WORLD["structures"] = [_make_structure(pos=(5, 6))]
+        result = execute_action("hauler-mistral", "upgrade_building", {})
+        self.assertFalse(result["ok"])
+        self.assertIn("hauler", result["error"].lower())
+
+    def test_building_upgrade_return_value_structure(self):
+        """Successful building upgrade returns dict with expected keys."""
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["position"] = [5, 5]
+        rover["battery"] = 1.0
+        rover["inventory"] = [
+            {"type": "basalt_vein", "grade": "low", "quantity": 25},
+        ]
+        WORLD["structures"] = [_make_structure(pos=(5, 6))]
+        result = execute_action("rover-mistral", "upgrade_building", {})
+        self.assertTrue(result["ok"])
+        for key in ("ok", "structure_type", "new_level", "position"):
+            self.assertIn(key, result, f"Missing key: {key}")
+
+
+# ---------------------------------------------------------------------------
+# US3: Multi-Level and Integration Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiLevelUpgrades(_WorldSaveRestore):
+    """Tests multi-level upgrade progression and cumulative effects."""
+
+    def test_extended_fuel_level2_adds_200(self):
+        """Two levels of extended_fuel adds 200 to fuel capacity."""
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["type"] = "rover"
+        WORLD["station_resources"] = {"water": 200, "gas": 200, "parts": []}
+
+        # Level 1
+        result1 = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "extended_fuel"})
+        self.assertTrue(result1["ok"])
+        self.assertEqual(result1["new_level"], 1)
+        self.assertEqual(_effective_fuel_capacity(rover), FUEL_CAPACITY_ROVER + 100)
+
+        # Level 2
+        result2 = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "extended_fuel"})
+        self.assertTrue(result2["ok"])
+        self.assertEqual(result2["new_level"], 2)
+        self.assertEqual(_effective_fuel_capacity(rover), FUEL_CAPACITY_ROVER + 200)
+
+    def test_enhanced_scanner_level2_adds_2_radius(self):
+        """Two levels of enhanced_scanner adds 2 to reveal radius."""
+        rover = WORLD["agents"]["rover-mistral"]
+        WORLD["station_resources"] = {"water": 200, "gas": 200, "parts": []}
+
+        result1 = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "enhanced_scanner"})
+        self.assertTrue(result1["ok"])
+        self.assertEqual(_reveal_radius_for(rover), ROVER_REVEAL_RADIUS + 1)
+
+        result2 = _execute_upgrade_base("rover-mistral", rover, {"upgrade": "enhanced_scanner"})
+        self.assertTrue(result2["ok"])
+        self.assertEqual(_reveal_radius_for(rover), ROVER_REVEAL_RADIUS + 2)
+
+    def test_building_re_upgrade_uses_base_contents(self):
+        """Re-upgrading a building preserves _base_contents and calculates from base."""
+        structure = _make_structure("solar_panel_structure")
+        base_rate = structure["contents"]["charge_rate"]
+        base_radius = structure["contents"]["charge_radius"]
+
+        # Upgrade to level 2
+        structure["upgrade_level"] = 2
+        _apply_upgrade_bonuses(structure)
+        self.assertIn("_base_contents", structure)
+        self.assertAlmostEqual(
+            structure["contents"]["charge_rate"], round(base_rate * 1.5, 5), places=5
+        )
+
+        # Upgrade to level 3 -- bonuses should be from base, not from level-2 values
+        structure["upgrade_level"] = 3
+        _apply_upgrade_bonuses(structure)
+        self.assertAlmostEqual(
+            structure["contents"]["charge_rate"], round(base_rate * 2.25, 5), places=5
+        )
+        self.assertEqual(structure["contents"]["charge_radius"], base_radius + 2)
+
+
+class TestUpgradeIntegration(_WorldSaveRestore):
+    """Integration tests for upgrade flows."""
+
+    def test_full_base_upgrade_flow(self):
+        """Full flow: set resources, upgrade via execute_action, verify effect."""
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["position"] = [0, 0]
+
+        # Upgrade via execute_action (tests the routing layer)
+        result = execute_action("rover-mistral", "upgrade_base", {"upgrade": "enhanced_scanner"})
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["upgrade"], "enhanced_scanner")
+
+        # Verify resources deducted
+        self.assertEqual(WORLD["station_resources"]["water"], 100 - 20)
+        self.assertEqual(WORLD["station_resources"]["gas"], 100 - 15)
+
+        # Verify effect applied
+        self.assertEqual(_get_upgrade_level("enhanced_scanner"), 1)
+        self.assertEqual(_reveal_radius_for(rover), ROVER_REVEAL_RADIUS + 1)
+
+    def test_upgrade_during_storm(self):
+        """Base upgrade succeeds during an active storm (storms don't block upgrades)."""
+        WORLD["station_resources"] = {"water": 100, "gas": 100, "parts": []}
+        WORLD["storm"] = {
+            "phase": "active",
+            "next_storm_tick": 0,
+            "active_start": 0,
+            "active_end": 100,
+            "intensity": 0.8,
+            "warning_start": 0,
+        }
+        rover = WORLD["agents"]["rover-mistral"]
+        rover["position"] = [0, 0]
+
+        result = execute_action("rover-mistral", "upgrade_base", {"upgrade": "charge_mk2"})
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["new_level"], 1)

--- a/specs/190-upgrade-system-tests/checklists/requirements.md
+++ b/specs/190-upgrade-system-tests/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Upgrade System Tests
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` and `/speckit.plan`.
+- Assumptions: Tests target the existing implementation without modifying production code. Test patterns follow existing conventions from test_upgrades.py and test_coverage_expansion.py.

--- a/specs/190-upgrade-system-tests/data-model.md
+++ b/specs/190-upgrade-system-tests/data-model.md
@@ -1,0 +1,63 @@
+# Data Model: Upgrade System Tests
+
+This feature does not introduce new data entities. It tests existing entities documented below for reference.
+
+## Existing Entities Under Test
+
+### Base Upgrade (UPGRADES dict)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| water | int | Water cost from station_resources |
+| gas | int | Gas cost from station_resources |
+| description | str | Human-readable upgrade description |
+| max_level | int | Maximum upgrade level (1 or 2) |
+
+**Instances**:
+- `charge_mk2`: water=50, gas=20, max_level=1 -- doubles station charge rate
+- `extended_fuel`: water=30, gas=10, max_level=2 -- +100 rover fuel capacity per level
+- `enhanced_scanner`: water=20, gas=15, max_level=2 -- +1 rover reveal radius per level
+- `repair_bay`: water=40, gas=30, max_level=1 -- auto-repair rovers at station
+
+### Station Upgrades State (WORLD["station_upgrades"])
+
+| Field | Type | Description |
+|-------|------|-------------|
+| {upgrade_name} | int | Current level of each upgrade (0 = not purchased) |
+
+### Station Resources (WORLD["station_resources"])
+
+| Field | Type | Description |
+|-------|------|-------------|
+| water | int | Water available for upgrades |
+| gas | int | Gas available for upgrades |
+| parts | list | Salvaged parts (not used by base upgrades) |
+
+### Structure (building upgrade target)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| type | str | One of: refinery, solar_panel_structure, accumulator |
+| position | list[int] | [x, y] grid position |
+| active | bool | Whether structure is operational |
+| upgrade_level | int | Current level (1-3, default 1) |
+| contents | dict | Type-specific attributes (affected by bonuses) |
+| _base_contents | dict | Cached original contents (set on first bonus application) |
+
+**Contents by type**:
+- refinery: `{processing_capacity: 50}`
+- solar_panel_structure: `{charge_rate: 0.01, charge_interval: 2, charge_radius: 1}`
+- accumulator: `{capacity_bonus: 0.20, recharge_rate: 0.01, recharge_interval: 5}`
+
+### Bonus Formula
+
+`multiplier = 1.5 ^ (level - 1)`
+
+| Level | Multiplier |
+|-------|-----------|
+| 1 | 1.0 |
+| 2 | 1.5 |
+| 3 | 2.25 |
+
+Solar panel charge_radius: `base_radius + (level - 1)`
+Accumulator recharge_interval: `max(1, base_interval - (level - 1))`

--- a/specs/190-upgrade-system-tests/plan.md
+++ b/specs/190-upgrade-system-tests/plan.md
@@ -1,0 +1,58 @@
+# Implementation Plan: Upgrade System Tests
+
+**Branch**: `190-upgrade-system-tests` | **Date**: 2026-03-06 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/190-upgrade-system-tests/spec.md`
+
+## Summary
+
+Close the validation gap on the base upgrade and building upgrade systems by writing comprehensive tests. Create `server/tests/test_upgrade_contract.py` with 25+ tests covering all 4 base upgrade types (charge_mk2, extended_fuel, enhanced_scanner, repair_bay), all 3 building structure types (refinery, solar_panel_structure, accumulator) with level-by-level bonus validation, multi-level progression, and integration flows. Tests exercise `_execute_upgrade_base()`, `_execute_upgrade_building()`, `_apply_upgrade_bonuses()` and the `execute_action()` routing layer.
+
+## Technical Context
+
+**Language/Version**: Python 3.14+
+**Primary Dependencies**: FastAPI (app), unittest (tests), app.world module
+**Storage**: In-memory WORLD dict (no database needed for these tests)
+**Testing**: pytest with unittest.TestCase classes; direct world state manipulation
+**Target Platform**: Server-side (macOS/Linux)
+**Project Type**: Web service (test suite addition)
+**Performance Goals**: N/A (unit/contract tests)
+**Constraints**: Tests only -- no production code changes unless a genuine bug is discovered
+**Scale/Scope**: Single new test file, 25+ test methods
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution file contains only placeholder template content (no project-specific principles ratified). No gates to evaluate. Proceeding.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/190-upgrade-system-tests/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+server/
+├── app/
+│   └── world.py           # Production code (read-only for this feature)
+└── tests/
+    ├── test_upgrades.py              # Existing building upgrade tests
+    ├── test_coverage_expansion.py    # Existing base upgrade edge case tests
+    ├── test_resources.py             # Existing base upgrade basic test
+    └── test_upgrade_contract.py      # NEW: comprehensive upgrade contract tests
+```
+
+**Structure Decision**: Single new test file `server/tests/test_upgrade_contract.py` following existing test conventions. Uses `_WorldSaveRestore` pattern from `test_coverage_expansion.py` for world state isolation.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/190-upgrade-system-tests/quickstart.md
+++ b/specs/190-upgrade-system-tests/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Upgrade System Tests
+
+## Run the new tests
+
+```bash
+cd server
+uv run pytest tests/test_upgrade_contract.py -x -q
+```
+
+## Run all tests (including existing upgrade tests)
+
+```bash
+cd server
+uv run pytest tests/ -x -q
+```
+
+## Format and lint before committing
+
+```bash
+cd server && uv run ruff format app/ tests/ && uv run ruff check --fix app/ tests/
+```
+
+## File locations
+
+- New test file: `server/tests/test_upgrade_contract.py`
+- Production code under test: `server/app/world.py`
+- Existing upgrade tests: `server/tests/test_upgrades.py`, `server/tests/test_coverage_expansion.py`, `server/tests/test_resources.py`

--- a/specs/190-upgrade-system-tests/research.md
+++ b/specs/190-upgrade-system-tests/research.md
@@ -1,0 +1,65 @@
+# Research: Upgrade System Tests
+
+## R1: Test Pattern for World State Isolation
+
+**Decision**: Use `_WorldSaveRestore` base class pattern from `test_coverage_expansion.py`
+**Rationale**: This pattern saves/restores all relevant WORLD state keys (station_upgrades, station_resources, structures, stones, agents) in setUp/tearDown. It provides clean-slate isolation without requiring database access. Already proven in 15+ tests.
+**Alternatives considered**:
+- `CaseWithDB` base class from conftest: Requires SurrealDB; overkill for in-memory world state tests
+- Direct copy of setUp/tearDown from `test_upgrades.py`: Less comprehensive state restoration (misses station_upgrades, station_resources)
+- Fresh `_build_initial_world()` per test: Would require module-level patching of WORLD global; fragile
+
+## R2: How to Test Base Upgrade Effects
+
+**Decision**: Test each upgrade effect by calling the relevant helper function or action after setting station_upgrades:
+- `charge_mk2`: Call `_execute_charge()` or `execute_action("rover-mistral", "charge", {})` and compare charge rate with/without upgrade
+- `extended_fuel`: Call `_effective_fuel_capacity(agent)` and verify +100 per level
+- `enhanced_scanner`: Call `_reveal_radius_for(agent)` and verify +1 per level
+- `repair_bay`: Set up world state mimicking station tick logic (rover at station, repair_bay > 0) and verify battery = 1.0
+
+**Rationale**: Testing via the actual helper functions validates the real code paths. The effect functions read from `WORLD["station_upgrades"]` which we control directly.
+**Alternatives considered**:
+- Mocking `_get_upgrade_level()`: Would bypass the actual integration; less valuable
+- Testing only via `execute_action()`: Some effects (fuel capacity, reveal radius) are checked via helper functions, not actions
+
+## R3: How to Test Building Upgrade Bonuses Precisely
+
+**Decision**: Test `_apply_upgrade_bonuses()` directly with structure dicts at each level, then verify exact computed values using known formulas:
+- Level 1: multiplier = 1.0 (1.5^0)
+- Level 2: multiplier = 1.5 (1.5^1)
+- Level 3: multiplier = 2.25 (1.5^2)
+
+**Rationale**: Direct function testing gives precise control over inputs and expected outputs. The multiplier formula is deterministic.
+**Alternatives considered**:
+- Testing only via `_execute_upgrade_building()`: Couples bonus validation with upgrade action prerequisites; harder to isolate math errors
+
+## R4: Existing Test Coverage Overlap Analysis
+
+**Decision**: The new test file will NOT duplicate tests already in `test_upgrades.py` and `test_coverage_expansion.py`. It will add:
+- Effect verification tests (charge_mk2 effect, extended_fuel effect, etc.) -- NOT covered anywhere
+- Per-type max_level enforcement -- partially covered (only charge_mk2 in test_coverage_expansion)
+- Multi-level progression tests -- NOT covered
+- Building upgrade per-structure-type bonus validation at all levels -- NOT covered (only solar_panel at level 2)
+- Accumulator and refinery bonus tests -- NOT covered
+- Integration flow tests -- NOT covered
+- Return value structure validation -- NOT covered
+
+**Rationale**: Avoids bloat while closing the actual validation gap.
+**Alternatives considered**:
+- Merge into existing test files: Would make them too large; separate contract test file is cleaner
+
+## R5: Imports Required
+
+**Decision**: Import from `app.world`:
+- `WORLD` (global state dict)
+- `execute_action` (action routing)
+- `_execute_upgrade_base`, `_execute_upgrade_building`, `_apply_upgrade_bonuses` (direct function testing)
+- `_effective_fuel_capacity`, `_reveal_radius_for`, `_get_upgrade_level` (effect verification)
+- `_execute_charge` (charge_mk2 effect verification)
+- `UPGRADES`, `UPGRADE_MAX_LEVEL`, `MAX_UPGRADE_LEVEL` (constants)
+- `CHARGE_RATE`, `FUEL_CAPACITY_ROVER`, `ROVER_REVEAL_RADIUS` (baseline values)
+- `BATTERY_COST_UPGRADE`, `UPGRADE_BASALT_COST` (cost constants)
+- `STRUCTURE_TYPES` (for structure template creation)
+- `storm` module import via `app.world` for storm state
+
+**Rationale**: Direct imports allow precise testing without going through action routing for unit-level tests.

--- a/specs/190-upgrade-system-tests/spec.md
+++ b/specs/190-upgrade-system-tests/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Upgrade System Tests
+
+**Feature Branch**: `190-upgrade-system-tests`
+**Created**: 2026-03-06
+**Status**: Draft
+**Input**: User description: "Close the validation gap on the base upgrade and building upgrade systems by writing comprehensive tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Base Upgrade Contract Validation (Priority: P1)
+
+As a developer maintaining the Mars simulation, I need comprehensive tests for the base upgrade system so that all 4 upgrade types (charge_mk2, extended_fuel, enhanced_scanner, repair_bay) are validated for correct behavior including prerequisites, resource costs, level tracking, and applied effects.
+
+**Why this priority**: Base upgrades directly affect core agent capabilities (charge rate, fuel capacity, scanner radius, auto-repair). Without comprehensive test coverage, regressions in these systems would silently break gameplay.
+
+**Independent Test**: Can be fully tested by running the test suite against the world module's `_execute_upgrade_base()` function and verifying each upgrade type's contract independently.
+
+**Acceptance Scenarios**:
+
+1. **Given** a rover at the station with sufficient resources, **When** each of the 4 upgrade types is applied, **Then** the upgrade succeeds, level increments, and correct resources are deducted.
+2. **Given** a successful charge_mk2 upgrade, **When** a rover charges at the station, **Then** the charge rate is doubled compared to pre-upgrade.
+3. **Given** a successful extended_fuel upgrade at level 1, **When** the rover's effective fuel capacity is checked, **Then** it is increased by 100.
+4. **Given** a successful enhanced_scanner upgrade at level 1, **When** the rover's reveal radius is checked, **Then** it is increased by 1.
+5. **Given** a successful repair_bay upgrade, **When** a rover is at the station during a tick, **Then** the rover's battery is set to full.
+6. **Given** a rover not at the station, **When** an upgrade is attempted, **Then** the upgrade fails with a position error.
+7. **Given** insufficient water or gas, **When** an upgrade is attempted, **Then** the upgrade fails with a resource error.
+8. **Given** an upgrade already at max_level, **When** a further upgrade is attempted, **Then** the upgrade fails with a max level error.
+9. **Given** a drone or hauler agent, **When** an upgrade_base action is attempted, **Then** it is rejected.
+
+---
+
+### User Story 2 - Building Upgrade Contract Validation (Priority: P2)
+
+As a developer, I need comprehensive tests for the building upgrade system so that each structure type (refinery, solar_panel_structure, accumulator) is validated for correct bonus calculations at all upgrade levels.
+
+**Why this priority**: Building upgrades use a multiplier formula (1.5^(level-1)) that affects multiple structure attributes differently. Without level-by-level validation, subtle math errors could go undetected.
+
+**Independent Test**: Can be fully tested by running the test suite against `_execute_upgrade_building()` and `_apply_upgrade_bonuses()` with each structure type at each upgrade level.
+
+**Acceptance Scenarios**:
+
+1. **Given** a refinery at level 1, **When** upgraded to level 2, **Then** processing_capacity is multiplied by 1.5.
+2. **Given** a refinery at level 2, **When** upgraded to level 3, **Then** processing_capacity is multiplied by 2.25 (from base).
+3. **Given** a solar panel at level 1, **When** upgraded to level 2, **Then** charge_rate is multiplied by 1.5 and charge_radius increases by 1.
+4. **Given** a solar panel at level 2, **When** upgraded to level 3, **Then** charge_rate is multiplied by 2.25 (from base) and charge_radius increases by 2 (from base).
+5. **Given** an accumulator at level 1, **When** upgraded to level 2, **Then** recharge_rate is multiplied by 1.5 and recharge_interval decreases by 1.
+6. **Given** an accumulator at level 2, **When** upgraded to level 3, **Then** recharge_interval is clamped at minimum 1.
+7. **Given** one structure upgraded, **When** a different structure is inspected, **Then** it remains unchanged.
+8. **Given** a drone or hauler agent, **When** an upgrade_building action is attempted, **Then** it is rejected.
+
+---
+
+### User Story 3 - Multi-Level and Integration Validation (Priority: P3)
+
+As a developer, I need integration tests that validate multi-level upgrade progression and end-to-end flows (resources gathered, upgrade applied, effect verified) to ensure the upgrade systems work correctly as part of the broader simulation.
+
+**Why this priority**: Individual unit tests may pass while integration between resource management and upgrade effects could still break. Multi-level tests catch cumulative calculation errors.
+
+**Independent Test**: Can be fully tested by setting up world state with resources, executing upgrades at multiple levels, and verifying cumulative effects.
+
+**Acceptance Scenarios**:
+
+1. **Given** extended_fuel upgraded twice (to level 2), **When** the rover's effective fuel capacity is checked, **Then** it is increased by 200.
+2. **Given** enhanced_scanner upgraded twice (to level 2), **When** the rover's reveal radius is checked, **Then** it is increased by 2.
+3. **Given** a rover with resources at the station, **When** a base upgrade is performed followed by verifying the effect, **Then** the full flow succeeds.
+4. **Given** an active storm, **When** a rover at the station upgrades, **Then** the upgrade still succeeds (storms do not block upgrades).
+
+---
+
+### Edge Cases
+
+- What happens when upgrade_base is called with no `upgrade` parameter (None/missing)?
+- What happens when station_resources key does not exist in the world state?
+- What happens when a building is upgraded and then re-upgraded (base_contents caching)?
+- What happens when multiple structures are adjacent and only the first is targeted?
+- What happens when accumulator recharge_interval would go below 1 after multiple upgrades?
+- What happens when the return value structure from upgrade actions is missing expected keys?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Tests MUST validate all 4 base upgrade types succeed when prerequisites are met (correct position, sufficient resources, below max_level)
+- **FR-002**: Tests MUST verify each base upgrade type's specific gameplay effect is correctly applied (charge_mk2 doubles charge rate, extended_fuel adds 100 capacity, enhanced_scanner adds 1 radius, repair_bay enables auto-repair)
+- **FR-003**: Tests MUST verify exact resource deduction (water and gas) for each upgrade type matches the UPGRADES configuration
+- **FR-004**: Tests MUST verify max_level enforcement per upgrade type (charge_mk2 max 1, extended_fuel max 2, enhanced_scanner max 2, repair_bay max 1)
+- **FR-005**: Tests MUST verify failure cases: wrong position, insufficient water only, insufficient gas only, unknown upgrade name, drone/hauler agent types
+- **FR-006**: Tests MUST validate building upgrade bonus calculations at each level (1, 2, 3) for each structure type (refinery, solar_panel_structure, accumulator)
+- **FR-007**: Tests MUST verify solar panel charge_radius increases by (level - 1) from base
+- **FR-008**: Tests MUST verify accumulator recharge_interval is clamped at minimum 1
+- **FR-009**: Tests MUST verify upgrading one structure does not affect other structures
+- **FR-010**: Tests MUST verify multi-level upgrades produce cumulative effects (e.g., extended_fuel level 2 = +200 capacity)
+- **FR-011**: Tests MUST verify return value structure contains expected keys (ok, upgrade/structure_type, new_level, etc.)
+- **FR-012**: Tests MUST verify drone and hauler agents cannot use upgrade_building action
+
+### Key Entities
+
+- **Base Upgrade**: One of 4 station upgrade types with water/gas costs, max_level, and gameplay effects; tracked in station_upgrades dict
+- **Building Upgrade**: Structure-level upgrade with level 1-3 range, basalt cost, battery cost, and type-specific bonus multipliers
+- **Station Resources**: Water and gas reserves used as currency for base upgrades
+- **Structure**: In-world building (refinery, solar_panel_structure, accumulator) that can be upgraded with level-specific bonus calculations
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of the 4 base upgrade types have at least one success-path test and one failure-path test
+- **SC-002**: All 4 base upgrade effect verifications pass (charge rate doubling, fuel capacity increase, scanner radius increase, auto-repair)
+- **SC-003**: All 3 building structure types have bonus calculations validated at levels 1, 2, and 3
+- **SC-004**: All tests pass when run via `uv run pytest tests/test_upgrade_contract.py -x -q`
+- **SC-005**: No production code is modified (tests-only change) unless a genuine bug is discovered
+- **SC-006**: Test count in the new file is at least 25 covering the specified scenarios

--- a/specs/190-upgrade-system-tests/tasks.md
+++ b/specs/190-upgrade-system-tests/tasks.md
@@ -1,0 +1,197 @@
+# Tasks: Upgrade System Tests
+
+**Input**: Design documents from `/specs/190-upgrade-system-tests/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+
+**Organization**: Tasks are grouped by user story. This is a test-only feature -- all tasks create test methods in a single file `server/tests/test_upgrade_contract.py`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different test classes, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create test file with imports, helpers, and base class
+
+- [x] T001 Create `server/tests/test_upgrade_contract.py` with imports (WORLD, execute_action, _execute_upgrade_base, _execute_upgrade_building, _apply_upgrade_bonuses, _effective_fuel_capacity, _reveal_radius_for, _get_upgrade_level, _execute_charge, UPGRADES, UPGRADE_MAX_LEVEL, MAX_UPGRADE_LEVEL, CHARGE_RATE, FUEL_CAPACITY_ROVER, ROVER_REVEAL_RADIUS, BATTERY_COST_UPGRADE, UPGRADE_BASALT_COST, STRUCTURE_TYPES, storm module)
+- [x] T002 Implement `_WorldSaveRestore` base class in `server/tests/test_upgrade_contract.py` (save/restore WORLD state: station_upgrades, station_resources, structures, stones, ground_items, delivered_items, storm, rover agent, hauler agent, station agent; clean-slate setUp with rover at [0,0], battery=1.0, station at [0,0])
+- [x] T003 Implement `_make_structure()` helper in `server/tests/test_upgrade_contract.py` (create structure dict with type, position, active, upgrade_level, contents from STRUCTURE_TYPES templates)
+
+**Checkpoint**: Test file scaffolding is ready; all subsequent tasks add test methods
+
+---
+
+## Phase 2: User Story 1 - Base Upgrade Contract Validation (Priority: P1)
+
+**Goal**: Validate all 4 base upgrade types for correct behavior including success paths, effect verification, failure cases, and agent type restrictions
+
+**Independent Test**: `cd server && uv run pytest tests/test_upgrade_contract.py::TestBaseUpgradeSuccess -x -q && uv run pytest tests/test_upgrade_contract.py::TestBaseUpgradeEffects -x -q && uv run pytest tests/test_upgrade_contract.py::TestBaseUpgradeFailures -x -q`
+
+### Success Path Tests
+
+- [x] T004 [P] [US1] Write `TestBaseUpgradeSuccess.test_charge_mk2_succeeds` in `server/tests/test_upgrade_contract.py` -- rover at station, water=100, gas=100, upgrade charge_mk2, assert ok=True, new_level=1, cost={water:50, gas:20}
+- [x] T005 [P] [US1] Write `TestBaseUpgradeSuccess.test_extended_fuel_succeeds` in `server/tests/test_upgrade_contract.py` -- rover at station, water=100, gas=100, upgrade extended_fuel, assert ok=True, new_level=1, cost={water:30, gas:10}
+- [x] T006 [P] [US1] Write `TestBaseUpgradeSuccess.test_enhanced_scanner_succeeds` in `server/tests/test_upgrade_contract.py` -- rover at station, water=100, gas=100, upgrade enhanced_scanner, assert ok=True, new_level=1, cost={water:20, gas:15}
+- [x] T007 [P] [US1] Write `TestBaseUpgradeSuccess.test_repair_bay_succeeds` in `server/tests/test_upgrade_contract.py` -- rover at station, water=100, gas=100, upgrade repair_bay, assert ok=True, new_level=1, cost={water:40, gas:30}
+- [x] T008 [P] [US1] Write `TestBaseUpgradeSuccess.test_resource_deduction_exact` in `server/tests/test_upgrade_contract.py` -- for each upgrade type, verify station_resources water and gas are deducted by exact amounts from UPGRADES config
+- [x] T009 [P] [US1] Write `TestBaseUpgradeSuccess.test_return_value_structure` in `server/tests/test_upgrade_contract.py` -- verify result dict contains keys: ok, upgrade, new_level, cost, description
+
+### Effect Verification Tests
+
+- [x] T010 [P] [US1] Write `TestBaseUpgradeEffects.test_charge_mk2_doubles_charge_rate` in `server/tests/test_upgrade_contract.py` -- set station_upgrades={}, charge rover (record rate), set station_upgrades={"charge_mk2": 1}, charge rover again, assert second charge rate is 2x first via _execute_charge() or CHARGE_RATE comparison
+- [x] T011 [P] [US1] Write `TestBaseUpgradeEffects.test_extended_fuel_adds_100_capacity` in `server/tests/test_upgrade_contract.py` -- set station_upgrades={"extended_fuel": 1}, call _effective_fuel_capacity(rover), assert equals FUEL_CAPACITY_ROVER + 100
+- [x] T012 [P] [US1] Write `TestBaseUpgradeEffects.test_enhanced_scanner_adds_1_radius` in `server/tests/test_upgrade_contract.py` -- set station_upgrades={"enhanced_scanner": 1}, call _reveal_radius_for(rover), assert equals ROVER_REVEAL_RADIUS + 1
+- [x] T013 [P] [US1] Write `TestBaseUpgradeEffects.test_repair_bay_auto_repairs_at_station` in `server/tests/test_upgrade_contract.py` -- set station_upgrades={"repair_bay": 1}, rover at station with battery=0.5, verify auto-repair logic sets battery=1.0
+
+### Failure Case Tests
+
+- [x] T014 [P] [US1] Write `TestBaseUpgradeFailures.test_wrong_position` in `server/tests/test_upgrade_contract.py` -- rover at [5,5], station at [0,0], attempt upgrade, assert ok=False, error contains position message
+- [x] T015 [P] [US1] Write `TestBaseUpgradeFailures.test_insufficient_water_only` in `server/tests/test_upgrade_contract.py` -- rover at station, water=0, gas=100, attempt charge_mk2, assert ok=False, error mentions water
+- [x] T016 [P] [US1] Write `TestBaseUpgradeFailures.test_insufficient_gas_only` in `server/tests/test_upgrade_contract.py` -- rover at station, water=100, gas=0, attempt charge_mk2, assert ok=False, error mentions gas
+- [x] T017 [P] [US1] Write `TestBaseUpgradeFailures.test_unknown_upgrade_name` in `server/tests/test_upgrade_contract.py` -- rover at station, attempt upgrade "nonexistent", assert ok=False, error mentions unknown
+- [x] T018 [P] [US1] Write `TestBaseUpgradeFailures.test_max_level_charge_mk2` in `server/tests/test_upgrade_contract.py` -- station_upgrades={"charge_mk2": 1}, attempt upgrade charge_mk2 again, assert ok=False, error mentions max level
+- [x] T019 [P] [US1] Write `TestBaseUpgradeFailures.test_max_level_extended_fuel` in `server/tests/test_upgrade_contract.py` -- station_upgrades={"extended_fuel": 2}, attempt upgrade extended_fuel again, assert ok=False
+- [x] T020 [P] [US1] Write `TestBaseUpgradeFailures.test_max_level_enhanced_scanner` in `server/tests/test_upgrade_contract.py` -- station_upgrades={"enhanced_scanner": 2}, attempt upgrade enhanced_scanner again, assert ok=False
+- [x] T021 [P] [US1] Write `TestBaseUpgradeFailures.test_max_level_repair_bay` in `server/tests/test_upgrade_contract.py` -- station_upgrades={"repair_bay": 1}, attempt upgrade repair_bay again, assert ok=False
+- [x] T022 [P] [US1] Write `TestBaseUpgradeFailures.test_drone_cannot_upgrade_base` in `server/tests/test_upgrade_contract.py` -- execute_action("drone-mistral", "upgrade_base", {...}), assert ok=False, error mentions drone
+- [x] T023 [P] [US1] Write `TestBaseUpgradeFailures.test_hauler_cannot_upgrade_base` in `server/tests/test_upgrade_contract.py` -- execute_action("hauler-mistral", "upgrade_base", {...}), assert ok=False, error mentions hauler
+- [x] T024 [P] [US1] Write `TestBaseUpgradeFailures.test_missing_upgrade_param` in `server/tests/test_upgrade_contract.py` -- rover at station, attempt upgrade_base with no upgrade param (None), assert ok=False
+
+**Checkpoint**: All base upgrade contract tests pass independently via `uv run pytest tests/test_upgrade_contract.py -k "TestBaseUpgrade" -x -q`
+
+---
+
+## Phase 3: User Story 2 - Building Upgrade Contract Validation (Priority: P2)
+
+**Goal**: Validate building upgrade bonus calculations at all levels for each structure type (refinery, solar_panel_structure, accumulator)
+
+**Independent Test**: `cd server && uv run pytest tests/test_upgrade_contract.py::TestBuildingUpgradeBonuses -x -q && uv run pytest tests/test_upgrade_contract.py::TestBuildingUpgradeFailures -x -q`
+
+### Bonus Calculation Tests
+
+- [x] T025 [P] [US2] Write `TestBuildingUpgradeBonuses.test_refinery_level2_bonus` in `server/tests/test_upgrade_contract.py` -- create refinery structure, set upgrade_level=2, call _apply_upgrade_bonuses(), assert processing_capacity == int(round(50 * 1.5))
+- [x] T026 [P] [US2] Write `TestBuildingUpgradeBonuses.test_refinery_level3_bonus` in `server/tests/test_upgrade_contract.py` -- create refinery, set upgrade_level=3, call _apply_upgrade_bonuses(), assert processing_capacity == int(round(50 * 2.25))
+- [x] T027 [P] [US2] Write `TestBuildingUpgradeBonuses.test_solar_panel_level2_bonus` in `server/tests/test_upgrade_contract.py` -- create solar_panel_structure, set upgrade_level=2, call _apply_upgrade_bonuses(), assert charge_rate == round(0.01 * 1.5, 5) and charge_radius == 2
+- [x] T028 [P] [US2] Write `TestBuildingUpgradeBonuses.test_solar_panel_level3_bonus` in `server/tests/test_upgrade_contract.py` -- create solar_panel_structure, set upgrade_level=3, call _apply_upgrade_bonuses(), assert charge_rate == round(0.01 * 2.25, 5) and charge_radius == 3
+- [x] T029 [P] [US2] Write `TestBuildingUpgradeBonuses.test_accumulator_level2_bonus` in `server/tests/test_upgrade_contract.py` -- create accumulator, set upgrade_level=2, call _apply_upgrade_bonuses(), assert recharge_rate == round(0.01 * 1.5, 5) and recharge_interval == 4
+- [x] T030 [P] [US2] Write `TestBuildingUpgradeBonuses.test_accumulator_level3_bonus` in `server/tests/test_upgrade_contract.py` -- create accumulator, set upgrade_level=3, call _apply_upgrade_bonuses(), assert recharge_rate == round(0.01 * 2.25, 5) and recharge_interval == max(1, 5-2) == 3
+- [x] T031 [P] [US2] Write `TestBuildingUpgradeBonuses.test_accumulator_interval_clamp_at_1` in `server/tests/test_upgrade_contract.py` -- create accumulator with base recharge_interval=1, set upgrade_level=3, call _apply_upgrade_bonuses(), assert recharge_interval == max(1, 1-2) == 1
+- [x] T032 [P] [US2] Write `TestBuildingUpgradeBonuses.test_upgrade_one_structure_does_not_affect_other` in `server/tests/test_upgrade_contract.py` -- create two structures (refinery + solar panel), upgrade only refinery via execute_action, verify solar panel contents unchanged
+
+### Building Upgrade Failure Tests
+
+- [x] T033 [P] [US2] Write `TestBuildingUpgradeFailures.test_drone_cannot_upgrade_building` in `server/tests/test_upgrade_contract.py` -- execute_action("drone-mistral", "upgrade_building", {}), assert ok=False
+- [x] T034 [P] [US2] Write `TestBuildingUpgradeFailures.test_hauler_cannot_upgrade_building` in `server/tests/test_upgrade_contract.py` -- execute_action("hauler-mistral", "upgrade_building", {}), assert ok=False
+- [x] T035 [P] [US2] Write `TestBuildingUpgradeFailures.test_building_upgrade_return_value_structure` in `server/tests/test_upgrade_contract.py` -- successful building upgrade, verify result contains keys: ok, structure_type, new_level, position
+
+**Checkpoint**: All building upgrade contract tests pass via `uv run pytest tests/test_upgrade_contract.py -k "TestBuildingUpgrade" -x -q`
+
+---
+
+## Phase 4: User Story 3 - Multi-Level and Integration Validation (Priority: P3)
+
+**Goal**: Validate multi-level upgrade progression and end-to-end integration flows
+
+**Independent Test**: `cd server && uv run pytest tests/test_upgrade_contract.py::TestMultiLevelUpgrades -x -q && uv run pytest tests/test_upgrade_contract.py::TestUpgradeIntegration -x -q`
+
+### Multi-Level Tests
+
+- [x] T036 [P] [US3] Write `TestMultiLevelUpgrades.test_extended_fuel_level2_adds_200` in `server/tests/test_upgrade_contract.py` -- upgrade extended_fuel twice (level 1 then level 2), verify _effective_fuel_capacity(rover) == FUEL_CAPACITY_ROVER + 200
+- [x] T037 [P] [US3] Write `TestMultiLevelUpgrades.test_enhanced_scanner_level2_adds_2_radius` in `server/tests/test_upgrade_contract.py` -- upgrade enhanced_scanner twice, verify _reveal_radius_for(rover) == ROVER_REVEAL_RADIUS + 2
+- [x] T038 [P] [US3] Write `TestMultiLevelUpgrades.test_building_re_upgrade_uses_base_contents` in `server/tests/test_upgrade_contract.py` -- upgrade building to level 2, then level 3, verify _base_contents is preserved and bonuses are calculated from original base values
+
+### Integration Tests
+
+- [x] T039 [P] [US3] Write `TestUpgradeIntegration.test_full_base_upgrade_flow` in `server/tests/test_upgrade_contract.py` -- set up station_resources with water+gas, execute upgrade_base via execute_action, verify resources deducted and effect applied
+- [x] T040 [P] [US3] Write `TestUpgradeIntegration.test_upgrade_during_storm` in `server/tests/test_upgrade_contract.py` -- set storm state to active, rover at station, attempt base upgrade, assert still succeeds (storms do not block upgrades)
+
+**Checkpoint**: All multi-level and integration tests pass via `uv run pytest tests/test_upgrade_contract.py -k "TestMultiLevel or TestUpgradeIntegration" -x -q`
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, formatting, and documentation
+
+- [x] T041 Run `cd server && uv run ruff format app/ tests/ && uv run ruff check --fix app/ tests/` to format and lint
+- [x] T042 Run full test suite `cd server && uv run pytest tests/ -x -q` to verify no regressions
+- [x] T043 Verify test count in test_upgrade_contract.py is at least 25 methods
+- [x] T044 Update Changelog.md with upgrade system tests changes
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies -- create file, imports, helpers
+- **US1 (Phase 2)**: Depends on Setup (Phase 1) completion
+- **US2 (Phase 3)**: Depends on Setup (Phase 1) completion -- independent of US1
+- **US3 (Phase 4)**: Depends on Setup (Phase 1) completion -- some tests reference upgrade effects tested in US1
+- **Polish (Phase 5)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Phase 1 -- No dependencies on other stories
+- **User Story 2 (P2)**: Can start after Phase 1 -- Independent of US1 (different test classes, different code paths)
+- **User Story 3 (P3)**: Can start after Phase 1 -- Uses same helper functions tested in US1 but tests are self-contained
+
+### Within Each User Story
+
+- All test methods within a class are marked [P] (parallelizable) since they operate on independent world state via setUp/tearDown
+- Test classes within a story are independent (different setUp concerns)
+
+### Parallel Opportunities
+
+- T004-T024 (all US1 tests) can be written in parallel since each is an independent test method
+- T025-T035 (all US2 tests) can be written in parallel
+- T036-T040 (all US3 tests) can be written in parallel
+- US1 and US2 phases can proceed in parallel (no cross-dependencies)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# All these test methods can be written in parallel (same file, different methods):
+T004: TestBaseUpgradeSuccess.test_charge_mk2_succeeds
+T005: TestBaseUpgradeSuccess.test_extended_fuel_succeeds
+T010: TestBaseUpgradeEffects.test_charge_mk2_doubles_charge_rate
+T011: TestBaseUpgradeEffects.test_extended_fuel_adds_100_capacity
+T014: TestBaseUpgradeFailures.test_wrong_position
+T022: TestBaseUpgradeFailures.test_drone_cannot_upgrade_base
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T003)
+2. Complete Phase 2: User Story 1 -- Base Upgrade Contract Tests (T004-T024)
+3. **STOP and VALIDATE**: `cd server && uv run pytest tests/test_upgrade_contract.py -k "TestBaseUpgrade" -x -q`
+4. This alone closes the biggest validation gap (effect verification)
+
+### Incremental Delivery
+
+1. Setup (Phase 1) -- file scaffolding ready
+2. Add US1 tests (Phase 2) -- base upgrade contracts validated
+3. Add US2 tests (Phase 3) -- building upgrade contracts validated
+4. Add US3 tests (Phase 4) -- multi-level and integration validated
+5. Polish (Phase 5) -- formatting, full suite verification, changelog
+
+---
+
+## Notes
+
+- All tasks create test methods in a single file: `server/tests/test_upgrade_contract.py`
+- No production code changes unless a genuine bug is discovered during testing
+- Tests use `_WorldSaveRestore` pattern for state isolation (from research.md R1)
+- Test effects via helper functions, not just action routing (from research.md R2)
+- Test bonuses directly via `_apply_upgrade_bonuses()` for precision (from research.md R3)
+- Avoid duplicating tests already in test_upgrades.py and test_coverage_expansion.py (from research.md R4)


### PR DESCRIPTION
## Summary

- Add `test_upgrade_contract.py` with 38 tests covering the full base upgrade and building upgrade contract
- Tests verify all 4 base upgrade types (charge_mk2, extended_fuel, enhanced_scanner, repair_bay) with effect validation
- Tests cover building upgrade bonuses at each level, multi-level stacking, failure modes, and integration via `execute_action`

## Semantic Diff

### File Impact

| Section | Files | Lines Added | Lines Removed |
|---------|-------|-------------|---------------|
| Core | 0 | 0 | 0 |
| Test | 1 | 561 | 0 |
| Docs | 2 | 13 | 0 |
| Specs | 6 | 557 | 0 |
| **Total** | **10** | **1131** | **0** |

### Added
- `server/tests/test_upgrade_contract.py` (+561) — 38 tests across 7 test classes

### Changed
- `CLAUDE.md` (+2) — active technologies update
- `Changelog.md` (+11) — test coverage entry

### Spec Artifacts
- `specs/190-upgrade-system-tests/` — spec, plan, research, data-model, tasks, checklist

## Test Plan

- [x] All 38 new tests pass (`uv run pytest tests/test_upgrade_contract.py`)
- [x] Full suite: 899 passed, 3 skipped, 0 failures
- [x] Ruff format and lint clean
- [x] No production code modified

## Changelog

- **test/upgrade-system-tests:** add 38 comprehensive upgrade contract tests covering base upgrades (success, effects, failures), building upgrades (bonuses, levels, isolation), multi-level stacking, and integration flows

Co-Authored-By: agent-one team <agent-one@yanok.ai>